### PR TITLE
Add tsci build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Commands:
   logout                     Logout from tscircuit registry
   config                     Manage tscircuit CLI configuration
   export [options] <file>    Export tscircuit code to various formats
+  build [file]               Run tscircuit eval and output circuit json
   add <component>            Add a tscircuit component package to your project
   remove <component>         Remove a tscircuit component package from your
                              project

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -1,0 +1,36 @@
+import type { Command } from "commander"
+import path from "node:path"
+import fs from "node:fs"
+import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getEntrypoint } from "lib/shared/get-entrypoint"
+
+export const registerBuild = (program: Command) => {
+  program
+    .command("build")
+    .description("Run tscircuit eval and output circuit json")
+    .argument("[file]", "Path to the entry file")
+    .action(async (file?: string) => {
+      const entrypoint = await getEntrypoint({ filePath: file })
+      if (!entrypoint) return process.exit(1)
+
+      const projectDir = path.dirname(entrypoint)
+      const distDir = path.join(projectDir, "dist")
+      const outputPath = path.join(distDir, "circuit.json")
+
+      fs.mkdirSync(distDir, { recursive: true })
+
+      try {
+        const result = await generateCircuitJson({ filePath: entrypoint })
+        fs.writeFileSync(
+          outputPath,
+          JSON.stringify(result.circuitJson, null, 2),
+        )
+        console.log(
+          `Circuit JSON written to ${path.relative(projectDir, outputPath)}`,
+        )
+      } catch (err) {
+        console.error(`Build failed: ${err}`)
+        return process.exit(1)
+      }
+    })
+}

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -19,6 +19,7 @@ import { registerUpgradeCommand } from "./upgrade/register"
 import { registerConfigSet } from "./config/set/register"
 import { registerSearch } from "./search/register"
 import { registerRemove } from "./remove/register"
+import { registerBuild } from "./build/register"
 
 export const program = new Command()
 
@@ -41,6 +42,7 @@ registerConfigPrint(program)
 registerConfigSet(program)
 
 registerExport(program)
+registerBuild(program)
 registerAdd(program)
 registerRemove(program)
 

--- a/lib/shared/generate-circuit-json.ts
+++ b/lib/shared/generate-circuit-json.ts
@@ -76,6 +76,7 @@ export async function generateCircuitJson({
   // Execute the circuit runner with the virtual file system
   await runner.executeWithFsMap({
     fsMap,
+    mainComponentPath: relativeComponentPath,
   })
 
   // Wait for the circuit to be fully rendered

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -1,0 +1,28 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readFile } from "node:fs/promises"
+import path from "node:path"
+
+const circuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)`
+
+test("build command writes dist/circuit.json", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "test-circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { stdout } = await runCommand(`tsci build ${circuitPath}`)
+
+  const data = await readFile(
+    path.join(tmpDir, "dist", "circuit.json"),
+    "utf-8",
+  )
+  const json = JSON.parse(data)
+  const component = json.find((c: any) => c.type === "source_component")
+  expect(component.name).toBe("R1")
+})


### PR DESCRIPTION
## Summary
- add `build` command to run tscircuit eval and emit circuit JSON
- implement build test
- pass main component path to the circuit generator
- update CLI help in README

## Testing
- `TSCI_TEST_MODE=true bun test tests/cli/build/build.test.ts`
- `TSCI_TEST_MODE=true bun test` *(fails: basic init, add and clone tests due to timeouts)*

------
https://chatgpt.com/codex/tasks/task_b_6842153dc154832e9a888c9d94297650