### PR TITLE
Add tsci init command to initialize a TSCircuit project (#18)

### DIFF
--- a/cli/init/register.ts
+++ b/cli/init/register.ts
@@ -1,0 +1,59 @@
+import type { Command } from "commander"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+export const registerInit = (program: Command) => {
+  program
+    .command("init")
+    .description("Initialize a new TSCircuit project in the current directory")
+    .action(() => {
+      const currentDir = process.cwd()
+
+      const indexFilePath = path.join(currentDir, "index.tsx")
+      const npmrcFilePath = path.join(currentDir, ".npmrc")
+
+      const indexContent = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor
+      resistance="1k"
+      footprint="0402"
+      name="R1"
+      schX={3}
+      pcbX={3}
+    />
+    <capacitor
+      capacitance="1000pF"
+      footprint="0402"
+      name="C1"
+      schX={-3}
+      pcbX={-3}
+    />
+    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+  </board>
+);
+`
+
+      const npmrcContent = `
+@tsci:registry=https://npm.tscircuit.com
+`
+
+      if (!fs.existsSync(indexFilePath)) {
+        fs.writeFileSync(indexFilePath, indexContent.trimStart())
+        console.log(`Created: ${indexFilePath}`)
+      } else {
+        console.log(`Skipped: ${indexFilePath} already exists`)
+      }
+
+      if (!fs.existsSync(npmrcFilePath)) {
+        fs.writeFileSync(npmrcFilePath, npmrcContent.trimStart())
+        console.log(`Created: ${npmrcFilePath}`)
+      } else {
+        console.log(`Skipped: ${npmrcFilePath} already exists`)
+      }
+
+      console.log(
+        `Initialization complete. Run "tsci dev" to start developing.`,
+      )
+    })
+}

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Command } from "commander"
+import { registerInit } from "./init/register"
 import { registerDev } from "./dev/register"
 import { registerAuthLogin } from "./auth/login/register"
 import { registerAuthLogout } from "./auth/logout/register"
@@ -20,6 +21,8 @@ program
   // HACK: at build time the version is old, we need to
   // fix this at some point...
   .version(semver.inc(pkg.version, "patch") ?? pkg.version)
+
+registerInit(program)
 
 registerDev(program)
 registerClone(program)


### PR DESCRIPTION
This PR introduces the `tsci init` command to initialize a new TSCircuit project in the current directory.  

- **Creates an `index.tsx` file** with a basic circuit snippet.  
- **Creates a `.npmrc` file** to configure the TSCircuit private npm registry.  
- Logs each file created or skipped, ensuring clarity.  
- Prompts the user to run `tsci dev` to start developing their project.  

Closes #18.  

/claim #18