### PR TITLE
fix: handle missing jlc search results

### DIFF
--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -46,8 +46,8 @@ export const registerSearch = (program: Command) => {
           const jlcSearchUrl =
             "https://jlcsearch.tscircuit.com/api/search?limit=10&q=" +
             encodeURIComponent(query)
-          jlcResults = (await fetch(jlcSearchUrl).then((r) => r.json()))
-            .components
+          const jlcResponse = await fetch(jlcSearchUrl).then((r) => r.json())
+          jlcResults = jlcResponse?.components ?? []
         }
 
         const kicadFiles: string[] = await fetch(


### PR DESCRIPTION
## Summary
- prevent search command crash when JLC search returns no `components`

## Testing
- `bunx tsc --noEmit`
- `bun test tests/cli/search`


------
https://chatgpt.com/codex/tasks/task_b_68c3676ec01c832e85f32122513a68a2