### PR TITLE
Add `tsci setup` command to set up github actions

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -21,6 +21,7 @@ import { registerSearch } from "./search/register"
 import { registerRemove } from "./remove/register"
 import { registerBuild } from "./build/register"
 import { registerSnapshot } from "./snapshot/register"
+import { registerSetup } from "./setup/register"
 
 export const program = new Command()
 
@@ -47,6 +48,7 @@ registerBuild(program)
 registerAdd(program)
 registerRemove(program)
 registerSnapshot(program)
+registerSetup(program)
 
 registerUpgradeCommand(program)
 

--- a/cli/setup/register.ts
+++ b/cli/setup/register.ts
@@ -1,0 +1,29 @@
+import type { Command } from "commander"
+import { prompts } from "lib/utils/prompts"
+import { setupGithubActions } from "lib/shared/setup-github-actions"
+
+export const registerSetup = (program: Command) => {
+  program
+    .command("setup")
+    .description("Setup utilities like GitHub Actions")
+    .action(async () => {
+      const { option } = await prompts({
+        type: "select",
+        name: "option",
+        message: "Select setup option",
+        choices: [
+          {
+            title: "GitHub Action",
+            value: "github-action",
+            description:
+              "Automatically build, check and commit snapshots to the main branch",
+            selected: true,
+          },
+        ],
+      })
+
+      if (option === "github-action") {
+        setupGithubActions()
+      }
+    })
+}

--- a/lib/shared/setup-github-actions.ts
+++ b/lib/shared/setup-github-actions.ts
@@ -6,7 +6,7 @@ export const setupGithubActions = (projectDir: string = process.cwd()) => {
   const workflowsDir = path.join(projectDir, ".github", "workflows")
   fs.mkdirSync(workflowsDir, { recursive: true })
 
-  const buildWorkflow = `name: TSCircuit Build
+  const buildWorkflow = `name: tscircuit Build
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
       - run: bunx tsci build
 `
 
-  const snapshotWorkflow = `name: TSCircuit Snapshot
+  const snapshotWorkflow = `name: tscircuit Snapshot
 
 on:
   push:

--- a/lib/shared/setup-github-actions.ts
+++ b/lib/shared/setup-github-actions.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs"
+import path from "node:path"
+import { writeFileIfNotExists } from "./write-file-if-not-exists"
+
+export const setupGithubActions = (projectDir: string = process.cwd()) => {
+  const workflowsDir = path.join(projectDir, ".github", "workflows")
+  fs.mkdirSync(workflowsDir, { recursive: true })
+
+  const buildWorkflow = `name: TSCircuit Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bunx tsci build
+`
+
+  const snapshotWorkflow = `name: TSCircuit Snapshot
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bunx tsci snapshot --update
+      - name: Commit snapshots
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Update snapshots" || echo "No changes to commit"
+          git push
+`
+
+  writeFileIfNotExists(
+    path.join(workflowsDir, "tscircuit-build.yml"),
+    buildWorkflow,
+  )
+  writeFileIfNotExists(
+    path.join(workflowsDir, "tscircuit-snapshot.yml"),
+    snapshotWorkflow,
+  )
+}


### PR DESCRIPTION
## Summary
- add `setup` command for generating GitHub Actions
- implement workflow generator helper
- register new command in CLI
- use bun in generated workflows

## Testing
- `bun run format:check`
- `bun test` *(fails: clone, push, init, token tests)*

------
https://chatgpt.com/codex/tasks/task_b_6842580fd91c832e9d47ebf99739f5e0