### PR TITLE
refactor: remove unused export functionality

### DIFF
--- a/lib/server/EventsRoutes.ts
+++ b/lib/server/EventsRoutes.ts
@@ -23,8 +23,6 @@ export interface EventsRoutes {
             | "FAILED_TO_SAVE_SNIPPET"
             | "SNIPPET_SAVED"
             | "REQUEST_TO_SAVE_SNIPPET"
-            | "REQUEST_EXPORT"
-            | "EXPORT_CREATED"
           file_path: string
           created_at: string
           initiator?: string


### PR DESCRIPTION
should i also remove export function and put logic directory into cli command file like before?

![image](https://github.com/user-attachments/assets/b5717cd1-a544-4aef-829d-17e9f006777e)
