### PR TITLE
Log snapshot paths

### DIFF
--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs"
 import path from "node:path"
 import { globbySync } from "globby"
+import kleur from "kleur"
 import {
   convertCircuitJsonToPcbSvg,
   convertCircuitJsonToSchematicSvg,
@@ -82,6 +83,7 @@ export const snapshotProject = async ({
       const snapPath = path.join(snapDir, `${base}-${type}.snap.svg`)
       if (update || !fs.existsSync(snapPath)) {
         fs.writeFileSync(snapPath, svg)
+        console.log("✅", kleur.gray(path.relative(projectDir, snapPath)))
       } else {
         const existing = fs.readFileSync(snapPath, "utf-8")
         if (existing !== svg) mismatches.push(snapPath)

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -21,6 +21,15 @@ test("snapshot command creates SVG snapshots", async () => {
     "tsci snapshot --update --3d",
   )
   expect(updateStdout).toContain("Created snapshots")
+  expect(updateStdout).toContain(
+    `✅ ${join("__snapshots__", "test.board-pcb.snap.svg")}`,
+  )
+  expect(updateStdout).toContain(
+    `✅ ${join("__snapshots__", "test.board-schematic.snap.svg")}`,
+  )
+  expect(updateStdout).toContain(
+    `✅ ${join("__snapshots__", "test.board-3d.snap.svg")}`,
+  )
 
   const snapshotDir = join(tmpDir, "__snapshots__")
   const pcbSnapshot = await Bun.file(
@@ -82,6 +91,16 @@ test("snapshot command snapshots circuit files", async () => {
 
   const { stdout } = await runCommand("tsci snapshot --update")
   expect(stdout).toContain("Created snapshots")
+  expect(stdout).toContain(`✅ ${join("__snapshots__", "index-pcb.snap.svg")}`)
+  expect(stdout).toContain(
+    `✅ ${join("__snapshots__", "index-schematic.snap.svg")}`,
+  )
+  expect(stdout).toContain(
+    `✅ ${join("__snapshots__", "extra.circuit-pcb.snap.svg")}`,
+  )
+  expect(stdout).toContain(
+    `✅ ${join("__snapshots__", "extra.circuit-schematic.snap.svg")}`,
+  )
 
   const snapDir = join(tmpDir, "__snapshots__")
 


### PR DESCRIPTION
## Summary
- log snapshot paths when writing
- test snapshot log messages

## Testing
- `bun test tests/cli/snapshot/snapshot.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68539bbf3834832eaad7ba6b314d2a60