### PR TITLE
ref: rename snippet type to package type

### DIFF
--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -183,7 +183,7 @@ export const pushSnippet = async ({
       {
         name: "snippetType",
         type: "select",
-        message: "Snippet Type:",
+        message: "Package Type:",
         choices: [
           { title: "Reusable Package", value: "package", selected: true },
           { title: "Board", value: "board" },


### PR DESCRIPTION
fix: #172 

I have rename snippet type to package type.
Do i also need to rename at other places. 