### PR TITLE
Add tsci dev scripts to cloned packages

### DIFF
--- a/lib/shared/setup-tsci-packages.ts
+++ b/lib/shared/setup-tsci-packages.ts
@@ -31,6 +31,15 @@ export async function setupTsciProject(
   const packageJsonPath = path.join(projectPath, "package.json")
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
 
+  // Ensure required scripts exist
+  packageJson.scripts = {
+    ...(packageJson.scripts || {}),
+    dev: "tsci dev",
+    start: "tsci dev",
+  }
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+
   if (devDependencies.length > 0) {
     console.log("Installing dependencies...")
     try {

--- a/tests/cli/clone/clone.test.ts
+++ b/tests/cli/clone/clone.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import { join } from "node:path"
-import { readdirSync, existsSync } from "node:fs"
+import { readdirSync, existsSync, readFileSync } from "node:fs"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
 test("clone command fetches and creates package files correctly", async () => {
@@ -21,6 +21,12 @@ test("clone command fetches and creates package files correctly", async () => {
     "tsconfig.json",
     "circuit.json",
   ])
+
+  const packageJson = JSON.parse(
+    readFileSync(join(projectDir, "package.json"), "utf-8"),
+  )
+  expect(packageJson.scripts.dev).toBe("tsci dev")
+  expect(packageJson.scripts.start).toBe("tsci dev")
 }, 10_000)
 
 test("clone command handles invalid package path", async () => {
@@ -52,7 +58,7 @@ test("clone command rejects invalid URL formats", async () => {
     const { stderr } = await runCommand(`tsci clone ${url}`)
     expect(stderr).toContain("Invalid package path")
   }
-})
+}, 20_000)
 
 test("clone command accepts all valid formats", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()


### PR DESCRIPTION
## Summary
- ensure setupTsciProject adds `dev` and `start` scripts that run `tsci dev`
- verify cloned packages include required scripts and extend invalid URL format test timeout

## Testing
- `bun test tests/cli/clone/clone.test.ts`
- `bun test` *(fails: export readable-netlist snapshot mismatch and snapshot metadata tests)*

------
https://chatgpt.com/codex/tasks/task_b_68ac5449092c832799f45d901c6328d1