### PR TITLE
Support building index entrypoint when *.board.tsx and *.circuit.tsx files aren't found

### DIFF
--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -17,29 +17,48 @@ export async function getBuildEntrypoints({
 }> {
   const resolvedRoot = path.resolve(rootDir)
 
-  if (fileOrDir) {
-    const resolved = path.resolve(resolvedRoot, fileOrDir)
-    if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
-      const projectDir = resolved
-      const files = globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
-        cwd: projectDir,
-        ignore: DEFAULT_IGNORED_PATTERNS,
-      })
+  const buildFromProjectDir = async (projectDir: string) => {
+    const files = globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
+      cwd: projectDir,
+      ignore: DEFAULT_IGNORED_PATTERNS,
+    })
+
+    if (files.length > 0) {
       return {
         projectDir,
         circuitFiles: files.map((f) => path.join(projectDir, f)),
       }
     }
+
+    const mainEntrypoint = await getEntrypoint({
+      projectDir,
+      onSuccess: () => undefined,
+      onError: () => undefined,
+    })
+
+    if (mainEntrypoint) {
+      return {
+        projectDir,
+        mainEntrypoint,
+        circuitFiles: [mainEntrypoint],
+      }
+    }
+
+    return {
+      projectDir,
+      circuitFiles: [],
+    }
+  }
+
+  if (fileOrDir) {
+    const resolved = path.resolve(resolvedRoot, fileOrDir)
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+      const projectDir = resolved
+      return buildFromProjectDir(projectDir)
+    }
     return { projectDir: path.dirname(resolved), circuitFiles: [resolved] }
   }
 
   const projectDir = resolvedRoot
-  const files = globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
-    cwd: projectDir,
-    ignore: DEFAULT_IGNORED_PATTERNS,
-  })
-  return {
-    projectDir,
-    circuitFiles: files.map((f) => path.join(projectDir, f)),
-  }
+  return buildFromProjectDir(projectDir)
 }

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -77,3 +77,20 @@ test("build without file builds circuit and board files", async () => {
   )
   expect(boardComponent.name).toBe("R1")
 })
+
+test("build without circuit files falls back to main entrypoint", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const mainPath = path.join(tmpDir, "index.tsx")
+  await writeFile(mainPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build`)
+
+  const data = await readFile(
+    path.join(tmpDir, "dist", "index", "circuit.json"),
+    "utf-8",
+  )
+  const json = JSON.parse(data)
+  const component = json.find((c: any) => c.type === "source_component")
+  expect(component.name).toBe("R1")
+})


### PR DESCRIPTION
## Summary
- add a fallback in `tsci build` to detect and build the main entrypoint when no circuit/board files exist
- cover the new behavior with a CLI build test that ensures `index.tsx` is built when it is the only entrypoint

## Testing
- bun test tests/cli/build/build.test.ts
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68d4d12dd7b0832ea2347cf297800439