### PR TITLE
Support INITIAL_FILES_UPLOADED event to fix dev server race condition

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@biomejs/biome": "^1.9.4",
         "@tscircuit/circuit-json-util": "0.0.67",
         "@tscircuit/fake-snippets": "^0.0.110",
-        "@tscircuit/file-server": "^0.0.30",
+        "@tscircuit/file-server": "^0.0.32",
         "@tscircuit/math-utils": "0.0.21",
         "@tscircuit/props": "^0.0.356",
         "@tscircuit/runframe": "^0.0.1115",
@@ -233,7 +233,7 @@
 
     "@tscircuit/fake-snippets": ["@tscircuit/fake-snippets@0.0.110", "", {}, "sha512-NEk7+HfjXL2kSRfKek58ss+Zm/QfvmbjGPKxsG0MRcHDA4wZVry843iZcTkkN40mfi+LOELaRcuGyaPBtplFIw=="],
 
-    "@tscircuit/file-server": ["@tscircuit/file-server@0.0.30", "", { "dependencies": { "winterspec": "^0.0.86", "zod": "^3.23.8", "zustand": "^4.5.5", "zustand-hoist": "^2.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "file-server": "dist/cli.js" } }, "sha512-wxvICZMb6HC3xdxyneZPi7NGC2Mnk/AQK4gsIITK7dT5+yQlWwONIXLfqiRlw9s2QgCadgnTg9ErMiwEaQG7Ng=="],
+    "@tscircuit/file-server": ["@tscircuit/file-server@0.0.32", "", { "dependencies": { "winterspec": "^0.0.86", "zod": "^3.23.8", "zustand": "^4.5.5", "zustand-hoist": "^2.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "file-server": "dist/cli.js" } }, "sha512-RQDYRjwENDvVK/p0Wtw5rWCZAW2ZL2iKYspEhFr/oWiOC54brtQnL4udgwvyibE0qJxg8v3xR0AxOoebn3HeAA=="],
 
     "@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.236", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-SE03ZCNp9FxzSa3LdbQOMBHjT16Q86ZwN6iLu+RPsAbFrdE1RwtM7dv5lOb6lkh78mL3e7yyuyay+QrERiLcYQ=="],
 

--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -281,6 +281,10 @@ export class DevServer {
   }
 
   async upsertInitialFiles() {
+    await this.fsKy.post("api/events/reset", {
+      json: {},
+    })
+
     const filePaths = getPackageFilePaths(this.projectDir, this.ignoredFiles)
 
     for (const filePath of filePaths) {
@@ -297,6 +301,14 @@ export class DevServer {
         },
       })
     }
+
+    await this.fsKy.post("api/events/create", {
+      json: {
+        event_type: "INITIAL_FILES_UPLOADED",
+        file_count: filePaths.length,
+      },
+      throwHttpErrors: false,
+    })
   }
 
   private async saveSnippet() {

--- a/lib/server/EventsRoutes.ts
+++ b/lib/server/EventsRoutes.ts
@@ -3,7 +3,9 @@ export interface EventsRoutes {
     POST: {
       requestJson: {
         event_type: string
+        file_count?: number
         message?: string
+        full_package_name?: string
       }
       responseJson: {
         event: {
@@ -21,14 +23,27 @@ export interface EventsRoutes {
           event_type:
             | "FILE_UPDATED"
             | "FILE_DELETED"
+            | "INITIAL_FILES_UPLOADED"
             | "FAILED_TO_SAVE_SNIPPET"
             | "SNIPPET_SAVED"
             | "REQUEST_TO_SAVE_SNIPPET"
-          file_path: string
+            | "INSTALL_PACKAGE"
+            | "PACKAGE_INSTALLED"
+            | "PACKAGE_INSTALL_FAILED"
+          file_path?: string
           created_at: string
           initiator?: string
+          file_count?: number
+          message?: string
+          full_package_name?: string
         }>
       }
+    }
+  }
+  "api/events/reset": {
+    POST: {
+      requestJson: {}
+      responseJson: { ok: boolean }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@biomejs/biome": "^1.9.4",
     "@tscircuit/circuit-json-util": "0.0.67",
     "@tscircuit/fake-snippets": "^0.0.110",
-    "@tscircuit/file-server": "^0.0.30",
+    "@tscircuit/file-server": "^0.0.32",
     "@tscircuit/math-utils": "0.0.21",
     "@tscircuit/props": "^0.0.356",
     "@tscircuit/runframe": "^0.0.1115",

--- a/tests/cli/dev/initial-files-delay.test.ts
+++ b/tests/cli/dev/initial-files-delay.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test"
+import { DevServer } from "cli/dev/DevServer"
+import getPort from "get-port"
+import { join } from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test(
+  "dev-server handles delayed initial file uploads",
+  async () => {
+    const fixture = await getCliTestFixture()
+    const devServerPort = await getPort()
+
+    const mainTsxContent = `
+        import { partName } from "./util.ts"
+        export default () => (
+          <board>
+            <resistor name={partName} resistance="1k" footprint="0402" />
+          </board>
+        )
+    `
+    const utilTsContent = `export const partName = "R1"`
+
+    // We start the dev server with an empty project and manually control file uploads
+    // to simulate a delay, much like example33-delay-file-uploads-repro.fixture.tsx
+    const devServer = new DevServer({
+      port: devServerPort,
+      componentFilePath: join(fixture.tmpDir, "main.tsx"),
+      projectDir: fixture.tmpDir,
+    })
+
+    // Prevent automatic initial file upload
+    devServer.upsertInitialFiles = async () => {}
+
+    await devServer.start()
+
+    // Clean up any files from previous tests
+    const initialFiles = (await devServer.fsKy
+      .get("api/files/list")
+      .json()) as any
+    for (const file of initialFiles.file_list) {
+      await devServer.fsKy.post("api/files/delete", {
+        json: { file_path: file.file_path },
+        throwHttpErrors: false,
+      })
+    }
+
+    // 1. Reset events
+    await devServer.fsKy.post("api/events/reset", { json: {} })
+
+    // 2. Upload main.tsx first
+    await devServer.fsKy.post("api/files/upsert", {
+      json: {
+        file_path: "main.tsx",
+        text_content: mainTsxContent,
+      },
+    })
+
+    // 3. Verify only main.tsx is present
+    let fileListRes = (await devServer.fsKy.get("api/files/list").json()) as any
+    expect(fileListRes.file_list.length).toBe(1)
+    expect(fileListRes.file_list[0].file_path).toBe("main.tsx")
+
+    // 4. Introduce a delay
+    await new Promise((r) => setTimeout(r, 200))
+
+    // 5. Upload util.ts after the delay
+    await devServer.fsKy.post("api/files/upsert", {
+      json: {
+        file_path: "util.ts",
+        text_content: utilTsContent,
+      },
+    })
+
+    // 6. Verify both files are now present
+    fileListRes = (await devServer.fsKy.get("api/files/list").json()) as any
+    expect(fileListRes.file_list.length).toBe(2)
+    expect(fileListRes.file_list.map((f: any) => f.file_path)).toContainValues([
+      "main.tsx",
+      "util.ts",
+    ])
+
+    // 7. Signal that initial files are loaded
+    await devServer.fsKy.post("api/events/create", {
+      json: {
+        event_type: "INITIAL_FILES_UPLOADED",
+        file_count: 2,
+      },
+    })
+
+    // 8. Check that the event was created
+    const eventsRes = (await devServer.fsKy
+      .get("api/events/list")
+      .json()) as any
+    const initialFilesUploadedEvent = eventsRes.event_list.find(
+      (e: any) => e.event_type === "INITIAL_FILES_UPLOADED",
+    )
+    expect(initialFilesUploadedEvent).toBeDefined()
+    expect(initialFilesUploadedEvent.file_count).toBe(2)
+
+    await devServer.stop()
+  },
+  { timeout: 10_000 },
+)


### PR DESCRIPTION
This pull request resolves a race condition in the dev server where the    
front-end runframe could attempt to render a circuit before all of its     
dependent files were available.                                                     

 • The tsci dev server now emits the INITIAL_FILES_UPLOADED event after it finishes the initial  
   upload of all project files.                                            
 • The runframe now waits for this event before it begins to load and      
   render the circuit, ensuring all necessary files are present on the     
   file-server.                                                            
 • A new test case, initial-files-delay.test.ts, has been added to         
   specifically simulate and verify this scenario.                         

/claim #513
/closes #513