### PR TITLE
Switch snapshot 3D rendering to poppygl

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "@tscircuit/props": "^0.0.341",
         "@tscircuit/runframe": "^0.0.1036",
         "@tscircuit/schematic-match-adapt": "^0.0.22",
-        "@tscircuit/simple-3d-svg": "^0.0.38",
         "@types/bun": "^1.2.2",
         "@types/configstore": "^6.0.2",
         "@types/debug": "^4.1.12",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@tscircuit/props": "^0.0.341",
     "@tscircuit/runframe": "^0.0.1036",
     "@tscircuit/schematic-match-adapt": "^0.0.22",
-    "@tscircuit/simple-3d-svg": "^0.0.38",
     "@types/bun": "^1.2.2",
     "@types/configstore": "^6.0.2",
     "@types/debug": "^4.1.12",


### PR DESCRIPTION
## Summary
- replace the simple 3d SVG conversion in snapshot generation with a poppygl-based GLB -> PNG workflow
- write 3D snapshots as rendered PNG buffers and adjust diffing logic accordingly
- remove the unused simple 3d dependency from package metadata

## Testing
- bun run build:bun

------
https://chatgpt.com/codex/tasks/task_b_68e00b83e2608327a0aeade796032e9e