### PR TITLE
feat(cli): add search command to CLI for querying snippets

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -17,6 +17,7 @@ import { registerPush } from "./push/register"
 import { registerAdd } from "./add/register"
 import { registerUpgradeCommand } from "./upgrade/register"
 import { registerConfigSet } from "./config/set/register"
+import { registerSearch } from "./search/register"
 
 export const program = new Command()
 
@@ -45,6 +46,8 @@ registerExport(program)
 registerAdd(program)
 
 registerUpgradeCommand(program)
+
+registerSearch(program)
 
 if (process.argv.length === 2) {
   perfectCli(program, process.argv)

--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -1,0 +1,42 @@
+import type { Command } from "commander"
+import { getRegistryApiKy } from "lib/registry-api/get-ky"
+import kleur from "kleur"
+
+export const registerSearch = (program: Command) => {
+  program
+    .command("search")
+    .description("Search for snippets in the tscircuit registry")
+    .argument("<query>", "Search query (e.g. keyword, author, or snippet name)")
+    .action(async (query: string) => {
+      const ky = getRegistryApiKy()
+      let results: {
+        packages: Array<{ name: string; version: string; description?: string }>
+      } = { packages: [] }
+      try {
+        results = await ky
+          .post("packages/search", {
+            json: { query },
+          })
+          .json()
+      } catch (error) {
+        console.error(
+          kleur.red("Failed to search registry:"),
+          error instanceof Error ? error.message : error,
+        )
+        process.exit(1)
+      }
+      if (!results.packages.length) {
+        console.log(kleur.yellow("No packages found matching your query."))
+        return
+      }
+      console.log(
+        kleur.bold().underline(`Found ${results.packages.length} package(s):`),
+      )
+      for (const pkg of results.packages) {
+        console.log(
+          kleur.green(pkg.name) +
+            (pkg.description ? ` - ${pkg.description}` : ""),
+        )
+      }
+    })
+}


### PR DESCRIPTION
```bash

PS C:\Users\ansh\cli> tsci search 555
Found 14 package(s):
seveibar/a555timer - Generated from JLCPCB part number C46749   
easyeda/na555dr - 100kHz SOIC-8 Timers / Counters ROHS
seveibar/simple-blinking-555timer
ti-sid/NE555P - Generated from JLCPCB part number C46749
seveibar/NE555P - Generated from JLCPCB part number C46749
PatanSharuKhan/NE555P - Generated from JLCPCB part number C46749
siva222003/NE555P - Generated from JLCPCB part number C46749
minovap/NE555P - Generated from JLCPCB part number C46749
Anshgrover23/NE555P - Generated from JLCPCB part number C46749
guptadeepak8/NE555P - Generated from JLCPCB part number C46749
mohan-bee/NE555P - Generated from JLCPCB part number C46749
dhvll/NE555P - Generated from JLCPCB part number C46749
tscircuit/a555timer - 555Timer IC
Girish4489/NE555P - Generated from JLCPCB part number C46749
```