### PR TITLE
chore: update runframe

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@tscircuit/file-server": "^0.0.26",
         "@tscircuit/math-utils": "0.0.21",
         "@tscircuit/props": "^0.0.315",
-        "@tscircuit/runframe": "^0.0.924",
+        "@tscircuit/runframe": "^0.0.931",
         "@tscircuit/schematic-match-adapt": "^0.0.22",
         "@tscircuit/simple-3d-svg": "^0.0.38",
         "@types/bun": "^1.2.2",
@@ -522,7 +522,7 @@
 
     "@tscircuit/props": ["@tscircuit/props@0.0.315", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-g2zShSWWUiMYN+jMbFpOm0wmkEi+L7N8TScGOKOW0l4nwrT6tPTZ4S96i+jx5dxkscuYeSTHZIUJQYi4hEhp3g=="],
 
-    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.924", "", {}, "sha512-H0nhNdmqijpydmIFKOWE/n8JO7PfRZSrS0G+hFLrHG/s4aiLUYZshmPuGt/G3WhUJgGnq+jTYK5MkTXoyAAUHA=="],
+    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.931", "", {}, "sha512-K/mcu65ZOukJj1RYjcGPFTMqJ42B4PlLZkAf/5JBKHRbvuj+GE5DPVgMLm7CLNhNrsHFJG0X4cCDRfY3qGrH8A=="],
 
     "@tscircuit/schematic-autolayout": ["@tscircuit/schematic-autolayout@0.0.6", "", { "dependencies": { "@tscircuit/soup-util": "^0.0.38", "transformation-matrix": "^2.16.1" } }, "sha512-34cQxtlSylBKyHkzaMBCynaWJgN9c/mWm7cz63StTYIafKmfFs383K8Xoc4QX8HXCvVrHYl1aK15onZua9MxeA=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@tscircuit/file-server": "^0.0.26",
     "@tscircuit/math-utils": "0.0.21",
     "@tscircuit/props": "^0.0.315",
-    "@tscircuit/runframe": "^0.0.924",
+    "@tscircuit/runframe": "^0.0.931",
     "@tscircuit/schematic-match-adapt": "^0.0.22",
     "@tscircuit/simple-3d-svg": "^0.0.38",
     "@types/bun": "^1.2.2",


### PR DESCRIPTION
## Summary
- update @tscircuit/runframe to latest version

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests` (fails: print and set token explicitly timeout, snapshot does not update on metadata-only changes)
- `bunx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c5baaa0440832ebc660218cd9557b4