### PR TITLE
Fix/cli Bad representation after clone

### DIFF
--- a/cli/clone/register.ts
+++ b/cli/clone/register.ts
@@ -97,8 +97,15 @@ export const registerClone = (program: Command) => {
       setupTsciProject(dirPath)
 
       console.log(`Successfully cloned to ${dirPath}/`)
-      console.log(
-        `Run "cd ${path.dirname(dirPath)} && tsci dev" to start developing.`,
-      )
+      
+      // Get the relative directory name from the full path
+      const relativeDirName = path.basename(dirPath)
+      
+      console.log(`
+        \x1b[35mTo start developing, run:\x1b[0m
+    
+        \x1b[28mcd ${relativeDirName}\x1b[0m
+        \x1b[36mtsci dev\x1b[0m
+        `);
     })
 }

--- a/cli/clone/register.ts
+++ b/cli/clone/register.ts
@@ -97,14 +97,18 @@ export const registerClone = (program: Command) => {
       setupTsciProject(dirPath)
 
       console.log(`Successfully cloned to ${dirPath}/`)
-      // Get the relative directory name from the full path
-      const relativeDirName = path.relative(dirPath, process.cwd())
+
+      // Calculate relative path from current directory to snippet directory
+      const snippetDir = path.join(`${author}.${snippetName}`)
+      const relativeDirName = path
+        .relative(process.cwd(), snippetDir)
+        .replace(/\\/g, "/")
 
       console.log(`
-        \x1b[35mTo start developing, run:\x1b[0m
-    
-        \x1b[28mcd ${relativeDirName}\x1b[0m
-        \x1b[36mtsci dev\x1b[0m
-        `)
+          \x1b[35mTo start developing, run:\x1b[0m
+
+          \x1b[34mcd ${relativeDirName}\x1b[0m
+          \x1b[36mtsci dev\x1b[0m
+          `)
     })
 }

--- a/cli/clone/register.ts
+++ b/cli/clone/register.ts
@@ -97,9 +97,8 @@ export const registerClone = (program: Command) => {
       setupTsciProject(dirPath)
 
       console.log(`Successfully cloned to ${dirPath}/`)
-      
       // Get the relative directory name from the full path
-      const relativeDirName = path.basename(dirPath)
+      const relativeDirName = path.relative(dirPath, process.cwd());
       
       console.log(`
         \x1b[35mTo start developing, run:\x1b[0m

--- a/cli/clone/register.ts
+++ b/cli/clone/register.ts
@@ -99,7 +99,7 @@ export const registerClone = (program: Command) => {
       console.log(`Successfully cloned to ${dirPath}/`)
       // Get the relative directory name from the full path
       const relativeDirName = path.relative(dirPath, process.cwd());
-      
+
       console.log(`
         \x1b[35mTo start developing, run:\x1b[0m
     

--- a/cli/clone/register.ts
+++ b/cli/clone/register.ts
@@ -98,13 +98,13 @@ export const registerClone = (program: Command) => {
 
       console.log(`Successfully cloned to ${dirPath}/`)
       // Get the relative directory name from the full path
-      const relativeDirName = path.relative(dirPath, process.cwd());
+      const relativeDirName = path.relative(dirPath, process.cwd())
 
       console.log(`
         \x1b[35mTo start developing, run:\x1b[0m
     
         \x1b[28mcd ${relativeDirName}\x1b[0m
         \x1b[36mtsci dev\x1b[0m
-        `);
+        `)
     })
 }


### PR DESCRIPTION
@seveibar 

- Fix #165 

/claim #165

I made some changes to the user instructions output after the cloning of repository in the `cli/clone/register.ts` file, to improve the user experience by modifying the console output after a successful clone operation.

Enhancements to user instructions:

- Improved the user instructions by formatting the output with color codes and making the instructions more visually appealing.
