### PR TITLE
`tsci build` without arguments builds .circuit.tsx and .board.tsx files only (does not build index files automatically)

### DIFF
--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -21,40 +21,25 @@ export async function getBuildEntrypoints({
     const resolved = path.resolve(resolvedRoot, fileOrDir)
     if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
       const projectDir = resolved
-      const circuitFiles: string[] = []
-      const mainEntrypoint = await getEntrypoint({
-        projectDir,
-        onError: () => {},
-      })
-      const files = globbySync("**/*.circuit.tsx", {
+      const files = globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
         cwd: projectDir,
         ignore: DEFAULT_IGNORED_PATTERNS,
       })
-      for (const f of files) {
-        circuitFiles.push(path.join(projectDir, f))
-      }
       return {
         projectDir,
-        mainEntrypoint: mainEntrypoint || undefined,
-        circuitFiles,
+        circuitFiles: files.map((f) => path.join(projectDir, f)),
       }
     }
     return { projectDir: path.dirname(resolved), circuitFiles: [resolved] }
   }
 
   const projectDir = resolvedRoot
-  const circuitFiles: string[] = []
-  const mainEntrypoint = await getEntrypoint({ projectDir, onError: () => {} })
-  const files = globbySync("**/*.circuit.tsx", {
+  const files = globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
     cwd: projectDir,
     ignore: DEFAULT_IGNORED_PATTERNS,
   })
-  for (const f of files) {
-    circuitFiles.push(path.join(projectDir, f))
-  }
   return {
     projectDir,
-    mainEntrypoint: mainEntrypoint || undefined,
-    circuitFiles,
+    circuitFiles: files.map((f) => path.join(projectDir, f)),
   }
 }

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -34,25 +34,13 @@ export const registerBuild = (program: Command) => {
 
         let hasErrors = false
 
-        if (mainEntrypoint) {
-          const outputPath = path.join(distDir, "circuit.json")
-          const ok = await buildFile(mainEntrypoint, outputPath, projectDir, {
-            ...options,
-            platformConfig,
-          })
-          if (!ok) hasErrors = true
-        }
-
         for (const filePath of circuitFiles) {
           const relative = path.relative(projectDir, filePath)
-          const isCircuit = filePath.endsWith(".circuit.tsx")
-          const outputPath = isCircuit
-            ? path.join(
-                distDir,
-                relative.replace(/\.circuit\.tsx$/, ""),
-                "circuit.json",
-              )
-            : path.join(distDir, "circuit.json")
+          const outputDirName = relative.replace(
+            /(\.board|\.circuit)?\.tsx$/,
+            "",
+          )
+          const outputPath = path.join(distDir, outputDirName, "circuit.json")
           const ok = await buildFile(filePath, outputPath, projectDir, options)
           if (!ok) hasErrors = true
         }


### PR DESCRIPTION
This change updates the tsci build command to only build files ending in .circuit.tsx or .board.tsx when no file path is specified. 

previously the build command would build any index file:
![image](https://github.com/user-attachments/assets/23ea2da1-254b-466b-bd05-8d1fc98605c6)