### PR TITLE
Added handling for snapshotsDir 

### DIFF
--- a/cli/snapshot/register.ts
+++ b/cli/snapshot/register.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander"
 import { snapshotProject } from "lib/shared/snapshot-project"
+import { loadProjectConfig } from "lib/project-config"
 
 export const registerSnapshot = (program: Command) => {
   program
@@ -29,6 +30,8 @@ export const registerSnapshot = (program: Command) => {
           disablePartsEngine?: boolean
         },
       ) => {
+        const projectConfig = loadProjectConfig()
+        
         await snapshotProject({
           update: options.update ?? false,
           threeD: options["3d"] ?? false,
@@ -36,6 +39,7 @@ export const registerSnapshot = (program: Command) => {
           schematicOnly: options.schematicOnly ?? false,
           forceUpdate: options.forceUpdate ?? false,
           filePaths: target ? [target] : [],
+          snapshotsDir: projectConfig?.snapshotsDir,
           platformConfig: options.disablePartsEngine
             ? { partsEngineDisabled: true }
             : undefined,

--- a/cli/snapshot/register.ts
+++ b/cli/snapshot/register.ts
@@ -31,7 +31,7 @@ export const registerSnapshot = (program: Command) => {
         },
       ) => {
         const projectConfig = loadProjectConfig()
-        
+
         await snapshotProject({
           update: options.update ?? false,
           threeD: options["3d"] ?? false,

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -4,6 +4,7 @@ export const projectConfigSchema = z.object({
   mainEntrypoint: z.string().optional(),
   ignoredFiles: z.array(z.string()).optional(),
   includeBoardFiles: z.array(z.string()).optional(),
+  snapshotsDir: z.string().optional(),
 })
 
 export type TscircuitProjectConfigInput = z.input<typeof projectConfigSchema>

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -32,6 +32,8 @@ type SnapshotOptions = {
   forceUpdate?: boolean
   /** Optional platform configuration overrides */
   platformConfig?: PlatformConfig
+  /** Custom directory for snapshots (relative to project root or absolute path) */
+  snapshotsDir?: string
   onExit?: (code: number) => void
   onError?: (message: string) => void
   onSuccess?: (message: string) => void
@@ -45,6 +47,7 @@ export const snapshotProject = async ({
   schematicOnly = false,
   filePaths = [],
   forceUpdate = false,
+  snapshotsDir,
   onExit = (code) => process.exit(code),
   onError = (msg) => console.error(msg),
   onSuccess = (msg) => console.log(msg),
@@ -96,7 +99,16 @@ export const snapshotProject = async ({
       })
     }
 
-    const snapDir = path.join(path.dirname(file), "__snapshots__")
+    let snapDir: string
+    if (snapshotsDir) {
+      // Use custom snapshots directory
+      snapDir = path.isAbsolute(snapshotsDir)
+        ? snapshotsDir
+        : path.join(projectDir, snapshotsDir)
+    } else {
+      // Default: place snapshots in __snapshots__ directory next to the file
+      snapDir = path.join(path.dirname(file), "__snapshots__")
+    }
     fs.mkdirSync(snapDir, { recursive: true })
 
     const base = path.basename(file).replace(/\.tsx$/, "")


### PR DESCRIPTION
This PR adds the ability to customize the snapshot output directory through the `tscircuit.config.json` configuration file. Users can now specify a `snapshotsDir` field to control where snapshot files are generated, instead of being limited to the default `__snapshots__` directories next to each circuit file.

Fixes: [Allow customizing snapshot output directory for tsci snapshot via tscircuit.config.json](https://github.com/tscircuit/tscircuit/issues/1089)

/claim: [Allow customizing snapshot output directory for tsci snapshot via tscircuit.config.json](https://github.com/tscircuit/tscircuit/issues/1089)