### PR TITLE
feat(DevServer): add event creation for component file

### DIFF
--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -140,6 +140,16 @@ export class DevServer {
   async upsertInitialFiles() {
     const filePaths = getPackageFilePaths(this.projectDir)
 
+    if (this.componentFilePath && filePaths.includes(this.componentFilePath)) {
+      this.fsKy.post("api/events/create", {
+        json: {
+          event_type: "SET_COMPONENT_FILE",
+          message: this.componentFilePath,
+        },
+        throwHttpErrors: false,
+      })
+    }
+
     for (const filePath of filePaths) {
       const fileContent = fs.readFileSync(filePath, "utf-8")
       await this.fsKy.post("api/files/upsert", {

--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -144,7 +144,7 @@ export class DevServer {
       this.fsKy.post("api/events/create", {
         json: {
           event_type: "SET_COMPONENT_FILE",
-          message: this.componentFilePath,
+          message: path.relative(this.projectDir, this.componentFilePath),
         },
         throwHttpErrors: false,
       })


### PR DESCRIPTION
This commit introduces a new event creation when a component file is detected during the `upsertInitialFiles` process. The event type `SET_COMPONENT_FILE` is sent to the server with the component file path, enhancing the ability to track and manage component files in the development environment.

related #174