### PR TITLE
Add FILE_DELETED event handling to sync file deletions

### DIFF
--- a/lib/file-server/FileServerEvent.ts
+++ b/lib/file-server/FileServerEvent.ts
@@ -5,3 +5,10 @@ export interface FileUpdatedEvent {
   initiator?: "filesystem_change" | "browser_edit"
   created_at: string
 }
+
+export interface FileDeletedEvent {
+  event_id: string
+  event_type: "FILE_DELETED"
+  file_path: string
+  created_at: string
+}

--- a/lib/server/EventsRoutes.ts
+++ b/lib/server/EventsRoutes.ts
@@ -20,6 +20,7 @@ export interface EventsRoutes {
           event_id: string
           event_type:
             | "FILE_UPDATED"
+            | "FILE_DELETED"
             | "FAILED_TO_SAVE_SNIPPET"
             | "SNIPPET_SAVED"
             | "REQUEST_TO_SAVE_SNIPPET"


### PR DESCRIPTION
## PR description

- Added `FileDeletedEvent` interface in file server event types
- Included `FILE_DELETED` in EventsRoutes event type union
- Added event listener in `DevServer` to handle `FILE_DELETED` events from server
- Implemented `handleFileDeletedEventFromServer` to remove files

closes #615 