### PR TITLE
Externalize the majority of dependencies, including typescript and deps provided by "tscircuit"

### DIFF
--- a/.github/workflows/smoke-init-test.yml
+++ b/.github/workflows/smoke-init-test.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Install tscircuit globally from packed file
         run: |
           PACKAGE_FILE=$(ls *.tgz)
+          npm install -g tscircuit
           npm install -g "$PACKAGE_FILE"
 
       - name: Test tsci init in temporary directory

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     }
   },
   "bin": {
-    "tsci": "./cli/entrypoint.js"
+    "tscircuit-cli": "./cli/entrypoint.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "dev": "bun --hot ./cli/main.ts dev ./example-dir/index.circuit.tsx",
     "setup": "bun run build && npm install -g .",
     "build": "bun run build:bun",
-    "build:bun": "bun build ./cli/main.ts --target node --outfile ./dist/main.js --external looks-same",
+    "build:bun": "bun run scripts/bun-build.ts",
     "smoketest": "docker build -f Dockerfile.smoketest .",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/scripts/bun-build.ts
+++ b/scripts/bun-build.ts
@@ -8,6 +8,7 @@ const result = await Bun.build({
     "@tscircuit/*",
     "looks-same",
     "tscircuit",
+    "typescript",
     "circuit-to-svg",
     "@types/*",
   ],

--- a/scripts/bun-build.ts
+++ b/scripts/bun-build.ts
@@ -12,6 +12,7 @@ const result = await Bun.build({
   outdir: "./dist",
   external: [
     ...tscircuitPackageJsonDeps.filter((dep) => !ALLOW_BUNDLING.includes(dep)),
+    "zod",
     "looks-same",
     "tscircuit",
     "typescript",

--- a/scripts/bun-build.ts
+++ b/scripts/bun-build.ts
@@ -1,11 +1,17 @@
 import { extname, basename } from "node:path"
+// @ts-ignore
+import tscircuitPackageJson from "tscircuit/package.json"
+
+const tscircuitPackageJsonDeps = Object.keys(tscircuitPackageJson.dependencies)
+
+const ALLOW_BUNDLING = ["@tscircuit/runframe"]
 
 const result = await Bun.build({
   entrypoints: ["./cli/main.ts"],
   target: "node",
   outdir: "./dist",
   external: [
-    "@tscircuit/*",
+    ...tscircuitPackageJsonDeps.filter((dep) => !ALLOW_BUNDLING.includes(dep)),
     "looks-same",
     "tscircuit",
     "typescript",

--- a/scripts/bun-build.ts
+++ b/scripts/bun-build.ts
@@ -1,0 +1,23 @@
+import { extname, basename } from "node:path"
+
+const result = await Bun.build({
+  entrypoints: ["./cli/main.ts"],
+  target: "node",
+  outdir: "./dist",
+  external: ["@tscircuit/*", "looks-same", "tscircuit", "circuit-to-svg"],
+})
+
+const { outputs, success } = result
+
+if (!success) {
+  console.error("Build failed", result.logs)
+  process.exit(1)
+}
+
+for (const output of outputs) {
+  console.log(
+    `${basename(output.path)} ${(output.size / 1024 / 1024).toFixed(2)} MB`,
+  )
+}
+
+export {}

--- a/scripts/bun-build.ts
+++ b/scripts/bun-build.ts
@@ -4,7 +4,13 @@ const result = await Bun.build({
   entrypoints: ["./cli/main.ts"],
   target: "node",
   outdir: "./dist",
-  external: ["@tscircuit/*", "looks-same", "tscircuit", "circuit-to-svg"],
+  external: [
+    "@tscircuit/*",
+    "looks-same",
+    "tscircuit",
+    "circuit-to-svg",
+    "@types/*",
+  ],
 })
 
 const { outputs, success } = result


### PR DESCRIPTION
- **add explicit script for bun build to reduce bundling issue**
- **wip**
- **don't bundle typescript**
