### PR TITLE
Add tsci snapshot command

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -19,6 +19,7 @@ import { registerUpgradeCommand } from "./upgrade/register"
 import { registerConfigSet } from "./config/set/register"
 import { registerSearch } from "./search/register"
 import { registerRemove } from "./remove/register"
+import { registerSnapshot } from "./snapshot/register"
 
 export const program = new Command()
 
@@ -43,6 +44,7 @@ registerConfigSet(program)
 registerExport(program)
 registerAdd(program)
 registerRemove(program)
+registerSnapshot(program)
 
 registerUpgradeCommand(program)
 

--- a/cli/snapshot/register.ts
+++ b/cli/snapshot/register.ts
@@ -1,0 +1,17 @@
+import type { Command } from "commander"
+import { snapshotProject } from "lib/shared/snapshot-project"
+
+export const registerSnapshot = (program: Command) => {
+  program
+    .command("snapshot")
+    .description("Generate schematic and PCB snapshots")
+    .option("-u, --update", "Update snapshots on disk")
+    .action(async (options: { update?: boolean }) => {
+      await snapshotProject({
+        update: options.update ?? false,
+        onExit: (code) => process.exit(code),
+        onError: (msg) => console.error(msg),
+        onSuccess: (msg) => console.log(msg),
+      })
+    })
+}

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs"
+import path from "node:path"
+import { globbySync } from "globby"
+import {
+  convertCircuitJsonToPcbSvg,
+  convertCircuitJsonToSchematicSvg,
+} from "circuit-to-svg"
+import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getEntrypoint } from "lib/shared/get-entrypoint"
+import {
+  DEFAULT_IGNORED_PATTERNS,
+  normalizeIgnorePattern,
+} from "lib/shared/should-ignore-path"
+
+type SnapshotOptions = {
+  update?: boolean
+  ignored?: string[]
+  onExit?: (code: number) => void
+  onError?: (message: string) => void
+  onSuccess?: (message: string) => void
+}
+
+export const snapshotProject = async ({
+  update = false,
+  ignored = [],
+  onExit = (code) => process.exit(code),
+  onError = (msg) => console.error(msg),
+  onSuccess = (msg) => console.log(msg),
+}: SnapshotOptions = {}) => {
+  const projectDir = process.cwd()
+  const ignore = [
+    ...DEFAULT_IGNORED_PATTERNS,
+    ...ignored.map(normalizeIgnorePattern),
+  ]
+  const boardFiles = globbySync("**/*.board.tsx", { cwd: projectDir, ignore })
+  let files = boardFiles.map((f) => path.join(projectDir, f))
+
+  if (files.length === 0) {
+    const entry = await getEntrypoint({
+      projectDir,
+      onError: onError,
+      onSuccess: () => {},
+    })
+    if (!entry) return onExit(1)
+    files = [entry]
+  }
+
+  const mismatches: string[] = []
+  for (const file of files) {
+    const { circuitJson } = await generateCircuitJson({ filePath: file })
+    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+    const schSvg = convertCircuitJsonToSchematicSvg(circuitJson)
+    const snapDir = path.join(path.dirname(file), "__snapshots__")
+    fs.mkdirSync(snapDir, { recursive: true })
+    const base = path.basename(file).replace(/\.tsx$/, "")
+    for (const [type, svg] of [
+      ["pcb", pcbSvg],
+      ["schematic", schSvg],
+    ] as const) {
+      const snapPath = path.join(snapDir, `${base}-${type}.snap.svg`)
+      if (update || !fs.existsSync(snapPath)) {
+        fs.writeFileSync(snapPath, svg)
+      } else {
+        const existing = fs.readFileSync(snapPath, "utf-8")
+        if (existing !== svg) mismatches.push(snapPath)
+      }
+    }
+  }
+
+  if (update) {
+    onSuccess("Created snapshots")
+    return onExit(0)
+  }
+
+  if (mismatches.length > 0) {
+    onError(`Snapshot mismatch:\n${mismatches.join("\n")}`)
+    return onExit(1)
+  }
+
+  onSuccess("All snapshots match")
+  return onExit(0)
+}


### PR DESCRIPTION
## Summary
- add board snapshot generation helper
- wire up a new `tsci snapshot` command

## Testing
- `bun test` *(fails: Test "init command installs @types/react and passes type-checking" timed out)*

------
https://chatgpt.com/codex/tasks/task_b_684215e0f2b4832eb347ec78fa95d31c