### PR TITLE
Show package versions on build/snapshot failure

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -3,6 +3,7 @@ import fs from "node:fs"
 import kleur from "kleur"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
+import { getTscircuitVersionsMessage } from "lib/shared/get-tscircuit-versions"
 
 export const buildFile = async (
   input: string,
@@ -34,7 +35,7 @@ export const buildFile = async (
 
     return errors.length === 0
   } catch (err) {
-    console.error(`Build failed: ${err}`)
+    console.error(`Build failed: ${err}\n${getTscircuitVersionsMessage()}`)
     return false
   }
 }

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import fs from "node:fs"
 import { buildFile } from "./build-file"
 import { getBuildEntrypoints } from "./get-build-entrypoints"
+import { getTscircuitVersionsMessage } from "lib/shared/get-tscircuit-versions"
 
 export const registerBuild = (program: Command) => {
   program
@@ -50,6 +51,7 @@ export const registerBuild = (program: Command) => {
         }
 
         if (hasErrors && !options?.ignoreErrors) {
+          console.error(getTscircuitVersionsMessage())
           process.exit(1)
         }
       },

--- a/lib/shared/get-tscircuit-versions.ts
+++ b/lib/shared/get-tscircuit-versions.ts
@@ -1,6 +1,9 @@
-import tscircuitPkg from "tscircuit/package.json" assert { type: "json" }
-import corePkg from "@tscircuit/core/package.json" assert { type: "json" }
-import evalPkg from "@tscircuit/eval/package.json" assert { type: "json" }
+import { createRequire } from "module"
+
+const require = createRequire(import.meta.url)
+const tscircuitPkg = require("tscircuit/package.json") as { version: string }
+const corePkg = require("@tscircuit/core/package.json") as { version: string }
+const evalPkg = require("@tscircuit/eval/package.json") as { version: string }
 
 export const getTscircuitVersions = () => {
   return {

--- a/lib/shared/get-tscircuit-versions.ts
+++ b/lib/shared/get-tscircuit-versions.ts
@@ -1,0 +1,16 @@
+import tscircuitPkg from "tscircuit/package.json" assert { type: "json" }
+import corePkg from "@tscircuit/core/package.json" assert { type: "json" }
+import evalPkg from "@tscircuit/eval/package.json" assert { type: "json" }
+
+export const getTscircuitVersions = () => {
+  return {
+    tscircuit: tscircuitPkg.version as string,
+    core: corePkg.version as string,
+    eval: evalPkg.version as string,
+  }
+}
+
+export const getTscircuitVersionsMessage = () => {
+  const v = getTscircuitVersions()
+  return `Versions: tscircuit@${v.tscircuit}, @tscircuit/core@${v.core}, @tscircuit/eval@${v.eval}`
+}

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -8,6 +8,7 @@ import {
 } from "circuit-to-svg"
 import { convertCircuitJsonToSimple3dSvg } from "circuit-json-to-simple-3d"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getTscircuitVersionsMessage } from "lib/shared/get-tscircuit-versions"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
 import {
   DEFAULT_IGNORED_PATTERNS,
@@ -105,7 +106,7 @@ export const snapshotProject = async ({
 
   if (mismatches.length > 0) {
     onError(
-      `Snapshot mismatch:\n${mismatches.join("\n")}\n\nRun with --update to fix.`,
+      `Snapshot mismatch:\n${mismatches.join("\n")}\n\nRun with --update to fix.\n${getTscircuitVersionsMessage()}`,
     )
     return onExit(1)
   }

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -65,3 +65,18 @@ test("build without file builds circuit files", async () => {
   )
   expect(extraComponent.name).toBe("R1")
 })
+
+test("build failure outputs versions", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "bad.circuit.tsx")
+  await writeFile(
+    circuitPath,
+    `export default () => { throw new Error('fail'); return <board /> }`,
+  )
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { stderr } = await runCommand(`tsci build ${circuitPath}`)
+  expect(stderr).toContain("tscircuit")
+  expect(stderr).toContain("@tscircuit/core")
+  expect(stderr).toContain("@tscircuit/eval")
+})

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -218,3 +218,24 @@ test("snapshot command with file path", async () => {
   const rootSnapExists = await Bun.file(join(tmpDir, "__snapshots__")).exists()
   expect(rootSnapExists).toBe(false)
 })
+
+test("snapshot mismatch outputs versions", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "snap.board.tsx"),
+    `export const SnapBoard = () => (<board width="10mm" height="10mm"><chip name="U1" footprint="soic8" /></board>)`,
+  )
+
+  await runCommand("tsci snapshot snap.board.tsx --update")
+
+  await Bun.write(
+    join(tmpDir, "snap.board.tsx"),
+    `export const SnapBoard = () => (<board width="10mm" height="10mm"><chip name="U2" footprint="soic8" /></board>)`,
+  )
+
+  const { stderr } = await runCommand("tsci snapshot snap.board.tsx")
+  expect(stderr).toContain("tscircuit")
+  expect(stderr).toContain("@tscircuit/core")
+  expect(stderr).toContain("@tscircuit/eval")
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": false,
     "noEmit": true,
 


### PR DESCRIPTION
## Summary
- output tscircuit package versions when snapshot mismatches
- output tscircuit package versions when build exits with an error
- include failing versions in build error message
- add tests for new failure messaging

## Testing
- `bun test tests/cli/build/build.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/cli/snapshot/snapshot.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_685721918bac832ea531052096f30737