### PR TITLE
Add pcb-only & schematic-only snapshot options

### DIFF
--- a/cli/snapshot/register.ts
+++ b/cli/snapshot/register.ts
@@ -9,13 +9,24 @@ export const registerSnapshot = (program: Command) => {
     )
     .option("-u, --update", "Update snapshots on disk")
     .option("--3d", "Generate 3d preview snapshots")
-    .action(async (options: { update?: boolean; "3d"?: boolean }) => {
-      await snapshotProject({
-        update: options.update ?? false,
-        threeD: options["3d"] ?? false,
-        onExit: (code) => process.exit(code),
-        onError: (msg) => console.error(msg),
-        onSuccess: (msg) => console.log(msg),
-      })
-    })
+    .option("--pcb-only", "Generate only PCB snapshots")
+    .option("--schematic-only", "Generate only schematic snapshots")
+    .action(
+      async (options: {
+        update?: boolean
+        "3d"?: boolean
+        pcbOnly?: boolean
+        schematicOnly?: boolean
+      }) => {
+        await snapshotProject({
+          update: options.update ?? false,
+          threeD: options["3d"] ?? false,
+          pcbOnly: options.pcbOnly ?? false,
+          schematicOnly: options.schematicOnly ?? false,
+          onExit: (code) => process.exit(code),
+          onError: (msg) => console.error(msg),
+          onSuccess: (msg) => console.log(msg),
+        })
+      },
+    )
 }

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -19,6 +19,10 @@ type SnapshotOptions = {
   ignored?: string[]
   /** Enable generation of 3d preview snapshots */
   threeD?: boolean
+  /** Only generate PCB snapshots */
+  pcbOnly?: boolean
+  /** Only generate schematic snapshots */
+  schematicOnly?: boolean
   onExit?: (code: number) => void
   onError?: (message: string) => void
   onSuccess?: (message: string) => void
@@ -28,6 +32,8 @@ export const snapshotProject = async ({
   update = false,
   ignored = [],
   threeD = false,
+  pcbOnly = false,
+  schematicOnly = false,
   onExit = (code) => process.exit(code),
   onError = (msg) => console.error(msg),
   onSuccess = (msg) => console.log(msg),
@@ -71,10 +77,12 @@ export const snapshotProject = async ({
     const snapDir = path.join(path.dirname(file), "__snapshots__")
     fs.mkdirSync(snapDir, { recursive: true })
     const base = path.basename(file).replace(/\.tsx$/, "")
-    const snapshotPairs: Array<["pcb" | "schematic" | "3d", string]> = [
-      ["pcb", pcbSvg],
-      ["schematic", schSvg],
-    ]
+    const snapshotPairs: Array<["pcb" | "schematic" | "3d", string]> = []
+    const includePcb = pcbOnly || !schematicOnly
+    const includeSchematic = schematicOnly || !pcbOnly
+
+    if (includePcb) snapshotPairs.push(["pcb", pcbSvg])
+    if (includeSchematic) snapshotPairs.push(["schematic", schSvg])
     if (threeD && svg3d) {
       snapshotPairs.push(["3d", svg3d])
     }

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -120,3 +120,59 @@ test("snapshot command snapshots circuit files", async () => {
   expect(extraPcb).toBe(true)
   expect(extraSch).toBe(true)
 })
+
+test("snapshot command --pcb-only", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "only.board.tsx"),
+    `
+    export const OnlyBoard = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  await runCommand("tsci snapshot --update --pcb-only")
+
+  const snapDir = join(tmpDir, "__snapshots__")
+  const pcbExists = await Bun.file(
+    join(snapDir, "only.board-pcb.snap.svg"),
+  ).exists()
+  const schExists = await Bun.file(
+    join(snapDir, "only.board-schematic.snap.svg"),
+  ).exists()
+
+  expect(pcbExists).toBe(true)
+  expect(schExists).toBe(false)
+})
+
+test("snapshot command --schematic-only", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "schem.board.tsx"),
+    `
+    export const SchemBoard = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  await runCommand("tsci snapshot --update --schematic-only")
+
+  const snapDir = join(tmpDir, "__snapshots__")
+  const pcbExists = await Bun.file(
+    join(snapDir, "schem.board-pcb.snap.svg"),
+  ).exists()
+  const schExists = await Bun.file(
+    join(snapDir, "schem.board-schematic.snap.svg"),
+  ).exists()
+
+  expect(pcbExists).toBe(false)
+  expect(schExists).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add `--pcb-only` and `--schematic-only` flags to `tsci snapshot`
- support new flags in `snapshotProject`
- test new snapshot options

## Testing
- `bun test tests/cli/snapshot/snapshot.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68542528ce24832ebee4980db88321f2