### PR TITLE
Implement tsci pull to sync cli with registry

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -15,6 +15,7 @@ import { registerAuthPrintToken } from "./auth/print-token/register"
 import { registerAuthSetToken } from "./auth/set-token/register"
 import { registerPush } from "./push/register"
 import { registerAdd } from "./add/register"
+import { registerPull } from "./pull/register"
 import { registerUpgradeCommand } from "./upgrade/register"
 import { registerConfigSet } from "./config/set/register"
 import { registerSearch } from "./search/register"
@@ -32,6 +33,7 @@ registerInit(program)
 registerDev(program)
 registerClone(program)
 registerPush(program)
+registerPull(program)
 
 registerAuth(program)
 registerAuthLogin(program)

--- a/cli/pull/register.ts
+++ b/cli/pull/register.ts
@@ -1,0 +1,31 @@
+import type { Command } from "commander"
+import path from "node:path"
+import { pullPackage } from "lib/shared/pull-package"
+
+export const registerPull = (program: Command) => {
+  program
+    .command("pull")
+    .description("Fetch latest package files from the registry")
+    .argument("[directory]", "Directory of the package")
+    .action(async (directory?: string) => {
+      const projectDir = path.resolve(directory || process.cwd())
+      try {
+        await pullPackage(projectDir)
+      } catch (error) {
+        if (
+          error &&
+          typeof error === "object" &&
+          "error_code" in error &&
+          "message" in error
+        ) {
+          console.error(JSON.stringify(error))
+        } else {
+          const message = error instanceof Error ? error.message : String(error)
+          console.error(
+            JSON.stringify({ error_code: "unknown_error", message }),
+          )
+        }
+        process.exit(1)
+      }
+    })
+}

--- a/lib/shared/pull-package.ts
+++ b/lib/shared/pull-package.ts
@@ -1,0 +1,86 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { getRegistryApiKy } from "lib/registry-api/get-ky"
+import kleur from "kleur"
+import { getPackageAuthor } from "lib/utils/get-package-author"
+import { getUnscopedPackageName } from "lib/utils/get-unscoped-package-name"
+
+export const pullPackage = async (projectDir: string = process.cwd()) => {
+  const packageJsonPath = path.join(projectDir, "package.json")
+  if (!fs.existsSync(packageJsonPath)) {
+    throw {
+      error_code: "package_json_not_found",
+      message: "package.json not found",
+    }
+  }
+
+  let packageJson: { name?: string }
+  try {
+    packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
+  } catch {
+    throw {
+      error_code: "invalid_package_json",
+      message: "Invalid package.json",
+    }
+  }
+
+  if (!packageJson.name) {
+    throw {
+      error_code: "package_name_missing",
+      message: "Package name missing in package.json",
+    }
+  }
+
+  const author = getPackageAuthor(packageJson.name)
+  const unscopedName = getUnscopedPackageName(packageJson.name)
+
+  const ky = getRegistryApiKy()
+  let fileList: { package_files: Array<{ file_path: string }> } = {
+    package_files: [],
+  }
+  try {
+    fileList = await ky
+      .post<{ package_files: Array<{ file_path: string }> }>(
+        "package_files/list",
+        {
+          json: {
+            package_name: `${author}/${unscopedName}`,
+            use_latest_version: true,
+          },
+        },
+      )
+      .json()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw {
+      error_code: "fetch_failed",
+      message: `Failed to fetch package files: ${message}`,
+    }
+  }
+
+  for (const fileInfo of fileList.package_files) {
+    const relative = fileInfo.file_path.replace(/^\/|dist\//g, "")
+    if (!relative) continue
+    const fullPath = path.join(projectDir, relative)
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+    try {
+      const fileContent = await ky
+        .post<{ package_file: { content_text: string } }>("package_files/get", {
+          json: {
+            package_name: `${author}/${unscopedName}`,
+            file_path: fileInfo.file_path,
+          },
+        })
+        .json()
+      fs.writeFileSync(fullPath, fileContent.package_file.content_text)
+      console.log(kleur.gray(`\u2b07 ${relative}`))
+    } catch (error) {
+      console.warn(
+        `Skipping ${relative} due to error:`,
+        error instanceof Error ? error.message : error,
+      )
+    }
+  }
+
+  console.log(kleur.green("Package updated from registry"))
+}

--- a/tests/cli/pull/pull.test.ts
+++ b/tests/cli/pull/pull.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test"
+import { join } from "node:path"
+import { readFileSync, writeFileSync } from "node:fs"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test.skip("pull command updates files from registry", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await runCommand("tsci clone testuser/my-test-board")
+
+  const projectDir = join(tmpDir, "my-test-board")
+  const filePath = join(projectDir, "index.tsx")
+  const packageJsonPath = join(projectDir, "package.json")
+  const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+  pkg.name = "@tsci/testuser.my-test-board"
+  writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2))
+  const original = readFileSync(filePath, "utf8")
+  writeFileSync(filePath, "// modified")
+
+  await runCommand("tsci pull my-test-board")
+
+  const pulled = readFileSync(filePath, "utf8")
+  expect(pulled).toBe(original)
+}, 20_000)


### PR DESCRIPTION
## Summary
- emit raw error objects from `pullPackage`
- handle plain error objects in `tsci pull` command

## Testing
- `bun run format:check`
- `bun test tests/cli/pull/pull.test.ts` (1 skipped)


------
https://chatgpt.com/codex/tasks/task_b_68435a14eec88327b96aa8c9a6f4fc70