### PR TITLE
Improve error reporting for API requests

### DIFF
--- a/lib/registry-api/get-ky.ts
+++ b/lib/registry-api/get-ky.ts
@@ -8,7 +8,7 @@ export const prettyResponseErrorHook: AfterResponseHook = async (
 ) => {
   if (!response.ok) {
     try {
-      const errorData = await response.json()
+      const errorData = (await response.json()) as any
 
       let requestBody = ""
       try {

--- a/lib/registry-api/get-ky.ts
+++ b/lib/registry-api/get-ky.ts
@@ -9,10 +9,20 @@ export const prettyResponseErrorHook: AfterResponseHook = async (
   if (!response.ok) {
     try {
       const errorData = await response.json()
+      let requestBody = ""
+      try {
+        requestBody = await _request.clone().text()
+      } catch {
+        // ignore
+      }
       throw new Error(
         `FAIL [${response.status}]: ${_request.method} ${
           new URL(_request.url).pathname
-        } \n\n ${JSON.stringify(errorData, null, 2)}`,
+        }` +
+          (requestBody
+            ? `\n\nRequest Body:\n${requestBody}`
+            : "") +
+          `\n\n${JSON.stringify(errorData, null, 2)}`,
       )
     } catch (e) {
       //ignore, allow the error to be thrown

--- a/lib/registry-api/get-ky.ts
+++ b/lib/registry-api/get-ky.ts
@@ -9,19 +9,25 @@ export const prettyResponseErrorHook: AfterResponseHook = async (
   if (!response.ok) {
     try {
       const errorData = await response.json()
+
       let requestBody = ""
       try {
         requestBody = await _request.clone().text()
       } catch {
-        // ignore
+        // ignore errors cloning request body
       }
+
+      const apiError = errorData?.error
+      const errorString = apiError
+        ? `\n${apiError.error_code}: ${apiError.message}`
+        : ""
+
       throw new Error(
         `FAIL [${response.status}]: ${_request.method} ${
           new URL(_request.url).pathname
         }` +
-          (requestBody
-            ? `\n\nRequest Body:\n${requestBody}`
-            : "") +
+          errorString +
+          (requestBody ? `\n\nRequest Body:\n${requestBody}` : "") +
           `\n\n${JSON.stringify(errorData, null, 2)}`,
       )
     } catch (e) {


### PR DESCRIPTION
## Summary
- include request body in API error messages

## Testing
- `bun test` *(fails: ENOENT, expect mismatches)*

------
https://chatgpt.com/codex/tasks/task_b_683e88375a84832e8b8914118d4cee81