### PR TITLE
fix(tests): sort directory listing in clone test snapshot

### DIFF
--- a/tests/cli/clone/clone.test.ts
+++ b/tests/cli/clone/clone.test.ts
@@ -8,17 +8,17 @@ test("clone command fetches and creates package files correctly", async () => {
   const { stdout } = await runCommand("tsci clone testuser/my-test-board")
 
   const projectDir = join(tmpDir, "testuser.my-test-board")
-  const dirFiles = readdirSync(projectDir)
+  const dirFiles = readdirSync(projectDir).sort()
 
   expect(dirFiles).toMatchInlineSnapshot(`
     [
+      ".npmrc",
+      "circuit.json",
       "index.tsx",
       "node_modules",
-      ".npmrc",
       "package-lock.json",
       "package.json",
       "tsconfig.json",
-      "circuit.json",
     ]
   `)
 }, 10_000)


### PR DESCRIPTION
All tests are passing now

![image](https://github.com/user-attachments/assets/05d974a2-ccab-43ef-832d-673ca52e5572)


#83 can be closed