### PR TITLE
Prefix KiCad footprints in search output

### DIFF
--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -79,7 +79,9 @@ export const registerSearch = (program: Command) => {
 
         kicadResults.forEach((path, idx) => {
           console.log(
-            `${(idx + 1).toString().padStart(2, " ")}. ${path.replace(".kicad_mod", "").replace(".pretty", "")}`,
+            `${(idx + 1).toString().padStart(2, " ")}. kicad:${path
+              .replace(".kicad_mod", "")
+              .replace(".pretty", "")}`,
           )
         })
       }

--- a/tests/cli/search/search-kicad.test.ts
+++ b/tests/cli/search/search-kicad.test.ts
@@ -6,5 +6,5 @@ test("search command returns kicad footprint results", async () => {
   const { stdout, stderr } = await runCommand("tsci search R_0805")
   expect(stderr).toBe("")
   expect(stdout).toContain("KiCad")
-  expect(stdout).toMatch(/R_0805/)
+  expect(stdout).toMatch(/kicad:.*R_0805/)
 })


### PR DESCRIPTION
## Summary
- prefix KiCad footprint search results with `kicad:` for easier copy/paste into tscircuit
- update CLI test to expect `kicad:` prefix

## Testing
- `bunx tsc --noEmit`
- `bun test tests/cli/search`


------
https://chatgpt.com/codex/tasks/task_b_68c33e0da450832ea661d272438a8374