### PR TITLE
Inject registry token into runframe

### DIFF
--- a/lib/site/getIndex.ts
+++ b/lib/site/getIndex.ts
@@ -1,10 +1,16 @@
+import { getSessionToken } from "lib/cli-config"
+
 export const getIndex = async () => {
+  const sessionToken = getSessionToken()
+  const tokenScript = sessionToken
+    ? `\n        window.TSCIRCUIT_REGISTRY_TOKEN = ${JSON.stringify(sessionToken)};`
+    : ""
   return `<html>
     <head>
     </head>
     <body>
       <script>
-        window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI = true;
+        window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI = true;${tokenScript}
       </script>
       <script src="https://cdn.tailwindcss.com"></script>
       <div id="root">loading...</div>

--- a/tests/test4-get-index-token.test.ts
+++ b/tests/test4-get-index-token.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test"
+import { cliConfig } from "lib/cli-config"
+import { getIndex } from "lib/site/getIndex"
+
+const DUMMY_TOKEN = "dummy-token"
+
+test("getIndex injects registry token when logged in", async () => {
+  const originalToken = cliConfig.get("sessionToken")
+  cliConfig.set("sessionToken", DUMMY_TOKEN)
+  const html = await getIndex()
+  if (originalToken) cliConfig.set("sessionToken", originalToken)
+  else cliConfig.delete("sessionToken")
+
+  expect(html).toContain(`window.TSCIRCUIT_REGISTRY_TOKEN = \"${DUMMY_TOKEN}\"`)
+})
+
+test("getIndex does not inject registry token when logged out", async () => {
+  const originalToken = cliConfig.get("sessionToken")
+  cliConfig.delete("sessionToken")
+  const html = await getIndex()
+  if (originalToken) cliConfig.set("sessionToken", originalToken)
+
+  expect(html).not.toContain("TSCIRCUIT_REGISTRY_TOKEN")
+})


### PR DESCRIPTION
## Summary
- pass CLI session token to runframe standalone HTML
- test injection logic in `getIndex`

## Testing
- `bun test tests/test4-get-index-token.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_684e37e86350832ea6d786113cb4f045