### PR TITLE
fix: allow dev command to start without entrypoint by creating defaul…

### DIFF
--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -79,7 +79,7 @@ export class DevServer {
       port: this.port,
       defaultMainComponentPath: this.componentFilePath
         ? path.relative(this.projectDir, this.componentFilePath)
-        : null,
+        : undefined,
     })
     this.httpServer = server
 

--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -23,7 +23,7 @@ export class DevServer {
   port: number
   /**
    * The path to a component that exports a <board /> or <group /> component
-   * Can be null when running in sandbox mode without a specific file
+   * Can be null when running without a specific file
    */
   componentFilePath: string | null
 
@@ -253,7 +253,7 @@ export class DevServer {
   async upsertInitialFiles() {
     const filePaths = getPackageFilePaths(this.projectDir, this.ignoredFiles)
 
-    // In true sandbox mode, don't create any entrypoint files
+    // When no entrypoint is specified, don't create any entrypoint files
     // Let runframe handle the empty state
 
     for (const filePath of filePaths) {

--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -278,19 +278,25 @@ export class DevServer {
         throwHttpErrors: false,
       })
 
-    if (this.componentFilePath) {
-      await pushSnippet({
-        filePath: this.componentFilePath,
-        onExit: () => {},
-        onError: (e) => {
-          console.error("Failed to save snippet:- ", e)
-          postEvent("FAILED_TO_SAVE_SNIPPET", e)
-        },
-        onSuccess: () => {
-          postEvent("SNIPPET_SAVED")
-        },
-      })
+    if (!this.componentFilePath) {
+      const errorMessage =
+        "Cannot save snippet: No component file path specified"
+      console.error(errorMessage)
+      await postEvent("FAILED_TO_SAVE_SNIPPET", errorMessage)
+      throw new Error(errorMessage)
     }
+
+    await pushSnippet({
+      filePath: this.componentFilePath,
+      onExit: () => {},
+      onError: (e) => {
+        console.error("Failed to save snippet:- ", e)
+        postEvent("FAILED_TO_SAVE_SNIPPET", e)
+      },
+      onSuccess: () => {
+        postEvent("SNIPPET_SAVED")
+      },
+    })
   }
   async stop() {
     this.httpServer?.close()

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -54,7 +54,7 @@ export const registerDev = (program: Command) => {
         } else {
           console.log(
             kleur.yellow(
-              "No entrypoint found. Starting development server in sandbox mode.",
+              "No entrypoint found. Starting development server.",
             ),
           )
           console.log(
@@ -62,7 +62,7 @@ export const registerDev = (program: Command) => {
               "Tip: You can run 'tsci init' to set up a complete project structure or specify a file with 'tsci dev <file>'.",
             ),
           )
-          // No file - pure sandbox mode
+          // No file - no entrypoint specified
           absolutePath = null
         }
       }

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -73,7 +73,7 @@ export default () => (
               "Tip: You can run 'tsci init' to set up a complete project structure.",
             ),
           )
-          
+
           fs.writeFileSync(defaultEntrypoint, defaultContent)
           absolutePath = defaultEntrypoint
           console.log(

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -52,10 +52,35 @@ export const registerDev = (program: Command) => {
           absolutePath = entrypointPath
           console.log("Found entrypoint at:", entrypointPath)
         } else {
+          // Create a default index.tsx file if no entrypoint is found
+          const defaultEntrypoint = path.join(process.cwd(), "index.tsx")
+          const defaultContent = `
+export default () => (
+  <board>
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+    <capacitor capacitance="1000pF" footprint="0402" name="C1" schX={-3} pcbX={-3} />
+    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+  </board>
+)
+`
           console.log(
-            "No entrypoint found. Run 'tsci init' to bootstrap a basic project.",
+            kleur.yellow(
+              "No entrypoint found. Creating a default index.tsx file to get you started.",
+            ),
           )
-          return
+          console.log(
+            kleur.gray(
+              "Tip: You can run 'tsci init' to set up a complete project structure.",
+            ),
+          )
+          
+          fs.writeFileSync(defaultEntrypoint, defaultContent)
+          absolutePath = defaultEntrypoint
+          console.log(
+            kleur.green("✓"),
+            "Created default entrypoint at:",
+            defaultEntrypoint,
+          )
         }
       }
 

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -53,9 +53,7 @@ export const registerDev = (program: Command) => {
           console.log("Found entrypoint at:", entrypointPath)
         } else {
           console.log(
-            kleur.yellow(
-              "No entrypoint found. Starting development server.",
-            ),
+            kleur.yellow("No entrypoint found. Starting development server."),
           )
           console.log(
             kleur.gray(

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -36,7 +36,7 @@ export const registerDev = (program: Command) => {
         port += 1
       }
 
-      let absolutePath: string
+      let absolutePath: string | null
 
       if (file) {
         absolutePath = path.resolve(file)
@@ -52,46 +52,31 @@ export const registerDev = (program: Command) => {
           absolutePath = entrypointPath
           console.log("Found entrypoint at:", entrypointPath)
         } else {
-          // Create a default index.tsx file if no entrypoint is found
-          const defaultEntrypoint = path.join(process.cwd(), "index.tsx")
-          const defaultContent = `
-export default () => (
-  <board>
-    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
-    <capacitor capacitance="1000pF" footprint="0402" name="C1" schX={-3} pcbX={-3} />
-    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
-  </board>
-)
-`
           console.log(
             kleur.yellow(
-              "No entrypoint found. Creating a default index.tsx file to get you started.",
+              "No entrypoint found. Starting development server in sandbox mode.",
             ),
           )
           console.log(
             kleur.gray(
-              "Tip: You can run 'tsci init' to set up a complete project structure.",
+              "Tip: You can run 'tsci init' to set up a complete project structure or specify a file with 'tsci dev <file>'.",
             ),
           )
-
-          fs.writeFileSync(defaultEntrypoint, defaultContent)
-          absolutePath = defaultEntrypoint
-          console.log(
-            kleur.green("✓"),
-            "Created default entrypoint at:",
-            defaultEntrypoint,
-          )
+          // No file - pure sandbox mode
+          absolutePath = null
         }
       }
 
-      try {
-        process.stdout.write(
-          kleur.gray("Installing types for imported packages..."),
-        )
-        await installNodeModuleTypesForSnippet(absolutePath)
-        console.log(kleur.green(" done"))
-      } catch (error) {
-        console.warn("Failed to install types:", error)
+      if (absolutePath && fs.existsSync(absolutePath)) {
+        try {
+          process.stdout.write(
+            kleur.gray("Installing types for imported packages..."),
+          )
+          await installNodeModuleTypesForSnippet(absolutePath)
+          console.log(kleur.green(" done"))
+        } catch (error) {
+          console.warn("Failed to install types:", error)
+        }
       }
 
       const server = new DevServer({


### PR DESCRIPTION
This pull request introduces an improvement to the developer experience in the CLI registration flow. Now, if no entrypoint file is found, the CLI will automatically create a default `index.tsx` file with a simple board example, instead of just prompting the user to initialize the project manually.

Enhancements to entrypoint handling:

* If no entrypoint is detected, a default `index.tsx` file is created in the current working directory with a basic board component example, making it easier for users to get started.
* User messaging has been improved: the CLI now informs the user that a default entrypoint has been created and provides a tip about using `tsci init` for a full project setup



https://github.com/user-attachments/assets/d9c1dc46-edbf-4f49-8397-7d6143f68026



/claim #325
Fixes #325