### PR TITLE
fix: take account of patched version instead of packages version

### DIFF
--- a/lib/shared/check-for-cli-update.ts
+++ b/lib/shared/check-for-cli-update.ts
@@ -9,7 +9,8 @@ import { version as pkgVersion } from "../../package.json"
 
 export const checkForTsciUpdates = async () => {
   if (process.env.TSCI_SKIP_CLI_UPDATE == "true") return
-  const currentCliVersion = program.version() ?? semver.inc(pkgVersion, "patch")
+  const currentCliVersion =
+    program.version() ?? semver.inc(pkgVersion, "patch") ?? pkgVersion
   const { version: latestCliVersion } = await ky
     .get<{ version: string }>(
       "https://registry.npmjs.org/@tscircuit/cli/latest",
@@ -17,7 +18,7 @@ export const checkForTsciUpdates = async () => {
     )
     .json()
 
-  if (latestCliVersion && semver.gt(latestCliVersion, currentCliVersion!)) {
+  if (latestCliVersion && semver.gt(latestCliVersion, currentCliVersion)) {
     const userWantsToUpdate = await askConfirmation(
       `A new version of tsci is available (${currentCliVersion} → ${latestCliVersion}).\nWould you like to update now?`,
     )

--- a/tests/cli/init/init.test.ts
+++ b/tests/cli/init/init.test.ts
@@ -6,7 +6,6 @@ import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 test("init command installs @types/react and passes type-checking", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
-  process.env.TSCI_SKIP_CLI_UPDATE = "true"
   const { stdout } = await runCommand("tsci init")
   console.log(stdout)
 


### PR DESCRIPTION
fix #99 

> [!CAUTION]
> export test PROBABLY failing due to core update https://github.com/tscircuit/cli/commit/a797483f03a2c5c98332d1376d82466f205e471c and this pr doesn't changed anything for export , its sperate issue to update snapshots 