### PR TITLE
Check circuit.json for errors on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Commands:
   logout                     Logout from tscircuit registry
   config                     Manage tscircuit CLI configuration
   export [options] <file>    Export tscircuit code to various formats
-  build [file]               Run tscircuit eval and output circuit json
+  build [options] [file]     Run tscircuit eval and output circuit json
   add <component>            Add a tscircuit component package to your project
   remove <component>         Remove a tscircuit component package from your
                              project
@@ -61,6 +61,11 @@ Commands:
   help [command]             display help for command
 ```
 <!-- END_HELP_OUTPUT -->
+
+The `build` command also accepts the following options:
+
+- `--ignore-errors` - continue build even if circuit JSON contains errors
+- `--ignore-warnings` - suppress warning output
 
 ## Development
 

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -3,34 +3,63 @@ import path from "node:path"
 import fs from "node:fs"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
+import kleur from "kleur"
+import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
 
 export const registerBuild = (program: Command) => {
   program
     .command("build")
     .description("Run tscircuit eval and output circuit json")
     .argument("[file]", "Path to the entry file")
-    .action(async (file?: string) => {
-      const entrypoint = await getEntrypoint({ filePath: file })
-      if (!entrypoint) return process.exit(1)
+    .option("--ignore-errors", "Do not exit with code 1 on errors")
+    .option("--ignore-warnings", "Do not log warnings")
+    .action(
+      async (
+        file?: string,
+        options?: { ignoreErrors?: boolean; ignoreWarnings?: boolean },
+      ) => {
+        const entrypoint = await getEntrypoint({ filePath: file })
+        if (!entrypoint) return process.exit(1)
 
-      const projectDir = path.dirname(entrypoint)
-      const distDir = path.join(projectDir, "dist")
-      const outputPath = path.join(distDir, "circuit.json")
+        const projectDir = path.dirname(entrypoint)
+        const distDir = path.join(projectDir, "dist")
+        const outputPath = path.join(distDir, "circuit.json")
 
-      fs.mkdirSync(distDir, { recursive: true })
+        fs.mkdirSync(distDir, { recursive: true })
 
-      try {
-        const result = await generateCircuitJson({ filePath: entrypoint })
-        fs.writeFileSync(
-          outputPath,
-          JSON.stringify(result.circuitJson, null, 2),
-        )
-        console.log(
-          `Circuit JSON written to ${path.relative(projectDir, outputPath)}`,
-        )
-      } catch (err) {
-        console.error(`Build failed: ${err}`)
-        return process.exit(1)
-      }
-    })
+        try {
+          const result = await generateCircuitJson({ filePath: entrypoint })
+          fs.writeFileSync(
+            outputPath,
+            JSON.stringify(result.circuitJson, null, 2),
+          )
+          console.log(
+            `Circuit JSON written to ${path.relative(projectDir, outputPath)}`,
+          )
+
+          const { errors, warnings } = analyzeCircuitJson(result.circuitJson)
+
+          if (!options?.ignoreWarnings) {
+            for (const warn of warnings) {
+              const msg = warn.message || JSON.stringify(warn)
+              console.log(kleur.yellow(msg))
+            }
+          }
+
+          if (!options?.ignoreErrors) {
+            for (const err of errors) {
+              const msg = err.message || JSON.stringify(err)
+              console.error(kleur.red(msg))
+            }
+          }
+
+          if (errors.length > 0 && !options?.ignoreErrors) {
+            return process.exit(1)
+          }
+        } catch (err) {
+          console.error(`Build failed: ${err}`)
+          return process.exit(1)
+        }
+      },
+    )
 }

--- a/lib/shared/circuit-json-diagnostics.ts
+++ b/lib/shared/circuit-json-diagnostics.ts
@@ -1,0 +1,26 @@
+export type CircuitJsonIssue = {
+  type: string
+  message?: string
+} & Record<string, any>
+
+export function analyzeCircuitJson(circuitJson: any[]): {
+  errors: CircuitJsonIssue[]
+  warnings: CircuitJsonIssue[]
+} {
+  const errors: CircuitJsonIssue[] = []
+  const warnings: CircuitJsonIssue[] = []
+
+  for (const item of circuitJson) {
+    if (!item || typeof item !== "object") continue
+
+    const t = item.type
+    if (typeof t === "string") {
+      if (t.endsWith("_error")) errors.push(item)
+      else if (t.endsWith("_warning")) warnings.push(item)
+    }
+    if ("error_type" in item) errors.push(item)
+    if ("warning_type" in item) warnings.push(item as CircuitJsonIssue)
+  }
+
+  return { errors, warnings }
+}

--- a/tests/analyze-circuit-json.test.ts
+++ b/tests/analyze-circuit-json.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test"
+import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
+
+const sample = [
+  { type: "source_component", name: "R1" },
+  { type: "pcb_autorouting_error", message: "failed" },
+  { type: "pcb_manual_edit_conflict_warning", message: "warn" },
+  {
+    type: "schematic_manual_edit_conflict_warning",
+    message: "warn2",
+  },
+  {
+    type: "other",
+    error_type: "source_missing_property_error",
+    message: "missing",
+  },
+]
+
+test("analyzeCircuitJson detects errors and warnings", () => {
+  const { errors, warnings } = analyzeCircuitJson(sample)
+  expect(errors.length).toBe(2)
+  expect(warnings.length).toBe(2)
+})


### PR DESCRIPTION
## Summary
- analyze circuit json after generation
- log errors in red and warnings in yellow
- fail build when errors are present unless `--ignore-errors`
- add an `analyzeCircuitJson` utility
- document build options in README
- update unit test for `analyzeCircuitJson`

## Testing
- `bun test tests/analyze-circuit-json.test.ts --bail`


------
https://chatgpt.com/codex/tasks/task_b_68423311d860832eaa1274bb0e9a48a4