### PR TITLE
Update snapshot command to handle *.circuit.tsx files

### DIFF
--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -54,3 +54,50 @@ test("snapshot command creates SVG snapshots", async () => {
   const { stdout: testStdout } = await runCommand("tsci snapshot --3d")
   expect(testStdout).toContain("All snapshots match")
 }, 10_000)
+
+test("snapshot command snapshots circuit files", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "index.tsx"),
+    `
+    export const IndexBoard = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  await Bun.write(
+    join(tmpDir, "extra.circuit.tsx"),
+    `
+    export const ExtraBoard = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  const { stdout } = await runCommand("tsci snapshot --update")
+  expect(stdout).toContain("Created snapshots")
+
+  const snapDir = join(tmpDir, "__snapshots__")
+
+  const indexPcb = await Bun.file(join(snapDir, "index-pcb.snap.svg")).exists()
+  const indexSch = await Bun.file(
+    join(snapDir, "index-schematic.snap.svg"),
+  ).exists()
+  const extraPcb = await Bun.file(
+    join(snapDir, "extra.circuit-pcb.snap.svg"),
+  ).exists()
+  const extraSch = await Bun.file(
+    join(snapDir, "extra.circuit-schematic.snap.svg"),
+  ).exists()
+
+  expect(indexPcb).toBe(true)
+  expect(indexSch).toBe(true)
+  expect(extraPcb).toBe(true)
+  expect(extraSch).toBe(true)
+})


### PR DESCRIPTION
## Summary
- snapshot `*.circuit.tsx` files like `tsci build`
- include entrypoint even when circuit files exist
- test snapshotting circuit files

## Testing
- `bun test tests/cli/snapshot/snapshot.test.ts`
- `bun test` *(fails: clone, init, login, token tests due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_685164bf2538833299e1eb6c94da1bac