### PR TITLE
fix: guard missing jlc search results

### DIFF
--- a/cli/import/register.ts
+++ b/cli/import/register.ts
@@ -46,7 +46,7 @@ export const registerImport = (program: Command) => {
           "https://jlcsearch.tscircuit.com/api/search?limit=10&q=" +
           encodeURIComponent(query)
         const resp = await fetch(searchUrl).then((r) => r.json())
-        jlcResults = resp.components
+        jlcResults = (resp as any)?.components ?? []
       } catch (error) {
         console.error(
           kleur.red("Failed to search JLCPCB:"),

--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -42,8 +42,9 @@ export const registerSearch = (program: Command) => {
         const jlcSearchUrl =
           "https://jlcsearch.tscircuit.com/api/search?limit=10&q=" +
           encodeURIComponent(query)
-        jlcResults = (await fetch(jlcSearchUrl).then((r) => r.json()))
-          .components
+        jlcResults =
+          ((await fetch(jlcSearchUrl).then((r) => r.json())) as any)
+            ?.components ?? []
 
         const kicadFiles: string[] = await fetch(
           "https://kicad-mod-cache.tscircuit.com/kicad_files.json",


### PR DESCRIPTION
## Summary
- prevent TypeError in `tsci search` when JLC search returns no `components`
- guard `import` command against missing JLC `components` results

## Testing
- `bunx tsc --noEmit`
- `bun test tests/cli/search`
- `bun test tests/cli/import`


------
https://chatgpt.com/codex/tasks/task_b_68c364c3fcd8832ea7ace50c5021be8c