### PR TITLE
Add circuit file build outputs for any *.circuit.tsx file

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -1,0 +1,40 @@
+import path from "node:path"
+import fs from "node:fs"
+import kleur from "kleur"
+import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
+
+export const buildFile = async (
+  input: string,
+  output: string,
+  projectDir: string,
+  options?: { ignoreErrors?: boolean; ignoreWarnings?: boolean },
+): Promise<boolean> => {
+  try {
+    const result = await generateCircuitJson({ filePath: input })
+    fs.mkdirSync(path.dirname(output), { recursive: true })
+    fs.writeFileSync(output, JSON.stringify(result.circuitJson, null, 2))
+    console.log(`Circuit JSON written to ${path.relative(projectDir, output)}`)
+
+    const { errors, warnings } = analyzeCircuitJson(result.circuitJson)
+
+    if (!options?.ignoreWarnings) {
+      for (const warn of warnings) {
+        const msg = warn.message || JSON.stringify(warn)
+        console.log(kleur.yellow(msg))
+      }
+    }
+
+    if (!options?.ignoreErrors) {
+      for (const err of errors) {
+        const msg = err.message || JSON.stringify(err)
+        console.error(kleur.red(msg))
+      }
+    }
+
+    return errors.length === 0
+  } catch (err) {
+    console.error(`Build failed: ${err}`)
+    return false
+  }
+}

--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs"
+import path from "node:path"
+import { globbySync } from "globby"
+import { getEntrypoint } from "lib/shared/get-entrypoint"
+import { DEFAULT_IGNORED_PATTERNS } from "lib/shared/should-ignore-path"
+
+export async function getBuildEntrypoints({
+  fileOrDir,
+  rootDir = process.cwd(),
+}: {
+  fileOrDir?: string
+  rootDir?: string
+}): Promise<{
+  projectDir: string
+  mainEntrypoint?: string
+  circuitFiles: string[]
+}> {
+  const resolvedRoot = path.resolve(rootDir)
+
+  if (fileOrDir) {
+    const resolved = path.resolve(resolvedRoot, fileOrDir)
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+      const projectDir = resolved
+      const circuitFiles: string[] = []
+      const mainEntrypoint = await getEntrypoint({
+        projectDir,
+        onError: () => {},
+      })
+      const files = globbySync("**/*.circuit.tsx", {
+        cwd: projectDir,
+        ignore: DEFAULT_IGNORED_PATTERNS,
+      })
+      for (const f of files) {
+        circuitFiles.push(path.join(projectDir, f))
+      }
+      return {
+        projectDir,
+        mainEntrypoint: mainEntrypoint || undefined,
+        circuitFiles,
+      }
+    }
+    return { projectDir: path.dirname(resolved), circuitFiles: [resolved] }
+  }
+
+  const projectDir = resolvedRoot
+  const circuitFiles: string[] = []
+  const mainEntrypoint = await getEntrypoint({ projectDir, onError: () => {} })
+  const files = globbySync("**/*.circuit.tsx", {
+    cwd: projectDir,
+    ignore: DEFAULT_IGNORED_PATTERNS,
+  })
+  for (const f of files) {
+    circuitFiles.push(path.join(projectDir, f))
+  }
+  return {
+    projectDir,
+    mainEntrypoint: mainEntrypoint || undefined,
+    circuitFiles,
+  }
+}

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -1,12 +1,8 @@
 import type { Command } from "commander"
 import path from "node:path"
 import fs from "node:fs"
-import { generateCircuitJson } from "lib/shared/generate-circuit-json"
-import { getEntrypoint } from "lib/shared/get-entrypoint"
-import kleur from "kleur"
-import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
-import { globbySync } from "globby"
-import { DEFAULT_IGNORED_PATTERNS } from "lib/shared/should-ignore-path"
+import { buildFile } from "./build-file"
+import { getBuildEntrypoints } from "./get-build-entrypoints"
 
 export const registerBuild = (program: Command) => {
   program
@@ -20,73 +16,37 @@ export const registerBuild = (program: Command) => {
         file?: string,
         options?: { ignoreErrors?: boolean; ignoreWarnings?: boolean },
       ) => {
-        const entrypoint = await getEntrypoint({ filePath: file })
-
-        let projectDir = process.cwd()
-        if (entrypoint) projectDir = path.dirname(entrypoint)
+        const { projectDir, mainEntrypoint, circuitFiles } =
+          await getBuildEntrypoints({ fileOrDir: file })
 
         const distDir = path.join(projectDir, "dist")
         fs.mkdirSync(distDir, { recursive: true })
 
         let hasErrors = false
 
-        const buildFile = async (input: string, output: string) => {
-          try {
-            const result = await generateCircuitJson({ filePath: input })
-            fs.mkdirSync(path.dirname(output), { recursive: true })
-            fs.writeFileSync(
-              output,
-              JSON.stringify(result.circuitJson, null, 2),
-            )
-            console.log(
-              `Circuit JSON written to ${path.relative(projectDir, output)}`,
-            )
-
-            const { errors, warnings } = analyzeCircuitJson(result.circuitJson)
-
-            if (!options?.ignoreWarnings) {
-              for (const warn of warnings) {
-                const msg = warn.message || JSON.stringify(warn)
-                console.log(kleur.yellow(msg))
-              }
-            }
-
-            if (!options?.ignoreErrors) {
-              for (const err of errors) {
-                const msg = err.message || JSON.stringify(err)
-                console.error(kleur.red(msg))
-              }
-            }
-
-            if (errors.length > 0) {
-              hasErrors = true
-            }
-          } catch (err) {
-            console.error(`Build failed: ${err}`)
-            process.exit(1)
-          }
-        }
-
-        if (entrypoint) {
+        if (mainEntrypoint) {
           const outputPath = path.join(distDir, "circuit.json")
-          await buildFile(entrypoint, outputPath)
+          const ok = await buildFile(
+            mainEntrypoint,
+            outputPath,
+            projectDir,
+            options,
+          )
+          if (!ok) hasErrors = true
         }
-
-        const ignorePatterns = [...DEFAULT_IGNORED_PATTERNS]
-
-        const circuitFiles = globbySync("**/*.circuit.tsx", {
-          cwd: projectDir,
-          ignore: ignorePatterns,
-        })
 
         for (const filePath of circuitFiles) {
-          const abs = path.join(projectDir, filePath)
-          const outputPath = path.join(
-            distDir,
-            filePath.replace(/\.circuit\.tsx$/, ""),
-            "circuit.json",
-          )
-          await buildFile(abs, outputPath)
+          const relative = path.relative(projectDir, filePath)
+          const isCircuit = filePath.endsWith(".circuit.tsx")
+          const outputPath = isCircuit
+            ? path.join(
+                distDir,
+                relative.replace(/\.circuit\.tsx$/, ""),
+                "circuit.json",
+              )
+            : path.join(distDir, "circuit.json")
+          const ok = await buildFile(filePath, outputPath, projectDir, options)
+          if (!ok) hasErrors = true
         }
 
         if (hasErrors && !options?.ignoreErrors) {

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -13,7 +13,9 @@ export default () => (
 test("build command writes dist/circuit.json", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "test-circuit.tsx")
+  const extraCircuitPath = path.join(tmpDir, "extra.circuit.tsx")
   await writeFile(circuitPath, circuitCode)
+  await writeFile(extraCircuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   const { stdout } = await runCommand(`tsci build ${circuitPath}`)
@@ -25,4 +27,14 @@ test("build command writes dist/circuit.json", async () => {
   const json = JSON.parse(data)
   const component = json.find((c: any) => c.type === "source_component")
   expect(component.name).toBe("R1")
+
+  const extraData = await readFile(
+    path.join(tmpDir, "dist", "extra", "circuit.json"),
+    "utf-8",
+  )
+  const extraJson = JSON.parse(extraData)
+  const extraComponent = extraJson.find(
+    (c: any) => c.type === "source_component",
+  )
+  expect(extraComponent.name).toBe("R1")
 })

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -1,6 +1,6 @@
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 import { test, expect } from "bun:test"
-import { writeFile, readFile } from "node:fs/promises"
+import { writeFile, readFile, stat } from "node:fs/promises"
 import path from "node:path"
 
 const circuitCode = `
@@ -10,7 +10,9 @@ export default () => (
   </board>
 )`
 
-test("build command writes dist/circuit.json", async () => {
+// When a file is provided only that file should be built
+
+test("build with file only outputs that file", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "test-circuit.tsx")
   const extraCircuitPath = path.join(tmpDir, "extra.circuit.tsx")
@@ -18,7 +20,7 @@ test("build command writes dist/circuit.json", async () => {
   await writeFile(extraCircuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
-  const { stdout } = await runCommand(`tsci build ${circuitPath}`)
+  await runCommand(`tsci build ${circuitPath}`)
 
   const data = await readFile(
     path.join(tmpDir, "dist", "circuit.json"),
@@ -27,6 +29,31 @@ test("build command writes dist/circuit.json", async () => {
   const json = JSON.parse(data)
   const component = json.find((c: any) => c.type === "source_component")
   expect(component.name).toBe("R1")
+
+  await expect(
+    stat(path.join(tmpDir, "dist", "extra", "circuit.json")),
+  ).rejects.toBeTruthy()
+})
+
+// When no file is provided search for *.circuit.tsx files
+
+test("build without file builds circuit files", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const mainPath = path.join(tmpDir, "index.tsx")
+  const circuitPath = path.join(tmpDir, "extra.circuit.tsx")
+  await writeFile(mainPath, circuitCode)
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build`)
+
+  const mainData = await readFile(
+    path.join(tmpDir, "dist", "circuit.json"),
+    "utf-8",
+  )
+  const mainJson = JSON.parse(mainData)
+  const mainComponent = mainJson.find((c: any) => c.type === "source_component")
+  expect(mainComponent.name).toBe("R1")
 
   const extraData = await readFile(
     path.join(tmpDir, "dist", "extra", "circuit.json"),


### PR DESCRIPTION
## Summary
- build: generate circuit.json for each `*.circuit.tsx`
- test build command for circuit file output

## Testing
- `bun test tests/cli/build`

------
https://chatgpt.com/codex/tasks/task_b_68505958e7d8832eadbf5d68e9565940