### PR TITLE
fix: dynamic visual diff for snapshot updates with look-same

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "jwt-decode": "^4.0.0",
         "kleur": "^4.1.5",
         "ky": "^1.7.4",
+        "looks-same": "^9.0.1",
         "make-vfs": "^1.0.15",
         "perfect-cli": "^1.0.20",
         "prompts": "^2.4.2",
@@ -693,7 +694,7 @@
 
     "chokidar": ["chokidar@4.0.1", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA=="],
 
-    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "circuit-json": ["circuit-json@0.0.219", "", { "dependencies": { "nanoid": "^5.0.7" } }, "sha512-40oeO5OyjP1CpEQ4bc979APO4Z5RxOMyAlR+lpbf7nvKVeyavcPdyQGpnVAqNdGBJ9lkm9GYG1m02ewosPVikA=="],
 
@@ -735,7 +736,7 @@
 
     "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
-    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+    "color-convert": ["color-convert@0.5.3", "", {}, "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="],
 
     "color-diff": ["color-diff@1.4.0", "", {}, "sha512-4oDB/o78lNdppbaqrg0HjOp7pHmUc+dfCxWKWFnQg6AB/1dkjtBDop3RZht5386cq9xBUDRvDvSCA7WUlM9Jqw=="],
 
@@ -1851,6 +1852,8 @@
 
     "@vercel/routing-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
+    "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -1862,6 +1865,8 @@
     "circuit-json-to-gerber/transformation-matrix": ["transformation-matrix@3.0.0", "", {}, "sha512-C6NlNnD6T8JqDeY4BpGznuve4d8/JlLDZLcJbnnx7gQKoyk01+uk2XYVFjBGqvNsVxJUpUwb3WZpjpdPr+05FQ=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "color/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1925,8 +1930,6 @@
 
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "parse-color/color-convert": ["color-convert@0.5.3", "", {}, "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="],
-
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "perfect-cli/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
@@ -1978,6 +1981,8 @@
     "styled-components/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
     "styled-components/tslib": ["tslib@2.6.2", "", {}, "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="],
+
+    "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
@@ -2084,8 +2089,6 @@
     "next-themes/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "ora/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
-
-    "prebuild-install/tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 

--- a/cli/snapshot/register.ts
+++ b/cli/snapshot/register.ts
@@ -9,6 +9,7 @@ export const registerSnapshot = (program: Command) => {
       "Generate schematic and PCB snapshots (add --3d for 3d preview)",
     )
     .option("-u, --update", "Update snapshots on disk")
+    .option("--force-update", "Force update snapshots even if they match")
     .option("--3d", "Generate 3d preview snapshots")
     .option("--pcb-only", "Generate only PCB snapshots")
     .option("--schematic-only", "Generate only schematic snapshots")
@@ -20,6 +21,7 @@ export const registerSnapshot = (program: Command) => {
           "3d"?: boolean
           pcbOnly?: boolean
           schematicOnly?: boolean
+          forceUpdate?: boolean
         },
       ) => {
         await snapshotProject({
@@ -27,6 +29,7 @@ export const registerSnapshot = (program: Command) => {
           threeD: options["3d"] ?? false,
           pcbOnly: options.pcbOnly ?? false,
           schematicOnly: options.schematicOnly ?? false,
+          forceUpdate: options.forceUpdate ?? false,
           filePaths: file ? [file] : [],
           onExit: (code) => process.exit(code),
           onError: (msg) => console.error(msg),

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -119,10 +119,12 @@ export const snapshotProject = async ({
       const existing = fs.readFileSync(snapPath, "utf-8")
       const looksSame = await loadLooksSame()
       const equal = looksSame
-        ? (await looksSame.default(Buffer.from(svg), Buffer.from(existing), {
-            strict: false,
-            tolerance: 2,
-          })).equal
+        ? (
+            await looksSame.default(Buffer.from(svg), Buffer.from(existing), {
+              strict: false,
+              tolerance: 2,
+            })
+          ).equal
         : existing === svg
 
       if (update) {

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -2,6 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 import { globbySync } from "globby"
 import kleur from "kleur"
+import looksSame from "looks-same"
 import {
   convertCircuitJsonToPcbSvg,
   convertCircuitJsonToSchematicSvg,
@@ -25,6 +26,8 @@ type SnapshotOptions = {
   schematicOnly?: boolean
   /** Snapshot only the specified files */
   filePaths?: string[]
+  /** Force updating snapshots even if they match */
+  forceUpdate?: boolean
   onExit?: (code: number) => void
   onError?: (message: string) => void
   onSuccess?: (message: string) => void
@@ -37,6 +40,7 @@ export const snapshotProject = async ({
   pcbOnly = false,
   schematicOnly = false,
   filePaths = [],
+  forceUpdate = false,
   onExit = (code) => process.exit(code),
   onError = (msg) => console.error(msg),
   onSuccess = (msg) => console.log(msg),
@@ -88,12 +92,40 @@ export const snapshotProject = async ({
 
     for (const [type, svg] of snapshotPairs) {
       const snapPath = path.join(snapDir, `${base}-${type}.snap.svg`)
-      if (update || !fs.existsSync(snapPath)) {
+      const fileExists = fs.existsSync(snapPath)
+
+      if (!fileExists) {
         fs.writeFileSync(snapPath, svg)
         console.log("✅", kleur.gray(path.relative(projectDir, snapPath)))
-      } else {
-        const existing = fs.readFileSync(snapPath, "utf-8")
-        if (existing !== svg) mismatches.push(snapPath)
+        continue
+      }
+
+      const existing = fs.readFileSync(snapPath, "utf-8")
+      const result: any = await looksSame(
+        Buffer.from(svg),
+        Buffer.from(existing),
+        {
+          strict: false,
+          tolerance: 2,
+        },
+      )
+
+      if (update) {
+        if (!forceUpdate && result.equal) {
+          console.log("✅", kleur.gray(path.relative(projectDir, snapPath)))
+        } else {
+          fs.writeFileSync(snapPath, svg)
+          console.log("✅", kleur.gray(path.relative(projectDir, snapPath)))
+        }
+      } else if (!result.equal) {
+        const diffPath = snapPath.replace(".snap.svg", ".diff.png")
+        await looksSame.createDiff({
+          reference: Buffer.from(existing),
+          current: Buffer.from(svg),
+          diff: diffPath,
+          highlightColor: "#ff00ff",
+        })
+        mismatches.push(`${snapPath} (diff: ${diffPath})`)
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jwt-decode": "^4.0.0",
     "kleur": "^4.1.5",
     "ky": "^1.7.4",
+    "looks-same": "^9.0.1",
     "make-vfs": "^1.0.15",
     "perfect-cli": "^1.0.20",
     "prompts": "^2.4.2",

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -249,3 +249,84 @@ test("snapshot command skips updates when snapshots match visually", async () =>
 
   expect(contentsAfter).toBe(contentsBefore)
 })
+
+test("visual comparison works for pcb and schematic snapshots", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "both.board.tsx"),
+    `
+    export const Both = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  await runCommand("tsci snapshot --update")
+
+  const snapDir = join(tmpDir, "__snapshots__")
+  const pcbPath = join(snapDir, "both.board-pcb.snap.svg")
+  const schPath = join(snapDir, "both.board-schematic.snap.svg")
+
+  fs.appendFileSync(pcbPath, "\n<!-- comment -->\n")
+  fs.appendFileSync(schPath, "\n<!-- comment -->\n")
+
+  const pcbBefore = fs.readFileSync(pcbPath, "utf-8")
+  const schBefore = fs.readFileSync(schPath, "utf-8")
+
+  const { stdout } = await runCommand("tsci snapshot")
+  expect(stdout).toContain("All snapshots match")
+
+  await runCommand("tsci snapshot --update")
+
+  const pcbAfter = fs.readFileSync(pcbPath, "utf-8")
+  const schAfter = fs.readFileSync(schPath, "utf-8")
+
+  expect(pcbAfter).toBe(pcbBefore)
+  expect(schAfter).toBe(schBefore)
+})
+
+test("snapshot command creates diff images when visuals change", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "mismatch.board.tsx"),
+    `
+    export const Mismatch = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  await runCommand("tsci snapshot --update")
+
+  await Bun.write(
+    join(tmpDir, "mismatch.board.tsx"),
+    `
+    export const Mismatch = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+        <chip name="U2" footprint="soic8" schX={-3} pcbX={-3} />
+      </board>
+    )
+  `,
+  )
+
+  const { stderr } = await runCommand("tsci snapshot")
+  expect(stderr).toContain("Snapshot mismatch")
+
+  const snapDir = join(tmpDir, "__snapshots__")
+  const pcbDiff = await Bun.file(
+    join(snapDir, "mismatch.board-pcb.diff.png"),
+  ).exists()
+  const schDiff = await Bun.file(
+    join(snapDir, "mismatch.board-schematic.diff.png"),
+  ).exists()
+
+  expect(pcbDiff).toBe(true)
+  expect(schDiff).toBe(true)
+})


### PR DESCRIPTION
## Summary
- use `looks-same` to compare SVGs
- add `--force-update` flag to snapshot command
- write diff images when snapshots mismatch

## Testing
- `bun test tests/cli/snapshot/snapshot.test.ts --timeout 20_000`
- `bun run smoketest` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873de2679a08330a69b0cb35dc17be8