### PR TITLE
refactor: extract static index html generator

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@tscircuit/file-server": "^0.0.30",
         "@tscircuit/math-utils": "0.0.21",
         "@tscircuit/props": "^0.0.315",
-        "@tscircuit/runframe": "^0.0.970",
+        "@tscircuit/runframe": "^0.0.977",
         "@tscircuit/schematic-match-adapt": "^0.0.22",
         "@tscircuit/simple-3d-svg": "^0.0.38",
         "@types/bun": "^1.2.2",
@@ -523,7 +523,7 @@
 
     "@tscircuit/props": ["@tscircuit/props@0.0.315", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-g2zShSWWUiMYN+jMbFpOm0wmkEi+L7N8TScGOKOW0l4nwrT6tPTZ4S96i+jx5dxkscuYeSTHZIUJQYi4hEhp3g=="],
 
-    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.970", "", {}, "sha512-XJFWVU9euZW3pqA1fRL6wg7+3nS+FpZqgQGAmHCx+7SHQeDKBYc7RV441e1Yc+Ic7HAAYFoXvxUSZ4EOs62ETw=="],
+    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.977", "", {}, "sha512-HFUNkt8Q93Xto6tok63Gv6YmTk/JRn4yWtnCm8G3JI58/Mj8+cM+gZKFEDG8xxdUYhZLg4jjaMsToquIVpGFRQ=="],
 
     "@tscircuit/schematic-autolayout": ["@tscircuit/schematic-autolayout@0.0.6", "", { "dependencies": { "@tscircuit/soup-util": "^0.0.38", "transformation-matrix": "^2.16.1" } }, "sha512-34cQxtlSylBKyHkzaMBCynaWJgN9c/mWm7cz63StTYIafKmfFs383K8Xoc4QX8HXCvVrHYl1aK15onZua9MxeA=="],
 

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -3,6 +3,15 @@ import path from "node:path"
 import fs from "node:fs"
 import { buildFile } from "./build-file"
 import { getBuildEntrypoints } from "./get-build-entrypoints"
+import {
+  getStaticIndexHtmlFile,
+  type StaticBuildFileReference,
+} from "lib/site/getStaticIndexHtmlFile"
+
+// @ts-ignore
+import runFrameStandaloneBundleContent from "@tscircuit/runframe/standalone" with {
+  type: "text",
+}
 
 export const registerBuild = (program: Command) => {
   program
@@ -12,6 +21,7 @@ export const registerBuild = (program: Command) => {
     .option("--ignore-errors", "Do not exit with code 1 on errors")
     .option("--ignore-warnings", "Do not log warnings")
     .option("--disable-pcb", "Disable PCB outputs")
+    .option("--site", "Generate a static site in the dist directory")
     .action(
       async (
         file?: string,
@@ -19,15 +29,18 @@ export const registerBuild = (program: Command) => {
           ignoreErrors?: boolean
           ignoreWarnings?: boolean
           disablePcb?: boolean
+          site?: boolean
         },
       ) => {
-        const { projectDir, mainEntrypoint, circuitFiles } =
-          await getBuildEntrypoints({ fileOrDir: file })
+        const { projectDir, circuitFiles } = await getBuildEntrypoints({
+          fileOrDir: file,
+        })
 
         const distDir = path.join(projectDir, "dist")
         fs.mkdirSync(distDir, { recursive: true })
 
         let hasErrors = false
+        const staticFileReferences: StaticBuildFileReference[] = []
 
         for (const filePath of circuitFiles) {
           const relative = path.relative(projectDir, filePath)
@@ -37,11 +50,35 @@ export const registerBuild = (program: Command) => {
           )
           const outputPath = path.join(distDir, outputDirName, "circuit.json")
           const ok = await buildFile(filePath, outputPath, projectDir, options)
-          if (!ok) hasErrors = true
+          if (!ok) {
+            hasErrors = true
+          } else if (options?.site) {
+            const normalizedSourcePath = relative.split(path.sep).join("/")
+            const relativeOutputPath = path.join(outputDirName, "circuit.json")
+            const normalizedOutputPath = relativeOutputPath
+              .split(path.sep)
+              .join("/")
+            staticFileReferences.push({
+              filePath: normalizedSourcePath,
+              fileStaticAssetUrl: `./${normalizedOutputPath}`,
+            })
+          }
         }
 
         if (hasErrors && !options?.ignoreErrors) {
           process.exit(1)
+        }
+
+        if (options?.site) {
+          const indexHtml = getStaticIndexHtmlFile({
+            files: staticFileReferences,
+            standaloneScriptSrc: "./standalone.min.js",
+          })
+          fs.writeFileSync(path.join(distDir, "index.html"), indexHtml)
+          fs.writeFileSync(
+            path.join(distDir, "standalone.min.js"),
+            runFrameStandaloneBundleContent,
+          )
         }
       },
     )

--- a/lib/site/getStaticIndexHtmlFile.ts
+++ b/lib/site/getStaticIndexHtmlFile.ts
@@ -1,0 +1,34 @@
+export interface StaticBuildFileReference {
+  filePath: string
+  fileStaticAssetUrl: string
+}
+
+export interface GetStaticIndexHtmlFileOptions {
+  files: StaticBuildFileReference[]
+  standaloneScriptSrc?: string
+}
+
+export const getStaticIndexHtmlFile = ({
+  files,
+  standaloneScriptSrc = "./standalone.min.js",
+}: GetStaticIndexHtmlFileOptions) => {
+  const scriptLines = [
+    "window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI = false;",
+    `window.TSCIRCUIT_RUNFRAME_STATIC_FILE_LIST = ${JSON.stringify(files)};`,
+  ]
+
+  const scriptBlock = `      <script>\n        ${scriptLines.join("\n        ")}\n      </script>\n`
+
+  return `<html>
+    <head>
+    </head>
+    <body>
+${scriptBlock}      <script src="https://cdn.tailwindcss.com"></script>
+      <div id="root">loading...</div>
+      <script>
+      globalThis.process = { env: { NODE_ENV: "production" } }
+      </script>
+      <script src="${standaloneScriptSrc}"></script>
+    </body>
+  </html>`
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@tscircuit/file-server": "^0.0.30",
     "@tscircuit/math-utils": "0.0.21",
     "@tscircuit/props": "^0.0.315",
-    "@tscircuit/runframe": "^0.0.970",
+    "@tscircuit/runframe": "^0.0.977",
     "@tscircuit/schematic-match-adapt": "^0.0.22",
     "@tscircuit/simple-3d-svg": "^0.0.38",
     "@types/bun": "^1.2.2",

--- a/tests/test4-get-index-token.test.ts
+++ b/tests/test4-get-index-token.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test"
 import { cliConfig } from "lib/cli-config"
 import { getIndex } from "lib/site/getIndex"
+import { getStaticIndexHtmlFile } from "lib/site/getStaticIndexHtmlFile"
 
 const DUMMY_TOKEN = "dummy-token"
 
@@ -21,4 +22,28 @@ test("getIndex does not inject registry token when logged out", async () => {
   if (originalToken) cliConfig.set("sessionToken", originalToken)
 
   expect(html).not.toContain("TSCIRCUIT_REGISTRY_TOKEN")
+})
+
+test("getStaticIndexHtmlFile output includes file list and omits registry token", () => {
+  const originalToken = cliConfig.get("sessionToken")
+  cliConfig.set("sessionToken", DUMMY_TOKEN)
+  const staticFileList = [
+    {
+      filePath: "index.circuit.tsx",
+      fileStaticAssetUrl: "./index/circuit.json",
+    },
+  ]
+  const html = getStaticIndexHtmlFile({
+    files: staticFileList,
+    standaloneScriptSrc: "./standalone.min.js",
+  })
+  if (originalToken) cliConfig.set("sessionToken", originalToken)
+  else cliConfig.delete("sessionToken")
+
+  expect(html).toContain("window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI = false;")
+  expect(html).toContain(
+    `window.TSCIRCUIT_RUNFRAME_STATIC_FILE_LIST = ${JSON.stringify(staticFileList)}`,
+  )
+  expect(html).not.toContain("TSCIRCUIT_REGISTRY_TOKEN")
+  expect(html).toContain('<script src="./standalone.min.js"></script>')
 })


### PR DESCRIPTION
## Summary
- restore `getIndex` to its CLI-focused implementation and add a dedicated `getStaticIndexHtmlFile` helper for static builds
- switch the `tscircuit build --site` flow to the new static index generator and clarify the flag description
- update the existing index token tests to cover the static index HTML output

## Testing
- bun test tests/test4-get-index-token.test.ts
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68d0964c828c832e9200a96f616d2038