### PR TITLE
feat: add KiCad-only search option

### DIFF
--- a/tests/cli/search/search-kicad-only.test.ts
+++ b/tests/cli/search/search-kicad-only.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("search --kicad only returns kicad footprint results", async () => {
+  const { runCommand } = await getCliTestFixture()
+  const { stdout, stderr } = await runCommand("tsci search --kicad R_0805")
+  expect(stderr).toBe("")
+  expect(stdout).toContain("KiCad")
+  expect(stdout).toMatch(/R_0805/)
+  expect(stdout).not.toContain("tscircuit registry")
+  expect(stdout).not.toContain("JLC search")
+})


### PR DESCRIPTION
## Summary
- add `--kicad` option to `tsci search` to only query KiCad footprints
- test searching with `--kicad`

## Testing
- `bunx tsc --noEmit`
- `bun test tests/cli/search`


------
https://chatgpt.com/codex/tasks/task_b_68c362fed6e4832eaa7cf21a35c69dc7