### PR TITLE
fix(cli): prevent --version/-V from printing version with subcommands

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -47,7 +47,11 @@ registerUpgradeCommand(program)
 registerSearch(program)
 
 // Manually handle --version, -v, and -V flags
-if (process.argv.includes('--version') || process.argv.includes('-v') || process.argv.includes('-V')) {
+if (
+  process.argv.includes("--version") ||
+  process.argv.includes("-v") ||
+  process.argv.includes("-V")
+) {
   console.log(getVersion())
   process.exit(0)
 }

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -21,10 +21,7 @@ import { registerSearch } from "./search/register"
 
 export const program = new Command()
 
-program
-  .name("tsci")
-  .description("CLI for developing tscircuit snippets")
-  .version(getVersion())
+program.name("tsci").description("CLI for developing tscircuit snippets")
 
 registerInit(program)
 
@@ -48,6 +45,14 @@ registerAdd(program)
 registerUpgradeCommand(program)
 
 registerSearch(program)
+
+// Add a custom version command
+program
+  .command("version")
+  .description("Print CLI version")
+  .action(() => {
+    console.log(getVersion())
+  })
 
 if (process.argv.length === 2) {
   perfectCli(program, process.argv)

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -46,6 +46,12 @@ registerUpgradeCommand(program)
 
 registerSearch(program)
 
+// Manually handle --version, -v, and -V flags
+if (process.argv.includes('--version') || process.argv.includes('-v') || process.argv.includes('-V')) {
+  console.log(getVersion())
+  process.exit(0)
+}
+
 // Add a custom version command
 program
   .command("version")


### PR DESCRIPTION


**Before:**

```powershell
PS C:\Users\ansh\cli> tsci
√ Choose command » tsci login
> tsci login --version false --V false
0.1.100
PS C:\Users\ansh\cli>
```

**After:**

```powershell
PS C:\Users\ansh\cli> tsci
√ Choose command » tsci login
> tsci login
Already logged in! Use 'tsci logout' if you need to switch accounts.
PS C:\Users\ansh\cli>
```
