### PR TITLE
Add directory support to tsci snapshot

### DIFF
--- a/cli/snapshot/register.ts
+++ b/cli/snapshot/register.ts
@@ -4,7 +4,10 @@ import { snapshotProject } from "lib/shared/snapshot-project"
 export const registerSnapshot = (program: Command) => {
   program
     .command("snapshot")
-    .argument("[file]", "Path to the board or circuit file")
+    .argument(
+      "[path]",
+      "Path to the board, circuit file, or directory containing them",
+    )
     .description(
       "Generate schematic and PCB snapshots (add --3d for 3d preview)",
     )
@@ -15,7 +18,7 @@ export const registerSnapshot = (program: Command) => {
     .option("--schematic-only", "Generate only schematic snapshots")
     .action(
       async (
-        file: string | undefined,
+        target: string | undefined,
         options: {
           update?: boolean
           "3d"?: boolean
@@ -30,7 +33,7 @@ export const registerSnapshot = (program: Command) => {
           pcbOnly: options.pcbOnly ?? false,
           schematicOnly: options.schematicOnly ?? false,
           forceUpdate: options.forceUpdate ?? false,
-          filePaths: file ? [file] : [],
+          filePaths: target ? [target] : [],
           onExit: (code) => process.exit(code),
           onError: (msg) => console.error(msg),
           onSuccess: (msg) => console.log(msg),

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -53,9 +53,19 @@ export const snapshotProject = async ({
     ...ignored.map(normalizeIgnorePattern),
   ]
 
+  const resolvedPaths = filePaths.map((f) => path.resolve(projectDir, f))
+
   const boardFiles =
-    filePaths.length > 0
-      ? filePaths.map((f) => path.resolve(projectDir, f))
+    resolvedPaths.length > 0
+      ? resolvedPaths.flatMap((p) => {
+          if (fs.existsSync(p) && fs.statSync(p).isDirectory()) {
+            return globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
+              cwd: p,
+              ignore,
+            }).map((f) => path.join(p, f))
+          }
+          return [p]
+        })
       : globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
           cwd: projectDir,
           ignore,

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -218,6 +218,52 @@ test("snapshot command with file path", async () => {
   expect(rootSnapExists).toBe(false)
 })
 
+test("snapshot command with directory path", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  const subdir = join(tmpDir, "dir")
+  fs.mkdirSync(subdir)
+
+  await Bun.write(
+    join(subdir, "one.board.tsx"),
+    `
+    export const One = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  await Bun.write(
+    join(subdir, "two.circuit.tsx"),
+    `
+    export const Two = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  const { stdout } = await runCommand("tsci snapshot dir --update")
+  expect(stdout).toContain("Created snapshots")
+
+  const snapDir = join(subdir, "__snapshots__")
+  const onePcb = await Bun.file(
+    join(snapDir, "one.board-pcb.snap.svg"),
+  ).exists()
+  const twoPcb = await Bun.file(
+    join(snapDir, "two.circuit-pcb.snap.svg"),
+  ).exists()
+
+  expect(onePcb).toBe(true)
+  expect(twoPcb).toBe(true)
+
+  const rootExists = await Bun.file(join(tmpDir, "__snapshots__")).exists()
+  expect(rootExists).toBe(false)
+})
+
 test("snapshot command skips updates when snapshots match visually", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 


### PR DESCRIPTION
## Summary
- enable `tsci snapshot` to accept a directory
- handle directories in `snapshotProject`
- test directory snapshot behaviour

## Testing
- `bun test tests/cli/snapshot/snapshot.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/cli/snapshot/snapshot.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_688d6653744c832ebdc88b737c1d4e7b