### PR TITLE
refactor: centralize board file discovery, use `includeBoardFiles` from project config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@tscircuit/fake-snippets": "^0.0.110",
         "@tscircuit/file-server": "^0.0.30",
         "@tscircuit/math-utils": "0.0.21",
-        "@tscircuit/props": "^0.0.356",
+        "@tscircuit/props": "^0.0.364",
         "@tscircuit/runframe": "^0.0.1091",
         "@tscircuit/schematic-match-adapt": "^0.0.22",
         "@types/bun": "^1.2.2",
@@ -247,7 +247,7 @@
 
     "@tscircuit/mm": ["@tscircuit/mm@0.0.8", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-nl7nxE7AhARbKuobflI0LUzoir7+wJyvwfPw6bzA/O0Q3YTcH3vBkU/Of+V/fp6ht+AofiCXj7YAH9E446138Q=="],
 
-    "@tscircuit/props": ["@tscircuit/props@0.0.356", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-0hrKBuPKLthNzj9TzfrKORTMzoNAG4vCy1ZQmL5MtdXyrSEWCQJ3Z3cVoPVpRR9276aiw5WVvJcMRC18+N7Jog=="],
+    "@tscircuit/props": ["@tscircuit/props@0.0.364", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-65hfajqOBjqiH+DNyKDoN674riyFqSlqCCPDdtI15CEW74cidxJgcBAi1cQwjPop1JRm18yJaAIhtIlPIytGsQ=="],
 
     "@tscircuit/runframe": ["@tscircuit/runframe@0.0.1091", "", {}, "sha512-qowbi4VlXbz9oIL0mSrsVRMNQS9jkiA9zU1HwfpEFar/gT1bY4PTHz27NfiwYmDlNfXtnyekiOtEKakOWim2Yw=="],
 
@@ -909,7 +909,7 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "transformation-matrix": ["transformation-matrix@3.1.0", "", {}, "sha512-oYubRWTi2tYFHAL2J8DLvPIqIYcYZ0fSOi2vmSy042Ho4jBW2ce6VP7QfD44t65WQz6bw5w1Pk22J7lcUpaTKA=="],
+    "transformation-matrix": ["transformation-matrix@2.16.1", "", {}, "sha512-tdtC3wxVEuzU7X/ydL131Q3JU5cPMEn37oqVLITjRDSDsnSHVFzW2JiCLfZLIQEgWzZHdSy3J6bZzvKEN24jGA=="],
 
     "ts-deepmerge": ["ts-deepmerge@6.2.1", "", {}, "sha512-8CYSLazCyj0DJDpPIxOFzJG46r93uh6EynYjuey+bxcLltBeqZL7DMfaE5ZPzZNFlav7wx+2TDa/mBl8gkTYzw=="],
 
@@ -993,11 +993,7 @@
 
     "@tscircuit/circuit-json-flex/@tscircuit/miniflex": ["@tscircuit/miniflex@0.0.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-oRC0up2psp8dJD1CzXyUiFuhQZUWLdZNl9EAqOf/hHqXDhPKMU6wM79S+XQuaB0gdWNRnwcURHPPaKLw/ka3DQ=="],
 
-    "@tscircuit/core/transformation-matrix": ["transformation-matrix@2.16.1", "", {}, "sha512-tdtC3wxVEuzU7X/ydL131Q3JU5cPMEn37oqVLITjRDSDsnSHVFzW2JiCLfZLIQEgWzZHdSy3J6bZzvKEN24jGA=="],
-
     "@tscircuit/schematic-autolayout/@tscircuit/soup-util": ["@tscircuit/soup-util@0.0.38", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "*" } }, "sha512-GdcuFxk+qnJZv+eI7ZoJ1MJEseFgRyaztMtQ/OXA2SUnxyPEH0UTy9vkhKTm+8GTePryEgdXcc65TgUyrr44ww=="],
-
-    "@tscircuit/schematic-autolayout/transformation-matrix": ["transformation-matrix@2.16.1", "", {}, "sha512-tdtC3wxVEuzU7X/ydL131Q3JU5cPMEn37oqVLITjRDSDsnSHVFzW2JiCLfZLIQEgWzZHdSy3J6bZzvKEN24jGA=="],
 
     "@types/prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
@@ -1008,8 +1004,6 @@
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "circuit-json-to-connectivity-map/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg=="],
-
-    "circuit-to-svg/transformation-matrix": ["transformation-matrix@2.16.1", "", {}, "sha512-tdtC3wxVEuzU7X/ydL131Q3JU5cPMEn37oqVLITjRDSDsnSHVFzW2JiCLfZLIQEgWzZHdSy3J6bZzvKEN24jGA=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1030,6 +1024,8 @@
     "editorconfig/minimatch": ["minimatch@9.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "graphics-debug/transformation-matrix": ["transformation-matrix@3.1.0", "", {}, "sha512-oYubRWTi2tYFHAL2J8DLvPIqIYcYZ0fSOi2vmSy042Ho4jBW2ce6VP7QfD44t65WQz6bw5w1Pk22J7lcUpaTKA=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
@@ -1073,7 +1069,7 @@
 
     "tscircuit/poppygl": ["poppygl@0.0.6", "", { "dependencies": { "gl-matrix": "^3.4.4", "pureimage": "^0.4.18", "readable-stream": "^4.7.0" }, "peerDependencies": { "typescript": "^5" } }, "sha512-q5y6X/S2zFVktAT8mSlzzuxCjOOpwPxWEy5bYfnJkaJmCJ+fWM3vVjE6Acgt5TLyL1l72E/Qlq2zBNIa1wqqNQ=="],
 
-    "tscircuit/transformation-matrix": ["transformation-matrix@2.16.1", "", {}, "sha512-tdtC3wxVEuzU7X/ydL131Q3JU5cPMEn37oqVLITjRDSDsnSHVFzW2JiCLfZLIQEgWzZHdSy3J6bZzvKEN24jGA=="],
+    "use-mouse-matrix-transform/transformation-matrix": ["transformation-matrix@3.1.0", "", {}, "sha512-oYubRWTi2tYFHAL2J8DLvPIqIYcYZ0fSOi2vmSy042Ho4jBW2ce6VP7QfD44t65WQz6bw5w1Pk22J7lcUpaTKA=="],
 
     "winterspec/esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 

--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs"
 import path from "node:path"
-import { globbySync } from "globby"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
-import { DEFAULT_IGNORED_PATTERNS } from "lib/shared/should-ignore-path"
+import { findBoardFiles } from "lib/shared/find-board-files"
 
 export async function getBuildEntrypoints({
   fileOrDir,
@@ -18,15 +17,12 @@ export async function getBuildEntrypoints({
   const resolvedRoot = path.resolve(rootDir)
 
   const buildFromProjectDir = async (projectDir: string) => {
-    const files = globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
-      cwd: projectDir,
-      ignore: DEFAULT_IGNORED_PATTERNS,
-    })
+    const files = findBoardFiles({ projectDir })
 
     if (files.length > 0) {
       return {
         projectDir,
-        circuitFiles: files.map((f) => path.join(projectDir, f)),
+        circuitFiles: files,
       }
     }
 

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -8,9 +8,18 @@ import kleur from "kleur"
 import { getVersion } from "lib/getVersion"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
 import { globbySync } from "globby"
+import { findBoardFiles } from "lib/shared/find-board-files"
 import { DEFAULT_IGNORED_PATTERNS } from "lib/shared/should-ignore-path"
 
 const findSelectableTsxFiles = (projectDir: string): string[] => {
+  const boardFiles = findBoardFiles({ projectDir })
+    .filter((file) => fs.existsSync(file))
+    .sort()
+
+  if (boardFiles.length > 0) {
+    return boardFiles
+  }
+
   const files = globbySync(["**/*.tsx", "**/*.ts"], {
     cwd: projectDir,
     ignore: DEFAULT_IGNORED_PATTERNS,

--- a/lib/project-config/index.ts
+++ b/lib/project-config/index.ts
@@ -13,6 +13,11 @@ export const defineConfig = (config: TscircuitProjectConfig) => {
 
 export const CONFIG_FILENAME = "tscircuit.config.json"
 
+export const DEFAULT_BOARD_FILE_PATTERNS = [
+  "**/*.board.tsx",
+  "**/*.circuit.tsx",
+]
+
 /**
  * Load the tscircuit project configuration from the file system
  */
@@ -33,6 +38,21 @@ export const loadProjectConfig = (
     console.error(`Error loading tscircuit config: ${error}`)
     return null
   }
+}
+
+export const getBoardFilePatterns = (
+  projectDir: string = process.cwd(),
+): string[] => {
+  const config = loadProjectConfig(projectDir)
+  const patterns = config?.includeBoardFiles?.filter((pattern) =>
+    pattern.trim(),
+  )
+
+  if (patterns && patterns.length > 0) {
+    return patterns
+  }
+
+  return DEFAULT_BOARD_FILE_PATTERNS
 }
 
 /**

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 export const projectConfigSchema = z.object({
   mainEntrypoint: z.string().optional(),
   ignoredFiles: z.array(z.string()).optional(),
+  includeBoardFiles: z.array(z.string()).optional(),
 })
 
 export type TscircuitProjectConfigInput = z.input<typeof projectConfigSchema>

--- a/lib/shared/find-board-files.ts
+++ b/lib/shared/find-board-files.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs"
+import path from "node:path"
+import { globbySync } from "globby"
+import { getBoardFilePatterns } from "lib/project-config"
+import { DEFAULT_IGNORED_PATTERNS } from "./should-ignore-path"
+
+type FindBoardFilesOptions = {
+  projectDir?: string
+  ignore?: string[]
+  filePaths?: string[]
+}
+
+const isSubPath = (maybeChild: string, maybeParent: string) => {
+  const relative = path.relative(maybeParent, maybeChild)
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  )
+}
+
+/**
+ * Locate all board files that match the configured include globs.
+ *
+ * The returned paths are absolute to make it easier for callers to work with
+ * them directly without additional resolution logic.
+ */
+export const findBoardFiles = ({
+  projectDir = process.cwd(),
+  ignore = DEFAULT_IGNORED_PATTERNS,
+  filePaths = [],
+}: FindBoardFilesOptions = {}): string[] => {
+  const resolvedProjectDir = path.resolve(projectDir)
+  const boardFilePatterns = getBoardFilePatterns(resolvedProjectDir)
+
+  const relativeBoardFiles = globbySync(boardFilePatterns, {
+    cwd: resolvedProjectDir,
+    ignore,
+  })
+
+  const absoluteBoardFiles = relativeBoardFiles.map((f) =>
+    path.join(resolvedProjectDir, f),
+  )
+
+  const boardFileSet = new Set<string>()
+
+  const resolvedPaths = filePaths.map((f) =>
+    path.resolve(resolvedProjectDir, f),
+  )
+
+  if (resolvedPaths.length > 0) {
+    for (const targetPath of resolvedPaths) {
+      if (!fs.existsSync(targetPath)) {
+        continue
+      }
+
+      const stat = fs.statSync(targetPath)
+      if (stat.isDirectory()) {
+        const resolvedDir = path.resolve(targetPath)
+        if (isSubPath(resolvedDir, resolvedProjectDir)) {
+          for (const boardFile of absoluteBoardFiles) {
+            if (isSubPath(boardFile, resolvedDir)) {
+              boardFileSet.add(boardFile)
+            }
+          }
+        } else {
+          const externalMatches = globbySync(boardFilePatterns, {
+            cwd: resolvedDir,
+            ignore,
+          }).map((f) => path.join(resolvedDir, f))
+
+          for (const match of externalMatches) {
+            boardFileSet.add(match)
+          }
+        }
+      } else {
+        boardFileSet.add(targetPath)
+      }
+    }
+  } else {
+    for (const boardFile of absoluteBoardFiles) {
+      boardFileSet.add(boardFile)
+    }
+  }
+
+  return Array.from(boardFileSet).sort((a, b) => a.localeCompare(b))
+}

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs"
 import path from "node:path"
-import { globbySync } from "globby"
 import kleur from "kleur"
 import looksSame from "looks-same"
 import {
@@ -11,6 +10,7 @@ import { convertCircuitJsonToGltf } from "circuit-json-to-gltf"
 import { renderGLTFToPNGBufferFromGLBBuffer } from "poppygl"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import type { PlatformConfig } from "@tscircuit/props"
+import { findBoardFiles } from "lib/shared/find-board-files"
 import {
   DEFAULT_IGNORED_PATTERNS,
   normalizeIgnorePattern,
@@ -57,22 +57,11 @@ export const snapshotProject = async ({
   ]
 
   const resolvedPaths = filePaths.map((f) => path.resolve(projectDir, f))
-
-  const boardFiles =
-    resolvedPaths.length > 0
-      ? resolvedPaths.flatMap((p) => {
-          if (fs.existsSync(p) && fs.statSync(p).isDirectory()) {
-            return globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
-              cwd: p,
-              ignore,
-            }).map((f) => path.join(p, f))
-          }
-          return [p]
-        })
-      : globbySync(["**/*.board.tsx", "**/*.circuit.tsx"], {
-          cwd: projectDir,
-          ignore,
-        }).map((f) => path.join(projectDir, f))
+  const boardFiles = findBoardFiles({
+    projectDir,
+    ignore,
+    filePaths: resolvedPaths,
+  })
 
   if (boardFiles.length === 0) {
     console.log(

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@tscircuit/fake-snippets": "^0.0.110",
     "@tscircuit/file-server": "^0.0.30",
     "@tscircuit/math-utils": "0.0.21",
-    "@tscircuit/props": "^0.0.356",
+    "@tscircuit/props": "^0.0.364",
     "@tscircuit/runframe": "^0.0.1091",
     "@tscircuit/schematic-match-adapt": "^0.0.22",
     "@types/bun": "^1.2.2",

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -83,6 +83,7 @@ test("build respects includeBoardFiles config globs", async () => {
   const boardsDir = path.join(tmpDir, "boards")
   await mkdir(boardsDir, { recursive: true })
   const includedBoard = path.join(boardsDir, "selected.board.tsx")
+  const anotherIncludedBoard = path.join(boardsDir, "anotherboard.board.tsx")
   const excludedBoard = path.join(tmpDir, "ignored.board.tsx")
 
   await writeFile(
@@ -104,6 +105,10 @@ test("build respects includeBoardFiles config globs", async () => {
     (c: any) => c.type === "source_component",
   )
   expect(includedComponent.name).toBe("R1")
+
+  await expect(
+    stat(path.join(tmpDir, "dist", "boards", "anotherboard", "circuit.json")),
+  ).toBeTruthy()
 
   await expect(
     stat(path.join(tmpDir, "dist", "ignored", "circuit.json")),

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -91,6 +91,7 @@ test("build respects includeBoardFiles config globs", async () => {
     JSON.stringify({ includeBoardFiles: ["boards/**/*.board.tsx"] }),
   )
   await writeFile(includedBoard, circuitCode)
+  await writeFile(anotherIncludedBoard, circuitCode)
   await writeFile(excludedBoard, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
@@ -108,7 +109,7 @@ test("build respects includeBoardFiles config globs", async () => {
 
   await expect(
     stat(path.join(tmpDir, "dist", "boards", "anotherboard", "circuit.json")),
-  ).toBeTruthy()
+  ).resolves.toBeTruthy()
 
   await expect(
     stat(path.join(tmpDir, "dist", "ignored", "circuit.json")),

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -1,6 +1,6 @@
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 import { test, expect } from "bun:test"
-import { writeFile, readFile, stat } from "node:fs/promises"
+import { writeFile, readFile, stat, mkdir } from "node:fs/promises"
 import path from "node:path"
 
 const circuitCode = `
@@ -33,7 +33,7 @@ test("build with file only outputs that file", async () => {
   await expect(
     stat(path.join(tmpDir, "dist", "extra", "circuit.json")),
   ).rejects.toBeTruthy()
-})
+}, 30_000)
 
 // When no file is provided search for *.circuit.tsx and *.board.tsx files
 
@@ -76,7 +76,39 @@ test("build without file builds circuit and board files", async () => {
     (c: any) => c.type === "source_component",
   )
   expect(boardComponent.name).toBe("R1")
-})
+}, 30_000)
+
+test("build respects includeBoardFiles config globs", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const boardsDir = path.join(tmpDir, "boards")
+  await mkdir(boardsDir, { recursive: true })
+  const includedBoard = path.join(boardsDir, "selected.board.tsx")
+  const excludedBoard = path.join(tmpDir, "ignored.board.tsx")
+
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ includeBoardFiles: ["boards/**/*.board.tsx"] }),
+  )
+  await writeFile(includedBoard, circuitCode)
+  await writeFile(excludedBoard, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand("tsci build")
+
+  const includedOutput = await readFile(
+    path.join(tmpDir, "dist", "boards", "selected", "circuit.json"),
+    "utf-8",
+  )
+  const includedJson = JSON.parse(includedOutput)
+  const includedComponent = includedJson.find(
+    (c: any) => c.type === "source_component",
+  )
+  expect(includedComponent.name).toBe("R1")
+
+  await expect(
+    stat(path.join(tmpDir, "dist", "ignored", "circuit.json")),
+  ).rejects.toBeTruthy()
+}, 30_000)
 
 test("build without circuit files falls back to main entrypoint", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
@@ -93,7 +125,7 @@ test("build without circuit files falls back to main entrypoint", async () => {
   const json = JSON.parse(data)
   const component = json.find((c: any) => c.type === "source_component")
   expect(component.name).toBe("R1")
-})
+}, 30_000)
 
 test("build with --preview-images generates preview assets", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
@@ -117,4 +149,4 @@ test("build with --preview-images generates preview assets", async () => {
   expect(preview3d[1]).toBe(0x50)
   expect(preview3d[2]).toBe(0x4e)
   expect(preview3d[3]).toBe(0x47)
-})
+}, 30_000)

--- a/tests/cli/snapshot/looks-same-metadata.test.ts
+++ b/tests/cli/snapshot/looks-same-metadata.test.ts
@@ -49,4 +49,4 @@ test("snapshot does not update on metadata-only changes", async () => {
   const diffPath = join(snapDir, "meta.board-pcb.diff.png")
   const diffExists = fs.existsSync(diffPath)
   expect(diffExists).toBe(false)
-})
+}, 30_000)

--- a/tests/cli/snapshot/looks-same-visual-diff.test.ts
+++ b/tests/cli/snapshot/looks-same-visual-diff.test.ts
@@ -44,4 +44,4 @@ test("CLI detects visual change when another chip is added", async () => {
   const diffPath = join(tmpDir, "__snapshots__", "meta.board-pcb.diff.svg")
   const diffExists = fs.existsSync(diffPath)
   expect(diffExists).toBe(true)
-})
+}, 30_000)


### PR DESCRIPTION
## Summary
- upgrade @tscircuit/props to 0.0.364 and extend the project config schema with the new includeBoardFiles option
- reuse the configured board file globs when collecting files for tsci dev, tsci build, and tsci snapshot through a shared board file finder
- add coverage for the new config behavior and extend relevant CLI test timeouts to handle longer builds

## Testing
- bunx tsc --noEmit
- bun test tests/cli/build
- bun test tests/cli/snapshot

------
https://chatgpt.com/codex/tasks/task_b_68eecb0d1b44832e8075574a5283028c