### PR TITLE
feat: add preview image generation to build

### DIFF
--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs"
+import path from "node:path"
+import {
+  convertCircuitJsonToPcbSvg,
+  convertCircuitJsonToSchematicSvg,
+} from "circuit-to-svg"
+import { convertCircuitJsonToSimple3dSvg } from "circuit-json-to-simple-3d"
+import sharp from "sharp"
+
+export interface BuildFileResult {
+  sourcePath: string
+  outputPath: string
+  ok: boolean
+}
+
+export const buildPreviewImages = async ({
+  builtFiles,
+  distDir,
+  mainEntrypoint,
+}: {
+  builtFiles: BuildFileResult[]
+  distDir: string
+  mainEntrypoint?: string
+}) => {
+  const successfulBuilds = builtFiles.filter((file) => file.ok)
+  const normalizedMainEntrypoint = mainEntrypoint
+    ? path.resolve(mainEntrypoint)
+    : undefined
+
+  const previewBuild = (() => {
+    if (normalizedMainEntrypoint) {
+      const match = successfulBuilds.find(
+        (built) => path.resolve(built.sourcePath) === normalizedMainEntrypoint,
+      )
+      if (match) return match
+    }
+    return successfulBuilds[0]
+  })()
+
+  if (!previewBuild) {
+    console.warn(
+      "No successful build output available for preview image generation.",
+    )
+    return
+  }
+
+  try {
+    const circuitJsonRaw = fs.readFileSync(previewBuild.outputPath, "utf-8")
+    const circuitJson = JSON.parse(circuitJsonRaw)
+
+    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+    const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
+    const simple3dSvg = await convertCircuitJsonToSimple3dSvg(circuitJson)
+
+    fs.writeFileSync(path.join(distDir, "pcb.svg"), pcbSvg, "utf-8")
+    fs.writeFileSync(path.join(distDir, "schematic.svg"), schematicSvg, "utf-8")
+
+    if (simple3dSvg) {
+      const pngBuffer = await sharp(Buffer.from(simple3dSvg)).png().toBuffer()
+      fs.writeFileSync(path.join(distDir, "3d.png"), pngBuffer)
+    }
+  } catch (error) {
+    console.error("Failed to generate preview images:", error)
+  }
+}

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -94,3 +94,27 @@ test("build without circuit files falls back to main entrypoint", async () => {
   const component = json.find((c: any) => c.type === "source_component")
   expect(component.name).toBe("R1")
 })
+
+test("build with --preview-images generates preview assets", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --preview-images ${circuitPath}`)
+
+  const schematicSvg = await readFile(
+    path.join(tmpDir, "dist", "schematic.svg"),
+    "utf-8",
+  )
+  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  const preview3d = await readFile(path.join(tmpDir, "dist", "3d.png"))
+
+  expect(schematicSvg).toContain("<svg")
+  expect(pcbSvg).toContain("<svg")
+  expect(preview3d.byteLength).toBeGreaterThan(0)
+  expect(preview3d[0]).toBe(0x89)
+  expect(preview3d[1]).toBe(0x50)
+  expect(preview3d[2]).toBe(0x4e)
+  expect(preview3d[3]).toBe(0x47)
+})


### PR DESCRIPTION
## Summary
- add a --preview-images flag to `tsci build` that selects a built entrypoint and emits PCB, schematic, and 3D previews
- reuse the generated circuit JSON to render preview assets into the dist directory
- add a CLI regression test covering the new preview image workflow

## Testing
- bun test tests/cli/build/build.test.ts
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68d576f15e08832eb1adcc8c18510ed7