### PR TITLE
Support binary asset uploads

### DIFF
--- a/docs/file-server-api-usage.md
+++ b/docs/file-server-api-usage.md
@@ -9,11 +9,30 @@ changes.
 
 ```
 POST /files/upsert
-REQUEST: { file_id?, text_content, file_path }
-RESPONSE: { file: { file_id, file_path, text_content } }
+REQUEST: {
+  file_id?,
+  file_path,
+  text_content?,
+  binary_content_b64?
+}
+RESPONSE: {
+  file: {
+    file_id,
+    file_path,
+    text_content?,
+    binary_content_b64?
+  }
+}
 
 GET /files/get?file_id?&file_path?
-RESPONSE: { file: { file_id, file_path, text_content } }
+RESPONSE: {
+  file: {
+    file_id,
+    file_path,
+    text_content?,
+    binary_content_b64?
+  }
+}
 
 GET /files/list
 RESPONSE { file_list: Array<{ file_id, file_path } }

--- a/lib/file-server/FileServerRoutes.ts
+++ b/lib/file-server/FileServerRoutes.ts
@@ -10,7 +10,8 @@ export interface FileServerRoutes extends EventsRoutes {
         file: {
           file_id: string
           file_path: string
-          text_content: string
+          text_content?: string
+          binary_content_b64?: string
         }
       }
     }
@@ -19,7 +20,8 @@ export interface FileServerRoutes extends EventsRoutes {
     POST: {
       requestJson: {
         file_path: string
-        text_content: string
+        text_content?: string
+        binary_content_b64?: string
         initiator?: "filesystem_change"
       }
       responseJson: {
@@ -57,7 +59,8 @@ export interface FileServerRoutes extends EventsRoutes {
         file: {
           file_id: string
           file_path: string
-          text_content: string
+          text_content?: string
+          binary_content_b64?: string
           created_at: string
         } | null
       }

--- a/tests/test7-dev-server-binary-assets.test.ts
+++ b/tests/test7-dev-server-binary-assets.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { DevServer } from "cli/dev/DevServer"
+import getPort from "get-port"
+import { join } from "node:path"
+import { getCliTestFixture } from "./fixtures/get-cli-test-fixture"
+
+const BASIC_COMPONENT = `
+  export const MyCircuit = () => (
+    <board width="10mm" height="10mm">
+      <chip name="U1" footprint="soic8" />
+    </board>
+  )
+`
+
+test("binary assets are uploaded via binary_content_b64", async () => {
+  const fixture = await getCliTestFixture()
+
+  const snippetPath = join(fixture.tmpDir, "snippet.tsx")
+  const assetPath = join(fixture.tmpDir, "texture.png")
+
+  await Bun.write(snippetPath, BASIC_COMPONENT)
+
+  const binaryContent = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d])
+  await Bun.write(assetPath, binaryContent)
+
+  const devServerPort = await getPort()
+  const devServer = new DevServer({
+    port: devServerPort,
+    componentFilePath: snippetPath,
+  })
+
+  try {
+    await devServer.start()
+
+    const { file } = await devServer.fsKy
+      .get("api/files/get", {
+        searchParams: { file_path: "texture.png" },
+      })
+      .json()
+
+    const expectedBase64 = Buffer.from(binaryContent).toString("base64")
+    expect(file.binary_content_b64).toBe(expectedBase64)
+    expect(file.text_content).toBeUndefined()
+  } finally {
+    await devServer.stop()
+  }
+})


### PR DESCRIPTION
## Summary
- detect known binary asset extensions and upload them via `binary_content_b64`
- decode binary content when syncing from the file server and document API changes
- add a regression test covering binary asset propagation through the dev server

## Testing
- bunx tsc --noEmit
- bun test tests/test1-dev-server-basic.test.ts
- bun test tests/test6-file-rename.test.ts
- bun test tests/test7-dev-server-binary-assets.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68cad3d60dcc832e909520de9b737db3