### PR TITLE
Add smoke init test workflow

### DIFF
--- a/.github/workflows/smoke-init-test.yml
+++ b/.github/workflows/smoke-init-test.yml
@@ -1,0 +1,55 @@
+name: tscircuit Smoke Init Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  smoke-init-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build package
+        run: bun run build
+
+      - name: Pack package
+        run: bun pm pack
+
+      - name: Create temporary directory
+        run: |
+          TEMP_DIR=$(mktemp -d)
+          echo "TEMP_DIR=$TEMP_DIR" >> $GITHUB_ENV
+
+      - name: Install tscircuit globally from packed file
+        run: |
+          PACKAGE_FILE=$(ls *.tgz)
+          npm install -g "$PACKAGE_FILE"
+
+      - name: Test tsci init in temporary directory
+        run: |
+          cd "$TEMP_DIR"
+          tsci init -y
+
+      - name: Test tsci build in temporary directory
+        run: |
+          cd "$TEMP_DIR"
+          tsci build index.tsx
+
+      - name: Verify build output
+        run: |
+          cd "$TEMP_DIR"
+          ls -la
+          test -f index.tsx || (echo "index.tsx not found" && exit 1)


### PR DESCRIPTION
## Summary
- add smoke init test GitHub Actions workflow to validate `tsci init`

## Testing
- `bun test tests/test2-cli-init.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68701aefb60c832e851ce8522d05960f