### PR TITLE
Add stalebot workflow

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,0 +1,29 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'  # Runs at 1:30 AM UTC every day
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues config
+          stale-issue-message: 'This issue has been automatically marked as stale because it has had no recent activity. It will be closed if no further activity occurs.'
+          close-issue-message: 'This issue was closed because it has been inactive for 14 days since being marked as stale.'
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          
+          # Pull request config
+          stale-pr-message: 'This PR has been automatically marked as stale because it has had no recent activity. It will be closed if no further activity occurs.'
+          close-pr-message: 'This PR was closed because it has been inactive for 1 day since being marked as stale.'
+          days-before-pr-stale: 2
+          days-before-pr-close: 1
+          
+          # General config
+          exempt-issue-labels: 'pinned,security,help-wanted'
+          exempt-pr-labels: 'pinned,security,help-wanted'
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
- add a scheduled stalebot workflow to close stale issues and PRs

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68d31627b28c832eb8b6bbbcf2ed1e51