### PR TITLE
fix(auth): check session before logging out

### DIFF
--- a/cli/auth/logout/register.ts
+++ b/cli/auth/logout/register.ts
@@ -1,8 +1,13 @@
 import type { Command } from "commander"
-import { clearSession } from "lib/cli-config"
+import { clearSession, getSessionToken } from "lib/cli-config"
 
 export const registerAuthLogout = (program: Command) => {
   const logoutAction = () => {
+    const session = getSessionToken()
+    if (!session) {
+      console.log("You are not logged in!")
+      return
+    }
     clearSession()
     console.log("You have been logged out!")
   }

--- a/cli/upgrade/register.ts
+++ b/cli/upgrade/register.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander"
-import chalk from "chalk"
+import kleur from "kleur"
 import { checkForTsciUpdates } from "lib/shared/check-for-cli-update"
 
 export function registerUpgradeCommand(program: Command) {
@@ -10,7 +10,7 @@ export function registerUpgradeCommand(program: Command) {
       const isUpdated = await checkForTsciUpdates()
       if (!isUpdated) {
         console.log(
-          chalk.green("You are already using the latest version of tsci."),
+          kleur.green("You are already using the latest version of tsci."),
         )
       }
     })


### PR DESCRIPTION
Ensure the user is logged in before attempting to clear the session. This prevents unnecessary session clearing and provides a more user-friendly message when the user is already logged out.


fix #177 