### PR TITLE
refactor(get-entrypoint)!: improve entrypoint detection with recursive  search

### DIFF
--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -54,13 +54,15 @@ export class DevServer {
   constructor({
     port,
     componentFilePath,
+    projectDir,
   }: {
     port: number
     componentFilePath: string
+    projectDir?: string
   }) {
     this.port = port
     this.componentFilePath = componentFilePath
-    this.projectDir = path.dirname(componentFilePath)
+    this.projectDir = projectDir ?? path.dirname(componentFilePath)
     const projectConfig = loadProjectConfig(this.projectDir)
     this.ignoredFiles = projectConfig?.ignoredFiles ?? []
     this.fsKy = ky.create({

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -72,6 +72,7 @@ export const registerDev = (program: Command) => {
       const server = new DevServer({
         port,
         componentFilePath: absolutePath,
+        projectDir: process.cwd(),
       })
 
       await server.start()

--- a/lib/shared/get-entrypoint.ts
+++ b/lib/shared/get-entrypoint.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { loadProjectConfig, saveProjectConfig } from "lib/project-config"
+import { loadProjectConfig } from "lib/project-config"
 import kleur from "kleur"
 
 type EntrypointOptions = {
@@ -10,87 +10,156 @@ type EntrypointOptions = {
   onError?: (message: string) => void
 }
 
-/**
- * Detect the main entrypoint for a tscircuit project
- *
- * Logic:
- * 1. Use provided filePath if specified
- * 2. Check tscircuit.config.json for mainEntrypoint
- * 3. Check common locations (index.tsx, index.ts, lib/index.tsx, etc.)
- * 4. Update config with detected entrypoint
- */
+const ALLOWED_ENTRYPOINT_NAMES = Object.freeze([
+  "index.tsx",
+  "index.ts",
+  "index.circuit.tsx",
+  "main.tsx",
+  "main.circuit.tsx",
+])
+
+const MAX_SEARCH_DEPTH = 3
+const MAX_RESULTS = 100
+
+const isValidDirectory = (dirPath: string, projectDir: string): boolean => {
+  const resolvedDir = path.resolve(dirPath)
+  const resolvedProject = path.resolve(projectDir)
+  return resolvedDir.startsWith(resolvedProject) && !resolvedDir.includes("..")
+}
+
+const findEntrypointsRecursively = (
+  dir: string,
+  projectDir: string,
+  maxDepth: number = MAX_SEARCH_DEPTH,
+  fileNames: readonly string[] = ALLOWED_ENTRYPOINT_NAMES
+): string[] => {
+  if (maxDepth <= 0 || !isValidDirectory(dir, projectDir)) {
+    return []
+  }
+  
+  const results: string[] = []
+  
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    
+    for (const entry of entries) {
+      if (results.length >= MAX_RESULTS) break
+      
+      if (entry.isFile() && fileNames.includes(entry.name)) {
+        const filePath = path.resolve(dir, entry.name)
+        if (isValidDirectory(filePath, projectDir)) {
+          results.push(filePath)
+        }
+      }
+    }
+    
+    for (const entry of entries) {
+      if (results.length >= MAX_RESULTS) break
+      
+      if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
+        const subdirPath = path.resolve(dir, entry.name)
+        if (isValidDirectory(subdirPath, projectDir)) {
+          results.push(...findEntrypointsRecursively(subdirPath, projectDir, maxDepth - 1, fileNames))
+        }
+      }
+    }
+  } catch {
+    return []
+  }
+  
+  return results
+}
+
+
+const validateProjectDir = (projectDir: string): string => {
+  const resolvedDir = path.resolve(projectDir)
+  if (!fs.existsSync(resolvedDir)) {
+    throw new Error(`Project directory does not exist: ${projectDir}`)
+  }
+  return resolvedDir
+}
+
+const validateFilePath = (filePath: string, projectDir: string): string | null => {
+  const absolutePath = path.resolve(projectDir, filePath)
+  
+  if (!absolutePath.startsWith(path.resolve(projectDir))) {
+    return null
+  }
+  
+  if (absolutePath.includes("..")) {
+    return null
+  }
+  
+  return fs.existsSync(absolutePath) ? absolutePath : null
+}
+
 export const getEntrypoint = async ({
   filePath,
   projectDir = process.cwd(),
-  onSuccess = (message) => console.log(message),
-  onError = (message) => console.error(message),
+  onSuccess = (message: string) => console.log(message),
+  onError = (message: string) => console.error(message),
 }: EntrypointOptions): Promise<string | null> => {
-  // 1. Use provided filePath if specified
-  if (filePath) {
-    const absolutePath = path.resolve(projectDir, filePath)
-    if (fs.existsSync(absolutePath)) {
-      onSuccess(
-        `Using provided file: '${path.relative(projectDir, absolutePath)}'`,
-      )
-      return absolutePath
+  try {
+    const validatedProjectDir = validateProjectDir(projectDir)
+    
+    if (filePath) {
+      const validatedPath = validateFilePath(filePath, validatedProjectDir)
+      if (validatedPath) {
+        const relativePath = path.relative(validatedProjectDir, validatedPath)
+        onSuccess(`Using provided file: '${relativePath}'`)
+        return validatedPath
+      }
+      onError(kleur.red(`File not found or invalid: '${filePath}'`))
+      return null
     }
-    onError(kleur.red(`File not found: '${filePath}'`))
-    return null
-  }
 
-  // 2. Check tscircuit.config.json for mainEntrypoint
-  const projectConfig = loadProjectConfig(projectDir)
-  if (projectConfig?.mainEntrypoint) {
-    const configEntrypoint = path.resolve(
-      projectDir,
-      projectConfig.mainEntrypoint,
-    )
-    if (fs.existsSync(configEntrypoint)) {
-      onSuccess(
-        `Using entrypoint from tscircuit.config.json: '${path.relative(projectDir, configEntrypoint)}'`,
-      )
-      return configEntrypoint
+    const projectConfig = loadProjectConfig(validatedProjectDir)
+    if (projectConfig?.mainEntrypoint && typeof projectConfig.mainEntrypoint === "string") {
+      const validatedConfigPath = validateFilePath(projectConfig.mainEntrypoint, validatedProjectDir)
+      if (validatedConfigPath) {
+        const relativePath = path.relative(validatedProjectDir, validatedConfigPath)
+        onSuccess(`Using entrypoint from tscircuit.config.json: '${relativePath}'`)
+        return validatedConfigPath
+      }
     }
-  }
 
-  // 3. Check common locations
-  const possibleEntrypoints = [
-    path.resolve(projectDir, "index.tsx"),
-    path.resolve(projectDir, "index.ts"),
-    path.resolve(projectDir, "index.circuit.tsx"),
-    path.resolve(projectDir, "main.tsx"),
-    path.resolve(projectDir, "main.circuit.tsx"),
-    path.resolve(projectDir, "lib/index.tsx"),
-    path.resolve(projectDir, "lib/index.ts"),
-    path.resolve(projectDir, "lib/index.circuit.tsx"),
-    path.resolve(projectDir, "lib/main.tsx"),
-    path.resolve(projectDir, "lib/main.circuit.tsx"),
-    path.resolve(projectDir, "src/index.tsx"),
-    path.resolve(projectDir, "src/index.ts"),
-    path.resolve(projectDir, "src/index.circuit.tsx"),
-    path.resolve(projectDir, "src/main.tsx"),
-    path.resolve(projectDir, "src/main.circuit.tsx"),
-  ]
+    const commonLocations = [
+      "index.tsx",
+      "index.ts", 
+      "index.circuit.tsx",
+      "main.tsx",
+      "main.circuit.tsx",
+      "lib/index.tsx",
+      "lib/index.ts",
+      "lib/index.circuit.tsx",
+      "lib/main.tsx",
+      "lib/main.circuit.tsx",
+      "src/index.tsx",
+      "src/index.ts",
+      "src/index.circuit.tsx",
+      "src/main.tsx",
+      "src/main.circuit.tsx",
+    ].map(location => path.resolve(validatedProjectDir, location))
+    
+    const recursiveEntrypoints = findEntrypointsRecursively(validatedProjectDir, validatedProjectDir)
+    const possibleEntrypoints = [...commonLocations, ...recursiveEntrypoints]
 
-  let detectedEntrypoint: string | null = null
-
-  for (const entrypoint of possibleEntrypoints) {
-    if (fs.existsSync(entrypoint)) {
-      detectedEntrypoint = entrypoint
-      const relativePath = path.relative(projectDir, entrypoint)
-      onSuccess(`Detected entrypoint: '${relativePath}'`)
-
-      break
+    for (const entrypoint of possibleEntrypoints) {
+      if (fs.existsSync(entrypoint) && isValidDirectory(entrypoint, validatedProjectDir)) {
+        const relativePath = path.relative(validatedProjectDir, entrypoint)
+        onSuccess(`Detected entrypoint: '${relativePath}'`)
+        return entrypoint
+      }
     }
-  }
 
-  if (!detectedEntrypoint) {
     onError(
       kleur.red(
-        "No entrypoint found. Run 'tsci init' to bootstrap a basic project or specify a file with 'tsci push <file>'",
-      ),
+        "No entrypoint found. Run 'tsci init' to bootstrap a basic project or specify a file with 'tsci push <file>'"
+      )
     )
+    return null
+  } catch (error) {
+    onError(kleur.red(`Error detecting entrypoint: ${error instanceof Error ? error.message : 'Unknown error'}`)) 
+    return null
   }
-
-  return detectedEntrypoint
 }

--- a/tests/get-entrypoint.test.ts
+++ b/tests/get-entrypoint.test.ts
@@ -1,0 +1,135 @@
+import { test, expect } from "bun:test"
+import { getCliTestFixture } from "./fixtures/get-cli-test-fixture"
+import { getEntrypoint } from "../lib/shared/get-entrypoint"
+import * as path from "node:path"
+import * as fs from "node:fs/promises"
+
+test("getEntrypoint detects standard entrypoints", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  
+  // Create a standard entrypoint file
+  await fs.writeFile(
+    path.join(tmpDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>'
+  )
+  
+  // Test detection
+  let onSuccessCalled = false
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    onSuccess: () => { onSuccessCalled = true },
+  })
+  
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "index.tsx"))
+  expect(onSuccessCalled).toBeTrue()
+})
+
+test("getEntrypoint detects entrypoint from config", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  
+  // Create a config file with mainEntrypoint
+  await fs.mkdir(path.join(tmpDir, "src"))
+  await fs.writeFile(
+    path.join(tmpDir, "src", "main.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>'
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ mainEntrypoint: "src/main.circuit.tsx" })
+  )
+  
+  // Test detection
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+  
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "src", "main.circuit.tsx"))
+})
+
+test("getEntrypoint detects entrypoint in common locations", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  
+  // Create a file in one of the common locations
+  await fs.mkdir(path.join(tmpDir, "src"))
+  await fs.writeFile(
+    path.join(tmpDir, "src", "index.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>'
+  )
+  
+  // Test detection
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+  
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "src", "index.circuit.tsx"))
+})
+
+test("getEntrypoint recursively finds entrypoints in child directories", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  
+  // Create a nested directory structure with an entrypoint
+  await fs.mkdir(path.join(tmpDir, "components", "circuit1"), { recursive: true })
+  await fs.writeFile(
+    path.join(tmpDir, "components", "circuit1", "index.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>'
+  )
+  
+  // Test detection
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+  
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "components", "circuit1", "index.circuit.tsx"))
+})
+
+test("getEntrypoint returns null when no entrypoint is found", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  
+  // Create a file that is not an entrypoint
+  await fs.writeFile(
+    path.join(tmpDir, "not-an-entrypoint.js"),
+    'console.log("This is not an entrypoint");'
+  )
+  
+  // Test detection
+  let onErrorCalled = false
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    onError: () => { onErrorCalled = true },
+  })
+  
+  expect(entrypoint).toBeNull()
+  expect(onErrorCalled).toBeTrue()
+})
+
+test("getEntrypoint prioritizes provided filePath over other detection methods", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  
+  // Create multiple potential entrypoints
+  await fs.writeFile(
+    path.join(tmpDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>'
+  )
+  await fs.mkdir(path.join(tmpDir, "src"))
+  await fs.writeFile(
+    path.join(tmpDir, "src", "main.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>'
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "custom-entrypoint.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>'
+  )
+  
+  // Test detection with provided filePath
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    filePath: "custom-entrypoint.tsx",
+  })
+  
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "custom-entrypoint.tsx"))
+})

--- a/tests/get-entrypoint.test.ts
+++ b/tests/get-entrypoint.test.ts
@@ -6,20 +6,22 @@ import * as fs from "node:fs/promises"
 
 test("getEntrypoint detects standard entrypoints", async () => {
   const { tmpDir } = await getCliTestFixture()
-  
+
   // Create a standard entrypoint file
   await fs.writeFile(
     path.join(tmpDir, "index.tsx"),
-    'export default () => <board width="10mm" height="10mm"></board>'
+    'export default () => <board width="10mm" height="10mm"></board>',
   )
-  
+
   // Test detection
   let onSuccessCalled = false
   const entrypoint = await getEntrypoint({
     projectDir: tmpDir,
-    onSuccess: () => { onSuccessCalled = true },
+    onSuccess: () => {
+      onSuccessCalled = true
+    },
   })
-  
+
   expect(entrypoint).not.toBeNull()
   expect(entrypoint).toBe(path.join(tmpDir, "index.tsx"))
   expect(onSuccessCalled).toBeTrue()
@@ -27,109 +29,419 @@ test("getEntrypoint detects standard entrypoints", async () => {
 
 test("getEntrypoint detects entrypoint from config", async () => {
   const { tmpDir } = await getCliTestFixture()
-  
+
   // Create a config file with mainEntrypoint
   await fs.mkdir(path.join(tmpDir, "src"))
   await fs.writeFile(
     path.join(tmpDir, "src", "main.circuit.tsx"),
-    'export default () => <board width="10mm" height="10mm"></board>'
+    'export default () => <board width="10mm" height="10mm"></board>',
   )
   await fs.writeFile(
     path.join(tmpDir, "tscircuit.config.json"),
-    JSON.stringify({ mainEntrypoint: "src/main.circuit.tsx" })
+    JSON.stringify({ mainEntrypoint: "src/main.circuit.tsx" }),
   )
-  
+
   // Test detection
   const entrypoint = await getEntrypoint({
     projectDir: tmpDir,
   })
-  
+
   expect(entrypoint).not.toBeNull()
   expect(entrypoint).toBe(path.join(tmpDir, "src", "main.circuit.tsx"))
 })
 
 test("getEntrypoint detects entrypoint in common locations", async () => {
   const { tmpDir } = await getCliTestFixture()
-  
+
   // Create a file in one of the common locations
   await fs.mkdir(path.join(tmpDir, "src"))
   await fs.writeFile(
     path.join(tmpDir, "src", "index.circuit.tsx"),
-    'export default () => <board width="10mm" height="10mm"></board>'
+    'export default () => <board width="10mm" height="10mm"></board>',
   )
-  
+
   // Test detection
   const entrypoint = await getEntrypoint({
     projectDir: tmpDir,
   })
-  
+
   expect(entrypoint).not.toBeNull()
   expect(entrypoint).toBe(path.join(tmpDir, "src", "index.circuit.tsx"))
 })
 
 test("getEntrypoint recursively finds entrypoints in child directories", async () => {
   const { tmpDir } = await getCliTestFixture()
-  
+
   // Create a nested directory structure with an entrypoint
-  await fs.mkdir(path.join(tmpDir, "components", "circuit1"), { recursive: true })
+  await fs.mkdir(path.join(tmpDir, "components", "circuit1"), {
+    recursive: true,
+  })
   await fs.writeFile(
     path.join(tmpDir, "components", "circuit1", "index.circuit.tsx"),
-    'export default () => <board width="10mm" height="10mm"></board>'
+    'export default () => <board width="10mm" height="10mm"></board>',
   )
-  
+
   // Test detection
   const entrypoint = await getEntrypoint({
     projectDir: tmpDir,
   })
-  
+
   expect(entrypoint).not.toBeNull()
-  expect(entrypoint).toBe(path.join(tmpDir, "components", "circuit1", "index.circuit.tsx"))
+  expect(entrypoint).toBe(
+    path.join(tmpDir, "components", "circuit1", "index.circuit.tsx"),
+  )
 })
 
 test("getEntrypoint returns null when no entrypoint is found", async () => {
   const { tmpDir } = await getCliTestFixture()
-  
+
   // Create a file that is not an entrypoint
   await fs.writeFile(
     path.join(tmpDir, "not-an-entrypoint.js"),
-    'console.log("This is not an entrypoint");'
+    'console.log("This is not an entrypoint");',
   )
-  
+
   // Test detection
   let onErrorCalled = false
   const entrypoint = await getEntrypoint({
     projectDir: tmpDir,
-    onError: () => { onErrorCalled = true },
+    onError: () => {
+      onErrorCalled = true
+    },
   })
-  
+
   expect(entrypoint).toBeNull()
   expect(onErrorCalled).toBeTrue()
 })
 
 test("getEntrypoint prioritizes provided filePath over other detection methods", async () => {
   const { tmpDir } = await getCliTestFixture()
-  
+
   // Create multiple potential entrypoints
   await fs.writeFile(
     path.join(tmpDir, "index.tsx"),
-    'export default () => <board width="10mm" height="10mm"></board>'
+    'export default () => <board width="10mm" height="10mm"></board>',
   )
   await fs.mkdir(path.join(tmpDir, "src"))
   await fs.writeFile(
     path.join(tmpDir, "src", "main.circuit.tsx"),
-    'export default () => <board width="10mm" height="10mm"></board>'
+    'export default () => <board width="10mm" height="10mm"></board>',
   )
   await fs.writeFile(
     path.join(tmpDir, "custom-entrypoint.tsx"),
-    'export default () => <board width="10mm" height="10mm"></board>'
+    'export default () => <board width="10mm" height="10mm"></board>',
   )
-  
+
   // Test detection with provided filePath
   const entrypoint = await getEntrypoint({
     projectDir: tmpDir,
     filePath: "custom-entrypoint.tsx",
   })
-  
+
   expect(entrypoint).not.toBeNull()
   expect(entrypoint).toBe(path.join(tmpDir, "custom-entrypoint.tsx"))
+})
+
+// Security and validation tests
+test("getEntrypoint rejects path traversal attempts", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create a file outside the project directory
+  const parentDir = path.dirname(tmpDir)
+  await fs.writeFile(
+    path.join(parentDir, "malicious.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  let onErrorCalled = false
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    filePath: "../malicious.tsx",
+    onError: () => {
+      onErrorCalled = true
+    },
+  })
+
+  expect(entrypoint).toBeNull()
+  expect(onErrorCalled).toBeTrue()
+
+  // Cleanup
+  await fs.unlink(path.join(parentDir, "malicious.tsx"))
+})
+
+test("getEntrypoint handles non-existent project directory", async () => {
+  const nonExistentDir = path.join(
+    process.cwd(),
+    "non-existent-dir-" + Date.now(),
+  )
+
+  let onErrorCalled = false
+  const entrypoint = await getEntrypoint({
+    projectDir: nonExistentDir,
+    onError: () => {
+      onErrorCalled = true
+    },
+  })
+
+  expect(entrypoint).toBeNull()
+  expect(onErrorCalled).toBeTrue()
+})
+
+test("getEntrypoint ignores hidden directories", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create entrypoint in hidden directory
+  await fs.mkdir(path.join(tmpDir, ".hidden"))
+  await fs.writeFile(
+    path.join(tmpDir, ".hidden", "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  // Create valid entrypoint in visible directory
+  await fs.mkdir(path.join(tmpDir, "components"))
+  await fs.writeFile(
+    path.join(tmpDir, "components", "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "components", "index.tsx"))
+})
+
+test("getEntrypoint ignores node_modules directory", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create entrypoint in node_modules
+  await fs.mkdir(path.join(tmpDir, "node_modules", "some-package"), {
+    recursive: true,
+  })
+  await fs.writeFile(
+    path.join(tmpDir, "node_modules", "some-package", "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  // Create valid entrypoint in src
+  await fs.mkdir(path.join(tmpDir, "src"))
+  await fs.writeFile(
+    path.join(tmpDir, "src", "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "src", "index.tsx"))
+})
+
+test("getEntrypoint respects maximum search depth", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create deeply nested entrypoint (depth > 3)
+  const deepPath = path.join(tmpDir, "level1", "level2", "level3", "level4")
+  await fs.mkdir(deepPath, { recursive: true })
+  await fs.writeFile(
+    path.join(deepPath, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  // Create entrypoint at acceptable depth (depth = 2)
+  const shallowPath = path.join(tmpDir, "components", "circuit")
+  await fs.mkdir(shallowPath, { recursive: true })
+  await fs.writeFile(
+    path.join(shallowPath, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(shallowPath, "index.tsx"))
+})
+
+test("getEntrypoint handles invalid config mainEntrypoint", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create config with invalid mainEntrypoint
+  await fs.writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ mainEntrypoint: 123 }), // Invalid type
+  )
+
+  // Create fallback entrypoint
+  await fs.writeFile(
+    path.join(tmpDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "index.tsx"))
+})
+
+test("getEntrypoint handles config with non-existent mainEntrypoint", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create config with non-existent mainEntrypoint
+  await fs.writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ mainEntrypoint: "non-existent.tsx" }),
+  )
+
+  // Create fallback entrypoint
+  await fs.writeFile(
+    path.join(tmpDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "index.tsx"))
+})
+
+test("getEntrypoint detects all allowed entrypoint file types", async () => {
+  const allowedTypes = [
+    "index.tsx",
+    "index.ts",
+    "index.circuit.tsx",
+    "main.tsx",
+    "main.circuit.tsx",
+  ]
+
+  for (const fileName of allowedTypes) {
+    const { tmpDir } = await getCliTestFixture()
+
+    await fs.writeFile(
+      path.join(tmpDir, fileName),
+      'export default () => <board width="10mm" height="10mm"></board>',
+    )
+
+    const entrypoint = await getEntrypoint({
+      projectDir: tmpDir,
+    })
+
+    expect(entrypoint).not.toBeNull()
+    expect(entrypoint).toBe(path.join(tmpDir, fileName))
+  }
+})
+
+test("getEntrypoint prioritizes common locations over recursive search", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create entrypoint in common location (src/)
+  await fs.mkdir(path.join(tmpDir, "src"))
+  await fs.writeFile(
+    path.join(tmpDir, "src", "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  // Create entrypoint in nested location
+  await fs.mkdir(path.join(tmpDir, "components", "nested"), { recursive: true })
+  await fs.writeFile(
+    path.join(tmpDir, "components", "nested", "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "src", "index.tsx"))
+})
+
+test("getEntrypoint handles directory access errors gracefully", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create a valid entrypoint
+  await fs.writeFile(
+    path.join(tmpDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  // The function should still work even if some directories can't be accessed
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "index.tsx"))
+})
+
+test("getEntrypoint validates file paths within project directory", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Try to access file outside project with absolute path
+  const outsidePath = path.join(path.dirname(tmpDir), "outside.tsx")
+  await fs.writeFile(outsidePath, "export default () => <board></board>")
+
+  let onErrorCalled = false
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    filePath: outsidePath,
+    onError: () => {
+      onErrorCalled = true
+    },
+  })
+
+  expect(entrypoint).toBeNull()
+  expect(onErrorCalled).toBeTrue()
+
+  // Cleanup
+  await fs.unlink(outsidePath)
+})
+
+test("getEntrypoint handles empty project directory", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Don't create any files
+  let onErrorCalled = false
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    onError: () => {
+      onErrorCalled = true
+    },
+  })
+
+  expect(entrypoint).toBeNull()
+  expect(onErrorCalled).toBeTrue()
+})
+
+test("getEntrypoint uses custom callback functions", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  await fs.writeFile(
+    path.join(tmpDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  let successMessage = ""
+  let errorMessage = ""
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    onSuccess: (msg) => {
+      successMessage = msg
+    },
+    onError: (msg) => {
+      errorMessage = msg
+    },
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(successMessage).toContain("Detected entrypoint")
+  expect(errorMessage).toBe("")
 })


### PR DESCRIPTION
<img width="1850" height="988" alt="image" src="https://github.com/user-attachments/assets/e67214c4-b562-4365-b3c3-4b3822e275f4" />

- Add recursive search for entrypoints in child directories with depth limit
- Improve validation for project directory and file paths
- Add constants for allowed entrypoint names and search limits
- Better error handling and validation messages
- Remove unused saveProjectConfig import
- Support listing all files in root dir where cmd ran