### PR TITLE
Handle snapshot metadata differences

### DIFF
--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -118,6 +118,9 @@ export const snapshotProject = async ({
 
       const existing = fs.readFileSync(snapPath, "utf-8")
       const looksSame = await loadLooksSame()
+      const normalizeSvg = (s: string) =>
+        s.replace(/\s*data-software-used-string="[^"]*"/g, "")
+
       const equal = looksSame
         ? (
             await looksSame.default(Buffer.from(svg), Buffer.from(existing), {
@@ -125,7 +128,7 @@ export const snapshotProject = async ({
               tolerance: 2,
             })
           ).equal
-        : existing === svg
+        : normalizeSvg(existing) === normalizeSvg(svg)
 
       if (update) {
         if (!forceUpdate && equal) {

--- a/tests/looks-same-metadata.test.ts
+++ b/tests/looks-same-metadata.test.ts
@@ -5,10 +5,14 @@ const svgBase = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
 const svgChanged = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" data-software-used-string="@tscircuit/core@0.0.562"><rect width="10" height="10"/></svg>`
 
 test("looksSame ignores metadata differences", async () => {
-  const { equal } = await looksSame(Buffer.from(svgBase), Buffer.from(svgChanged), {
-    strict: false,
-    tolerance: 2,
-  })
+  const { equal } = await looksSame(
+    Buffer.from(svgBase),
+    Buffer.from(svgChanged),
+    {
+      strict: false,
+      tolerance: 2,
+    },
+  )
   expect(equal).toBe(true)
 })
 

--- a/tests/looks-same-metadata.test.ts
+++ b/tests/looks-same-metadata.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test"
+import looksSame from "looks-same"
+
+const svgBase = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>`
+const svgChanged = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" data-software-used-string="@tscircuit/core@0.0.562"><rect width="10" height="10"/></svg>`
+
+test("looksSame ignores metadata differences", async () => {
+  const { equal } = await looksSame(Buffer.from(svgBase), Buffer.from(svgChanged), {
+    strict: false,
+    tolerance: 2,
+  })
+  expect(equal).toBe(true)
+})
+
+function normalizeSvg(s: string) {
+  return s.replace(/\s*data-software-used-string="[^"]*"/g, "")
+}
+
+test("snapshot fallback ignores software version", () => {
+  expect(normalizeSvg(svgBase)).toBe(normalizeSvg(svgChanged))
+})


### PR DESCRIPTION
## Summary
- ensure snapshot comparison ignores `data-software-used-string` metadata
- add regression test covering metadata differences

## Testing
- `bun test tests/looks-same-metadata.test.ts`
- `bun test` *(fails: basic init, token handling, clone and other CLI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68750bd5d9a883308e39d3277bdb804b


------
the only thing changing is the metadata of core version 

<img width="1110" height="1201" alt="image" src="https://github.com/user-attachments/assets/10b1b330-2af1-490c-823c-8aeb30ea9dc0" />
