### PR TITLE
Rename config entry field to mainComponentPath

### DIFF
--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -12,7 +12,7 @@ export async function getBuildEntrypoints({
   rootDir?: string
 }): Promise<{
   projectDir: string
-  mainEntrypoint?: string
+  mainComponentPath?: string
   circuitFiles: string[]
 }> {
   const resolvedRoot = path.resolve(rootDir)
@@ -22,7 +22,7 @@ export async function getBuildEntrypoints({
     if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
       const projectDir = resolved
       const circuitFiles: string[] = []
-      const mainEntrypoint = await getEntrypoint({
+      const mainComponentPath = await getEntrypoint({
         projectDir,
         onError: () => {},
       })
@@ -35,7 +35,7 @@ export async function getBuildEntrypoints({
       }
       return {
         projectDir,
-        mainEntrypoint: mainEntrypoint || undefined,
+        mainComponentPath: mainComponentPath || undefined,
         circuitFiles,
       }
     }
@@ -44,7 +44,10 @@ export async function getBuildEntrypoints({
 
   const projectDir = resolvedRoot
   const circuitFiles: string[] = []
-  const mainEntrypoint = await getEntrypoint({ projectDir, onError: () => {} })
+  const mainComponentPath = await getEntrypoint({
+    projectDir,
+    onError: () => {},
+  })
   const files = globbySync("**/*.circuit.tsx", {
     cwd: projectDir,
     ignore: DEFAULT_IGNORED_PATTERNS,
@@ -54,7 +57,7 @@ export async function getBuildEntrypoints({
   }
   return {
     projectDir,
-    mainEntrypoint: mainEntrypoint || undefined,
+    mainComponentPath: mainComponentPath || undefined,
     circuitFiles,
   }
 }

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -16,7 +16,7 @@ export const registerBuild = (program: Command) => {
         file?: string,
         options?: { ignoreErrors?: boolean; ignoreWarnings?: boolean },
       ) => {
-        const { projectDir, mainEntrypoint, circuitFiles } =
+        const { projectDir, mainComponentPath, circuitFiles } =
           await getBuildEntrypoints({ fileOrDir: file })
 
         const distDir = path.join(projectDir, "dist")
@@ -24,10 +24,10 @@ export const registerBuild = (program: Command) => {
 
         let hasErrors = false
 
-        if (mainEntrypoint) {
+        if (mainComponentPath) {
           const outputPath = path.join(distDir, "circuit.json")
           const ok = await buildFile(
-            mainEntrypoint,
+            mainComponentPath,
             outputPath,
             projectDir,
             options,

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
 export const projectConfigSchema = z.object({
-  mainEntrypoint: z.string().optional(),
+  mainComponentPath: z.string().optional(),
   ignoredFiles: z.array(z.string()).optional(),
 })
 

--- a/lib/shared/get-entrypoint.ts
+++ b/lib/shared/get-entrypoint.ts
@@ -15,7 +15,7 @@ type EntrypointOptions = {
  *
  * Logic:
  * 1. Use provided filePath if specified
- * 2. Check tscircuit.config.json for mainEntrypoint
+ * 2. Check tscircuit.config.json for mainComponentPath
  * 3. Check common locations (index.tsx, index.ts, lib/index.tsx, etc.)
  * 4. Update config with detected entrypoint
  */
@@ -30,12 +30,12 @@ export const getEntrypoint = async ({
     return path.resolve(projectDir, filePath)
   }
 
-  // 2. Check tscircuit.config.json for mainEntrypoint
+  // 2. Check tscircuit.config.json for mainComponentPath
   const projectConfig = loadProjectConfig(projectDir)
-  if (projectConfig?.mainEntrypoint) {
+  if (projectConfig?.mainComponentPath) {
     const configEntrypoint = path.resolve(
       projectDir,
-      projectConfig.mainEntrypoint,
+      projectConfig.mainComponentPath,
     )
     if (fs.existsSync(configEntrypoint)) {
       onSuccess(
@@ -65,7 +65,7 @@ export const getEntrypoint = async ({
 
       // 4. Update config with detected entrypoint
       const newConfig = projectConfig || {}
-      newConfig.mainEntrypoint = relativePath
+      newConfig.mainComponentPath = relativePath
       saveProjectConfig(newConfig, projectDir)
       onSuccess(`Updated tscircuit.config.json with detected entrypoint`)
 


### PR DESCRIPTION
## Summary
- update getEntrypoint to use `mainComponentPath`
- rename project config schema field
- use new field in build command helpers

## Testing
- `bun test` *(fails: clone command and other tests due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6852830a54dc8327a4c6ba7c78a9a058