### PR TITLE
fix: use `bun install -g` instead of `bun add -g`

### DIFF
--- a/lib/shared/get-dep-install-command.ts
+++ b/lib/shared/get-dep-install-command.ts
@@ -8,7 +8,7 @@ export const getGlobalDepsInstallCommand = (
     case "pnpm":
       return `pnpm add -g ${deps}`
     case "bun":
-      return `bun add -g ${deps}`
+      return `bun install -g ${deps}`
     default:
       return `npm install -g ${deps}`
   }


### PR DESCRIPTION
Update bun install command to use 'bun install' instead of 'bun add' for global dependencies

Closes #155 

due to the wrong command the cli was not being updated !