### PR TITLE
Add jlcsearch to search command, remove interactive part of `search` (should be moved to `tsci import`)

### DIFF
--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -1,9 +1,6 @@
 import type { Command } from "commander"
 import { getRegistryApiKy } from "lib/registry-api/get-ky"
 import kleur from "kleur"
-import { prompts } from "lib/utils/prompts"
-import { shouldBeInteractive } from "lib/utils/should-be-interactive"
-import { addPackage } from "lib/shared/add-package"
 
 export const registerSearch = (program: Command) => {
   program
@@ -89,46 +86,6 @@ export const registerSearch = (program: Command) => {
           )
         })
       }
-
-      if (shouldBeInteractive() && results.packages.length) {
-        const choices = results.packages.map((pkg, idx) => ({
-          title: `${pkg.name} (v${pkg.version})`,
-          description: pkg.description || "",
-          value: pkg.name,
-          ...(idx === 0 ? { selected: true } : {}),
-        }))
-
-        const { selectedPackage } = await prompts({
-          type: "select",
-          name: "selectedPackage",
-          message: "Select a package to add:",
-          choices,
-        })
-
-        if (selectedPackage) {
-          const { confirm } = await prompts({
-            type: "confirm",
-            name: "confirm",
-            message: `Do you want to add ${kleur.green(selectedPackage)}?`,
-            initial: true,
-          })
-
-          if (confirm) {
-            try {
-              console.log(kleur.blue(`Installing ${selectedPackage}...`))
-              await addPackage(selectedPackage)
-              console.log(
-                kleur.green(`Successfully installed ${selectedPackage}`),
-              )
-            } catch (error) {
-              console.error(
-                kleur.red(`Failed to install ${selectedPackage}:`),
-                error,
-              )
-              process.exit(1)
-            }
-          }
-        }
-      }
+      console.log("\n")
     })
 }

--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -1,7 +1,8 @@
 import type { Command } from "commander"
 import { getRegistryApiKy } from "lib/registry-api/get-ky"
 import kleur from "kleur"
-import prompts from "prompts"
+import { prompts } from "lib/utils/prompts"
+import { shouldBeInteractive } from "lib/utils/should-be-interactive"
 import { addPackage } from "lib/shared/add-package"
 
 export const registerSearch = (program: Command) => {
@@ -12,8 +13,21 @@ export const registerSearch = (program: Command) => {
     .action(async (query: string) => {
       const ky = getRegistryApiKy()
       let results: {
-        packages: Array<{ name: string; version: string; description?: string }>
+        packages: Array<{
+          name: string
+          version: string
+          description?: string
+          star_count?: number
+        }>
       } = { packages: [] }
+
+      let jlcResults: Array<{
+        lcsc: number
+        mfr: string
+        package: string
+        description: string
+        price: number
+      }> = []
 
       try {
         results = await ky
@@ -21,6 +35,12 @@ export const registerSearch = (program: Command) => {
             json: { query },
           })
           .json()
+
+        const jlcSearchUrl =
+          "https://jlcsearch.tscircuit.com/api/search?limit=10&q=" +
+          encodeURIComponent(query)
+        jlcResults = (await fetch(jlcSearchUrl).then((r) => r.json()))
+          .components
       } catch (error) {
         console.error(
           kleur.red("Failed to search registry:"),
@@ -29,52 +49,85 @@ export const registerSearch = (program: Command) => {
         process.exit(1)
       }
 
-      if (!results.packages.length) {
-        console.log(kleur.yellow("No packages found matching your query."))
+      if (!results.packages.length && !jlcResults.length) {
+        console.log(kleur.yellow("No results found matching your query."))
         return
       }
 
-      console.log(
-        kleur.bold().underline(`Found ${results.packages.length} package(s):`),
-      )
+      if (results.packages.length) {
+        console.log(
+          kleur
+            .bold()
+            .underline(
+              `Found ${results.packages.length} package(s) in the tscircuit registry:`,
+            ),
+        )
 
-      const choices = results.packages.map((pkg) => ({
-        title: pkg.name,
-        description: pkg.description || "",
-        value: pkg.name,
-      }))
-
-      const { selectedPackage } = await prompts({
-        type: "select",
-        name: "selectedPackage",
-        message: "Select a package to add:",
-        choices,
-        initial: 0,
-      })
-
-      if (!selectedPackage) {
-        console.log(kleur.yellow("No package selected."))
-        return
-      }
-
-      const { confirm } = await prompts({
-        type: "confirm",
-        name: "confirm",
-        message: `Do you want to add ${kleur.green(selectedPackage)}?`,
-        initial: true,
-      })
-
-      if (confirm) {
-        try {
-          console.log(kleur.blue(`Installing ${selectedPackage}...`))
-          await addPackage(selectedPackage)
-          console.log(kleur.green(`Successfully installed ${selectedPackage}`))
-        } catch (error) {
-          console.error(
-            kleur.red(`Failed to install ${selectedPackage}:`),
-            error,
+        results.packages.forEach((pkg, idx) => {
+          const star = pkg.star_count ?? 0
+          console.log(
+            `${idx + 1}. ${pkg.name} (v${pkg.version}) - Stars: ${star}${
+              pkg.description ? ` - ${pkg.description}` : ""
+            }`,
           )
-          process.exit(1)
+        })
+      }
+
+      if (jlcResults.length) {
+        console.log()
+        console.log(
+          kleur
+            .bold()
+            .underline(
+              `Found ${jlcResults.length} component(s) in JLC search:`,
+            ),
+        )
+
+        jlcResults.forEach((comp, idx) => {
+          console.log(
+            `${idx + 1}. ${comp.mfr} (C${comp.lcsc}) - ${comp.description}`,
+          )
+        })
+      }
+
+      if (shouldBeInteractive() && results.packages.length) {
+        const choices = results.packages.map((pkg, idx) => ({
+          title: `${pkg.name} (v${pkg.version})`,
+          description: pkg.description || "",
+          value: pkg.name,
+          ...(idx === 0 ? { selected: true } : {}),
+        }))
+
+        const { selectedPackage } = await prompts({
+          type: "select",
+          name: "selectedPackage",
+          message: "Select a package to add:",
+          choices,
+        })
+
+        if (selectedPackage) {
+          const { confirm } = await prompts({
+            type: "confirm",
+            name: "confirm",
+            message: `Do you want to add ${kleur.green(selectedPackage)}?`,
+            initial: true,
+          })
+
+          if (confirm) {
+            try {
+              console.log(kleur.blue(`Installing ${selectedPackage}...`))
+              await addPackage(selectedPackage)
+              console.log(
+                kleur.green(`Successfully installed ${selectedPackage}`),
+              )
+            } catch (error) {
+              console.error(
+                kleur.red(`Failed to install ${selectedPackage}:`),
+                error,
+              )
+              process.exit(1)
+            }
+          }
         }
       }
     })

--- a/tests/cli/search/search.test.ts
+++ b/tests/cli/search/search.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("search command returns registry and jlc results", async () => {
+  const { runCommand } = await getCliTestFixture()
+  const { stdout, stderr } = await runCommand("tsci search 555")
+  // Should not output prompts in test mode
+  expect(stderr).toBe("")
+  expect(stdout).toContain("tscircuit registry")
+  expect(stdout).toContain("JLC search")
+  expect(stdout.toLowerCase()).toContain("stars")
+})


### PR DESCRIPTION
## Summary
- extend `tsci search` command to also query JLC search API
- show star count for registry results
- add non-interactive search test

## Testing
- `bun test tests/cli/search/search.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_688251f40468832e9ebcbe06fe01c487