### PR TITLE
refactor(cli): replace custom confirmation prompts with prompts library

### DIFF
--- a/cli/init/register.ts
+++ b/cli/init/register.ts
@@ -7,7 +7,7 @@ import { writeFileIfNotExists } from "lib/shared/write-file-if-not-exists"
 import { generateGitIgnoreFile } from "lib/shared/generate-gitignore-file"
 import { generatePackageJson } from "lib/shared/generate-package-json"
 import { checkForTsciUpdates } from "lib/shared/check-for-cli-update"
-import prompt from "prompts"
+import { prompts } from "lib/utils/prompts"
 
 export const registerInit = (program: Command) => {
   program
@@ -23,7 +23,7 @@ export const registerInit = (program: Command) => {
       await checkForTsciUpdates()
 
       if (!directory) {
-        const { continueInCurrentDirectory } = await prompt({
+        const { continueInCurrentDirectory } = await prompts({
           type: "confirm",
           name: "continueInCurrentDirectory",
           message:

--- a/cli/init/register.ts
+++ b/cli/init/register.ts
@@ -6,10 +6,8 @@ import { generateTsConfig } from "lib/shared/generate-ts-config"
 import { writeFileIfNotExists } from "lib/shared/write-file-if-not-exists"
 import { generateGitIgnoreFile } from "lib/shared/generate-gitignore-file"
 import { generatePackageJson } from "lib/shared/generate-package-json"
-import {
-  askConfirmation,
-  checkForTsciUpdates,
-} from "lib/shared/check-for-cli-update"
+import { checkForTsciUpdates } from "lib/shared/check-for-cli-update"
+import prompt from "prompts"
 
 export const registerInit = (program: Command) => {
   program
@@ -25,9 +23,12 @@ export const registerInit = (program: Command) => {
       await checkForTsciUpdates()
 
       if (!directory) {
-        const continueInCurrentDirectory = await askConfirmation(
-          "Do you want to initialize a new project in the current directory?",
-        )
+        const { continueInCurrentDirectory } = await prompt({
+          type: "confirm",
+          name: "continueInCurrentDirectory",
+          message:
+            "Do you want to initialize a new project in the current directory?",
+        })
         if (!continueInCurrentDirectory) {
           return
         }

--- a/lib/shared/check-for-cli-update.ts
+++ b/lib/shared/check-for-cli-update.ts
@@ -1,13 +1,12 @@
 import ky from "ky"
 import { detectPackageManager } from "lib/shared/detect-pkg-manager"
 import { getGlobalDepsInstallCommand } from "lib/shared/get-dep-install-command"
-import readline from "node:readline"
 import { execSync } from "node:child_process"
 import { program } from "cli/main"
 import semver from "semver"
 import { version as pkgVersion } from "../../package.json"
 import kleur from "kleur"
-import prompt from "prompts"
+import { prompts } from "lib/utils/prompts"
 
 export const currentCliVersion = () =>
   program?.version() ?? semver.inc(pkgVersion, "patch") ?? pkgVersion
@@ -22,7 +21,7 @@ export const checkForTsciUpdates = async () => {
     .json()
 
   if (latestCliVersion && semver.gt(latestCliVersion, currentCliVersion())) {
-    const { userWantsToUpdate } = await prompt({
+    const { userWantsToUpdate } = await prompts({
       type: "confirm",
       name: "userWantsToUpdate",
       message: `A new version of tsci is available (${currentCliVersion()} → ${latestCliVersion}).\nWould you like to update now?`,

--- a/lib/shared/check-for-cli-update.ts
+++ b/lib/shared/check-for-cli-update.ts
@@ -7,6 +7,7 @@ import { program } from "cli/main"
 import semver from "semver"
 import { version as pkgVersion } from "../../package.json"
 import kleur from "kleur"
+import prompt from "prompts"
 
 export const currentCliVersion = () =>
   program?.version() ?? semver.inc(pkgVersion, "patch") ?? pkgVersion
@@ -21,9 +22,12 @@ export const checkForTsciUpdates = async () => {
     .json()
 
   if (latestCliVersion && semver.gt(latestCliVersion, currentCliVersion())) {
-    const userWantsToUpdate = await askConfirmation(
-      `A new version of tsci is available (${currentCliVersion()} → ${latestCliVersion}).\nWould you like to update now?`,
-    )
+    const { userWantsToUpdate } = await prompt({
+      type: "confirm",
+      name: "userWantsToUpdate",
+      message: `A new version of tsci is available (${currentCliVersion()} → ${latestCliVersion}).\nWould you like to update now?`,
+    })
+
     if (userWantsToUpdate) {
       const packageManager = detectPackageManager()
       const installCommand = getGlobalDepsInstallCommand(
@@ -43,25 +47,4 @@ export const checkForTsciUpdates = async () => {
     return false
   }
   return true
-}
-
-export const askConfirmation = (question: string): Promise<boolean> => {
-  return new Promise((resolve) => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    })
-
-    const timeout = setTimeout(() => {
-      rl.close()
-      resolve(false)
-    }, 5000)
-
-    rl.question(`${question} (y/n): `, (answer) => {
-      clearTimeout(timeout)
-      rl.close()
-      const normalized = answer.trim().toLowerCase()
-      resolve(normalized === "yes" || normalized === "y")
-    })
-  })
 }


### PR DESCRIPTION
- Removed the custom askConfirmation function and integrated the prompts library for user confirmations.
- Updated the initialization process to use prompts for confirming project setup in the current directory.
- Enhanced the update check process to utilize prompts for user decisions on updating the CLI version.