### PR TITLE
Write default version for tsci push if no version detected

### DIFF
--- a/tests/test4-push-api.test.ts
+++ b/tests/test4-push-api.test.ts
@@ -29,7 +29,7 @@ test("should use default entrypoint if no file is provided", async () => {
   )
 })
 
-test("should fail if package.json is missing or invalid", async () => {
+test.skip("should fail if package.json is missing or invalid", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   const snippetFilePath = path.resolve(tmpDir, "snippet.tsx")


### PR DESCRIPTION
- **set a default version instead of error'ing**
- **skip old defunct test for invalid package json**
