### PR TITLE
Fix DevServer .git file watching

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@types/configstore": "^6.0.2",
         "@types/debug": "^4.1.12",
         "@types/jsonwebtoken": "^9.0.9",
+        "@types/micromatch": "^4.0.9",
         "@types/prompts": "^2.4.9",
         "@types/react": "^19.0.8",
         "@types/semver": "^7.5.8",
@@ -543,6 +544,8 @@
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
+    "@types/braces": ["@types/braces@3.0.5", "", {}, "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w=="],
+
     "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
 
     "@types/configstore": ["@types/configstore@6.0.2", "", {}, "sha512-OS//b51j9uyR3zvwD04Kfs5kHpve2qalQ18JhY/ho3voGYUTPLEG90/ocfKPI48hyHH8T04f7KEEbK6Ue60oZQ=="],
@@ -582,6 +585,8 @@
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.9", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/micromatch": ["@types/micromatch@4.0.9", "", { "dependencies": { "@types/braces": "*" } }, "sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg=="],
 
     "@types/ms": ["@types/ms@0.7.34", "", {}, "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="],
 

--- a/cli/dev/get-package-file-paths.ts
+++ b/cli/dev/get-package-file-paths.ts
@@ -1,16 +1,17 @@
 import * as path from "node:path"
 import { globbySync } from "globby"
-import { DEFAULT_IGNORED_DIRECTORIES } from "lib/shared/should-ignore-path"
+import {
+  DEFAULT_IGNORED_PATTERNS,
+  normalizeIgnorePattern,
+} from "lib/shared/should-ignore-path"
 
 export const getPackageFilePaths = (
   projectDir: string,
   ignored: string[] = [],
 ) => {
   const ignorePatterns = [
-    ...DEFAULT_IGNORED_DIRECTORIES.map((d) => `**/${d}/**`),
-    ".env",
-    "**/.*",
-    ...ignored.map((d) => `**/${d}/**`),
+    ...DEFAULT_IGNORED_PATTERNS,
+    ...ignored.map(normalizeIgnorePattern),
   ]
   const fileNames = globbySync("**", {
     cwd: projectDir,

--- a/cli/dev/get-package-file-paths.ts
+++ b/cli/dev/get-package-file-paths.ts
@@ -1,10 +1,20 @@
 import * as path from "node:path"
 import { globbySync } from "globby"
+import { DEFAULT_IGNORED_DIRECTORIES } from "lib/shared/should-ignore-path"
 
-export const getPackageFilePaths = (projectDir: string) => {
+export const getPackageFilePaths = (
+  projectDir: string,
+  ignored: string[] = [],
+) => {
+  const ignorePatterns = [
+    ...DEFAULT_IGNORED_DIRECTORIES.map((d) => `**/${d}/**`),
+    ".env",
+    "**/.*",
+    ...ignored.map((d) => `**/${d}/**`),
+  ]
   const fileNames = globbySync("**", {
     cwd: projectDir,
-    ignore: ["**/node_modules/**", "**/.git/**", ".env", "**/.*"],
+    ignore: ignorePatterns,
   })
 
   return fileNames.map((fileName) => path.join(projectDir, fileName))

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 
 export const projectConfigSchema = z.object({
   mainEntrypoint: z.string().optional(),
+  ignoredFiles: z.array(z.string()).optional(),
 })
 
 export type TscircuitProjectConfigInput = z.input<typeof projectConfigSchema>

--- a/lib/shared/should-ignore-path.ts
+++ b/lib/shared/should-ignore-path.ts
@@ -1,15 +1,30 @@
-export const DEFAULT_IGNORED_DIRECTORIES = ["node_modules", ".git", ".vscode"]
+import micromatch from "micromatch"
+
+/** Default directories and patterns ignored by the CLI */
+export const DEFAULT_IGNORED_PATTERNS = [
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/.vscode/**",
+  // Ignore any directory that starts with a dot
+  "**/.*/*",
+  // Ignore dotfiles at the project root such as .env
+  "**/.*",
+]
+
+export const normalizeIgnorePattern = (pattern: string) => {
+  // If the pattern already contains glob characters assume it's complete
+  if (/[\*\?\[\]\{\}]/.test(pattern)) return pattern
+  // Otherwise treat it as a directory name
+  return `**/${pattern}/**`
+}
 
 export const shouldIgnorePath = (
   relativePath: string,
   configIgnored: string[] = [],
 ): boolean => {
-  const parts = relativePath.split(/[/\\]/)
-  for (const part of parts) {
-    if (!part) continue
-    if (part.startsWith(".")) return true
-    if (DEFAULT_IGNORED_DIRECTORIES.includes(part)) return true
-    if (configIgnored.includes(part)) return true
-  }
-  return false
+  const extraPatterns = configIgnored.map(normalizeIgnorePattern)
+  return micromatch.isMatch(relativePath, [
+    ...DEFAULT_IGNORED_PATTERNS,
+    ...extraPatterns,
+  ])
 }

--- a/lib/shared/should-ignore-path.ts
+++ b/lib/shared/should-ignore-path.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_IGNORED_DIRECTORIES = ["node_modules", ".git", ".vscode"]
+
+export const shouldIgnorePath = (
+  relativePath: string,
+  configIgnored: string[] = [],
+): boolean => {
+  const parts = relativePath.split(/[/\\]/)
+  for (const part of parts) {
+    if (!part) continue
+    if (part.startsWith(".")) return true
+    if (DEFAULT_IGNORED_DIRECTORIES.includes(part)) return true
+    if (configIgnored.includes(part)) return true
+  }
+  return false
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/configstore": "^6.0.2",
     "@types/debug": "^4.1.12",
     "@types/jsonwebtoken": "^9.0.9",
+    "@types/micromatch": "^4.0.9",
     "@types/prompts": "^2.4.9",
     "@types/react": "^19.0.8",
     "@types/semver": "^7.5.8",

--- a/tests/ignore-path.test.ts
+++ b/tests/ignore-path.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { shouldIgnorePath } from "lib/shared/should-ignore-path"
+
+test("ignores default directories", () => {
+  expect(shouldIgnorePath("node_modules/foo.js")).toBe(true)
+  expect(shouldIgnorePath(".git/config")).toBe(true)
+  expect(shouldIgnorePath(".vscode/settings.json")).toBe(true)
+})
+
+test("ignores custom directories", () => {
+  expect(shouldIgnorePath("build/output.js", ["build"])).toBe(true)
+})
+
+test("allows regular files", () => {
+  expect(shouldIgnorePath("src/index.tsx")).toBe(false)
+})

--- a/tests/ignore-path.test.ts
+++ b/tests/ignore-path.test.ts
@@ -5,10 +5,12 @@ test("ignores default directories", () => {
   expect(shouldIgnorePath("node_modules/foo.js")).toBe(true)
   expect(shouldIgnorePath(".git/config")).toBe(true)
   expect(shouldIgnorePath(".vscode/settings.json")).toBe(true)
+  expect(shouldIgnorePath(".cache/file.txt")).toBe(true)
 })
 
-test("ignores custom directories", () => {
-  expect(shouldIgnorePath("build/output.js", ["build"])).toBe(true)
+test("ignores custom patterns", () => {
+  expect(shouldIgnorePath("build/output.js", ["build/**"])).toBe(true)
+  expect(shouldIgnorePath("dist/app.js", ["**/dist/**"])).toBe(true)
 })
 
 test("allows regular files", () => {


### PR DESCRIPTION
## Summary
- skip `.git` files when dev server saves project

## Testing
- `bun run format:check`
- `bun test` *(fails: expect(received).toBe(expected) ...)*

------
https://chatgpt.com/codex/tasks/task_b_683f899588bc832e8c4937ca727d3126