### PR TITLE
Add ready_to_build flag on push

### DIFF
--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -287,6 +287,18 @@ export const pushSnippet = async ({
       })
   }
 
+  await ky
+    .post("package_releases/update", {
+      json: {
+        package_name_with_version: `${scopedPackageName}@${packageVersion}`,
+        ready_to_build: true,
+      },
+    })
+    .catch((error) => {
+      onError(`Error setting ready_to_build: ${error}`)
+      return onExit(1)
+    })
+
   onSuccess(
     [
       kleur.green(`"${tsciPackageName}@${packageVersion}" published!`),

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -287,17 +287,12 @@ export const pushSnippet = async ({
       })
   }
 
-  await ky
-    .post("package_releases/update", {
-      json: {
-        package_name_with_version: `${scopedPackageName}@${packageVersion}`,
-        ready_to_build: true,
-      },
-    })
-    .catch((error) => {
-      onError(`Error setting ready_to_build: ${error}`)
-      return onExit(1)
-    })
+  await ky.post("package_releases/update", {
+    json: {
+      package_name_with_version: `${scopedPackageName}@${packageVersion}`,
+      ready_to_build: true,
+    },
+  })
 
   onSuccess(
     [


### PR DESCRIPTION
## Summary
- update push command to mark package releases as `ready_to_build` after uploading files

## Testing
- `bun test` *(fails: ENOENT and HTTPError, see logs)*

------
https://chatgpt.com/codex/tasks/task_b_684077a297b0832eaf28b828b3b7f630