### PR TITLE
Add -y flag for tsci init

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,31 +36,31 @@ Usage: tsci [options] [command]
 CLI for developing tscircuit packages
 
 Options:
-  -h, --help                 display help for command
+  -h, --help                  display help for command
 
 Commands:
-  init [directory]           Initialize a new TSCircuit project in the specified
-                             directory (or current directory if none is
-                             provided)
-  dev [options] [file]       Start development server for a package
-  clone [options] <package>  Clone a package from the registry
-  push [options] [file]      Save snippet code to Registry API
-  auth                       Login/logout
-  login                      Login to tscircuit registry
-  logout                     Logout from tscircuit registry
-  config                     Manage tscircuit CLI configuration
-  export [options] <file>    Export tscircuit code to various formats
-  build [options] [file]     Run tscircuit eval and output circuit json
-  add <component>            Add a tscircuit component package to your project
-  remove <component>         Remove a tscircuit component package from your
-                             project
-  snapshot [options] [file]  Generate schematic and PCB snapshots (add --3d for
-                             3d preview)
-  setup                      Setup utilities like GitHub Actions
-  upgrade                    Upgrade CLI to the latest version
-  search <query>             Search for packages in the tscircuit registry
-  version                    Print CLI version
-  help [command]             display help for command
+  init [options] [directory]  Initialize a new TSCircuit project in the
+                              specified directory (or current directory if none
+                              is provided)
+  dev [options] [file]        Start development server for a package
+  clone [options] <package>   Clone a package from the registry
+  push [options] [file]       Save snippet code to Registry API
+  auth                        Login/logout
+  login                       Login to tscircuit registry
+  logout                      Logout from tscircuit registry
+  config                      Manage tscircuit CLI configuration
+  export [options] <file>     Export tscircuit code to various formats
+  build [options] [file]      Run tscircuit eval and output circuit json
+  add <component>             Add a tscircuit component package to your project
+  remove <component>          Remove a tscircuit component package from your
+                              project
+  snapshot [options] [file]   Generate schematic and PCB snapshots (add --3d for
+                              3d preview)
+  setup                       Setup utilities like GitHub Actions
+  upgrade                     Upgrade CLI to the latest version
+  search <query>              Search for packages in the tscircuit registry
+  version                     Print CLI version
+  help [command]              display help for command
 ```
 <!-- END_HELP_OUTPUT -->
 

--- a/cli/init/register.ts
+++ b/cli/init/register.ts
@@ -22,10 +22,11 @@ export const registerInit = (program: Command) => {
       "[directory]",
       "Directory name (optional, defaults to current directory)",
     )
-    .action(async (directory?: string) => {
+    .option("-y, --yes", "Use defaults and skip prompts")
+    .action(async (directory?: string, options: { yes?: boolean }) => {
       await checkForTsciUpdates()
 
-      if (!directory) {
+      if (!directory && !options.yes) {
         const { continueInCurrentDirectory } = await prompts({
           type: "confirm",
           name: "continueInCurrentDirectory",
@@ -52,12 +53,14 @@ export const registerInit = (program: Command) => {
         : process.cwd()
 
       const defaultPackageName = path.basename(projectDir)
-      const { packageName } = await prompts({
-        type: "text",
-        name: "packageName",
-        message: "Package name",
-        initial: defaultPackageName,
-      })
+      const { packageName } = options.yes
+        ? { packageName: defaultPackageName }
+        : await prompts({
+            type: "text",
+            name: "packageName",
+            message: "Package name",
+            initial: defaultPackageName,
+          })
 
       let authorName = cliConfig.get("githubUsername")
       if (!authorName) {

--- a/cli/init/register.ts
+++ b/cli/init/register.ts
@@ -23,10 +23,10 @@ export const registerInit = (program: Command) => {
       "Directory name (optional, defaults to current directory)",
     )
     .option("-y, --yes", "Use defaults and skip prompts")
-    .action(async (directory?: string, options: { yes?: boolean }) => {
+    .action(async (directory?: string, options?: { yes?: boolean }) => {
       await checkForTsciUpdates()
 
-      if (!directory && !options.yes) {
+      if (!directory && !options?.yes) {
         const { continueInCurrentDirectory } = await prompts({
           type: "confirm",
           name: "continueInCurrentDirectory",
@@ -53,7 +53,7 @@ export const registerInit = (program: Command) => {
         : process.cwd()
 
       const defaultPackageName = path.basename(projectDir)
-      const { packageName } = options.yes
+      const { packageName } = options?.yes
         ? { packageName: defaultPackageName }
         : await prompts({
             type: "text",


### PR DESCRIPTION
## Summary
- add `-y`/`--yes` option to `tsci init`
- update generated README

## Testing
- `bun run format`
- `bun scripts/generate-readme-help-output.ts`
- `bun test` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ff4349210832784b84d65de16c2f3