### PR TITLE
feat(cli): add upgrade command to check for CLI updates

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -15,6 +15,7 @@ import { registerAuthPrintToken } from "./auth/print-token/register"
 import { registerAuthSetToken } from "./auth/set-token/register"
 import { registerPush } from "./push/register"
 import { registerAdd } from "./add/register"
+import { registerUpgradeCommand } from "./upgrade/register"
 
 export const program = new Command()
 
@@ -40,6 +41,8 @@ registerConfigPrint(program)
 
 registerExport(program)
 registerAdd(program)
+
+registerUpgradeCommand(program)
 
 if (process.argv.length === 2) {
   perfectCli(program, process.argv)

--- a/cli/upgrade/register.ts
+++ b/cli/upgrade/register.ts
@@ -1,6 +1,5 @@
 import type { Command } from "commander"
 import chalk from "chalk"
-import ora from "ora"
 import { checkForTsciUpdates } from "lib/shared/check-for-cli-update"
 
 export function registerUpgradeCommand(program: Command) {
@@ -13,7 +12,6 @@ export function registerUpgradeCommand(program: Command) {
         console.log(
           chalk.green("You are already using the latest version of tsci."),
         )
-        return
       }
     })
 }

--- a/cli/upgrade/register.ts
+++ b/cli/upgrade/register.ts
@@ -1,0 +1,19 @@
+import type { Command } from "commander"
+import chalk from "chalk"
+import ora from "ora"
+import { checkForTsciUpdates } from "lib/shared/check-for-cli-update"
+
+export function registerUpgradeCommand(program: Command) {
+  program
+    .command("upgrade")
+    .description("Upgrade CLI to the latest version")
+    .action(async () => {
+      const isUpdated = await checkForTsciUpdates()
+      if (!isUpdated) {
+        console.log(
+          chalk.green("You are already using the latest version of tsci."),
+        )
+        return
+      }
+    })
+}

--- a/lib/shared/check-for-cli-update.ts
+++ b/lib/shared/check-for-cli-update.ts
@@ -8,7 +8,7 @@ import semver from "semver"
 import { version as pkgVersion } from "../../package.json"
 
 export const checkForTsciUpdates = async () => {
-  if (process.env.TSCI_SKIP_CLI_UPDATE == "true") return
+  if (process.env.TSCI_SKIP_CLI_UPDATE === "true") return
   const currentCliVersion =
     program.version() ?? semver.inc(pkgVersion, "patch") ?? pkgVersion
   const { version: latestCliVersion } = await ky
@@ -37,6 +37,8 @@ export const checkForTsciUpdates = async () => {
         console.warn(`  ${installCommand}`)
       }
     }
+  } else {
+    return false
   }
 }
 


### PR DESCRIPTION
This commit introduces a new `upgrade` command that allows users to check for the latest version of the CLI. If the user is already on the latest version, a message is displayed indicating no update is needed. This enhances the CLI by providing a built-in mechanism for version management.