### PR TITLE
Update CLI commands and descriptions to reflect package terminology

### DIFF
--- a/cli/clone/register.ts
+++ b/cli/clone/register.ts
@@ -10,10 +10,10 @@ import { cliConfig } from "lib/cli-config"
 export const registerClone = (program: Command) => {
   program
     .command("clone")
-    .description("Clone a snippet from the registry")
+    .description("Clone a package from the registry")
     .argument(
-      "<snippet>",
-      "Snippet to clone (e.g. author/snippetName or https://tscircuit.com/author/snippetName)",
+      "<package>",
+      "Package to clone (e.g. author/packageName or https://tscircuit.com/author/packageName)",
     )
     .option("-a, --include-author", "Include author name in the directory path")
     .action(
@@ -29,7 +29,7 @@ export const registerClone = (program: Command) => {
 
         if (!urlMatch && !originalMatch) {
           console.error(
-            `Invalid snippet path "${snippetPath}". Accepted formats:\n - author/snippetName\n - author.snippetName \n - @tsci/author.snippetName\n - https://tscircuit.com/author/snippetName`,
+            `Invalid package path "${snippetPath}". Accepted formats:\n - author/snippetName\n - author.snippetName \n - @tsci/author.snippetName\n - https://tscircuit.com/author/snippetName`,
           )
           process.exit(1)
         }

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -10,8 +10,8 @@ import { getVersion } from "lib/getVersion"
 export const registerDev = (program: Command) => {
   program
     .command("dev")
-    .description("Start development server for a snippet")
-    .argument("[file]", "Path to the snippet file")
+    .description("Start development server for a package")
+    .argument("[file]", "Path to the package file")
     .option("-p, --port <number>", "Port to run server on", "3020")
     .action(async (file: string, options: { port: string }) => {
       let port = parseInt(options.port)
@@ -58,7 +58,7 @@ export const registerDev = (program: Command) => {
 
       try {
         process.stdout.write(
-          kleur.gray("Installing types for imported snippets..."),
+          kleur.gray("Installing types for imported packages..."),
         )
         await installNodeModuleTypesForSnippet(absolutePath)
         console.log(kleur.green(" done"))

--- a/cli/export/register.ts
+++ b/cli/export/register.ts
@@ -5,7 +5,7 @@ export const registerExport = (program: Command) => {
   program
     .command("export")
     .description("Export tscircuit code to various formats")
-    .argument("<file>", "Path to the snippet file")
+    .argument("<file>", "Path to the package file")
     .option("-f, --format <format>", "Output format")
     .option("-o, --output <path>", "Output file path")
     .action(async (file, options) => {

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -22,7 +22,7 @@ import { registerRemove } from "./remove/register"
 
 export const program = new Command()
 
-program.name("tsci").description("CLI for developing tscircuit snippets")
+program.name("tsci").description("CLI for developing tscircuit packages")
 
 registerInit(program)
 

--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -7,8 +7,8 @@ import { addPackage } from "lib/shared/add-package"
 export const registerSearch = (program: Command) => {
   program
     .command("search")
-    .description("Search for snippets in the tscircuit registry")
-    .argument("<query>", "Search query (e.g. keyword, author, or snippet name)")
+    .description("Search for packages in the tscircuit registry")
+    .argument("<query>", "Search query (e.g. keyword, author, or package name)")
     .action(async (query: string) => {
       const ky = getRegistryApiKy()
       let results: {

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -31,7 +31,7 @@ export const pushSnippet = async ({
   const sessionToken = cliConfig.get("sessionToken")
   if (!sessionToken) {
     onError(
-      "You need to log in to save snippet. Run 'tsci login' to authenticate.",
+      "You need to log in to save package. Run 'tsci login' to authenticate.",
     )
     return onExit(1)
   }

--- a/tests/cli/clone/clone.test.ts
+++ b/tests/cli/clone/clone.test.ts
@@ -23,11 +23,11 @@ test("clone command fetches and creates package files correctly", async () => {
   ])
 }, 10_000)
 
-test("clone command handles invalid snippet path", async () => {
+test("clone command handles invalid package path", async () => {
   const { runCommand } = await getCliTestFixture()
 
   const { stderr } = await runCommand("tsci clone invalid-path")
-  expect(stderr).toContain("Invalid snippet path")
+  expect(stderr).toContain("Invalid package path")
 })
 
 test("clone command handles API errors gracefully", async () => {
@@ -50,7 +50,7 @@ test("clone command rejects invalid URL formats", async () => {
 
   for (const url of testCases) {
     const { stderr } = await runCommand(`tsci clone ${url}`)
-    expect(stderr).toContain("Invalid snippet path")
+    expect(stderr).toContain("Invalid package path")
   }
 })
 


### PR DESCRIPTION
instead of snippet. Changes include updates to the 'clone', 'dev', 'export', and 'search' commands for consistency in messaging and argument naming.

ref #198