### PR TITLE
Add Node snapshot smoke test workflow

### DIFF
--- a/.github/workflows/node-snapshot.yml
+++ b/.github/workflows/node-snapshot.yml
@@ -1,0 +1,28 @@
+name: Node Snapshot Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  node-snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install
+      - name: Build and install tsci
+        run: |
+          bun run build
+          npm install -g .
+      - name: Run Node snapshot smoke test
+        run: node scripts/node-snapshot-test.js

--- a/scripts/node-snapshot-test.js
+++ b/scripts/node-snapshot-test.js
@@ -1,0 +1,38 @@
+import { mkdtempSync, writeFileSync, existsSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { spawnSync } from "child_process"
+
+const tmpDir = mkdtempSync(join(tmpdir(), "tsci-node-"))
+writeFileSync(
+  join(tmpDir, "test.board.tsx"),
+  `export const TestBoard = () => (
+    <board width="10mm" height="10mm">
+      <chip name="U1" footprint="soic8" />
+    </board>
+  )`,
+)
+
+const result = spawnSync("tsci", ["snapshot", "--update", "--3d"], {
+  cwd: tmpDir,
+  encoding: "utf8",
+})
+console.log(result.stdout)
+console.error(result.stderr)
+
+if (result.status !== 0) {
+  console.error("tsci snapshot failed")
+  process.exit(result.status || 1)
+}
+
+const snapDir = join(tmpDir, "__snapshots__")
+const pcbExists = existsSync(join(snapDir, "test.board-pcb.snap.svg"))
+const schExists = existsSync(join(snapDir, "test.board-schematic.snap.svg"))
+const threeExists = existsSync(join(snapDir, "test.board-3d.snap.svg"))
+
+if (!pcbExists || !schExists || !threeExists) {
+  console.error("Snapshots were not created as expected")
+  process.exit(1)
+}
+
+console.log("Node snapshot smoke test passed")


### PR DESCRIPTION
## Summary
- add a workflow running a Node-based smoke test for snapshotting
- create a small Node script that snapshots a simple board using the installed `tsci`

## Testing
- `bun run build`
- `npm install -g .`
- `node scripts/node-snapshot-test.js`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_686545bff3a0832e8284c5e69117a2df