### PR TITLE
feat: add --version-tag option to tsci push

### DIFF
--- a/cli/push/register.ts
+++ b/cli/push/register.ts
@@ -7,13 +7,23 @@ export const registerPush = (program: Command) => {
     .description("Save snippet code to Registry API")
     .argument("[file]", "Path to the snippet file")
     .option("--private", "Make the snippet private")
-    .action(async (filePath?: string, options: { private?: boolean } = {}) => {
-      await pushSnippet({
-        filePath,
-        isPrivate: options.private ?? false,
-        onExit: (code) => process.exit(code),
-        onError: (message) => console.error(message),
-        onSuccess: (message) => console.log(message),
-      })
-    })
+    .option(
+      "--version-tag <tag>",
+      "Publish as a non-latest version using the provided tag",
+    )
+    .action(
+      async (
+        filePath?: string,
+        options: { private?: boolean; versionTag?: string } = {},
+      ) => {
+        await pushSnippet({
+          filePath,
+          isPrivate: options.private ?? false,
+          versionTag: options.versionTag,
+          onExit: (code) => process.exit(code),
+          onError: (message) => console.error(message),
+          onSuccess: (message) => console.log(message),
+        })
+      },
+    )
 }

--- a/tests/cli/push/push10-version-tag.test.ts
+++ b/tests/cli/push/push10-version-tag.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+test("should publish a tagged release and increment when needed", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture({
+    loggedIn: true,
+  })
+
+  const snippetFilePath = path.resolve(tmpDir, "snippet.tsx")
+  const packageJsonPath = path.resolve(tmpDir, "package.json")
+
+  fs.writeFileSync(snippetFilePath, "// Snippet content")
+  fs.writeFileSync(
+    packageJsonPath,
+    JSON.stringify({ name: "test-package", version: "1.0.0" }),
+  )
+
+  const { stdout: stdout1, stderr: stderr1 } = await runCommand(
+    `tsci push --version-tag bugreport1 ${snippetFilePath}`,
+  )
+
+  expect({ stdout: stdout1, stderr: stderr1 }).toMatchInlineSnapshot(`
+    {
+      "stderr": "",
+      "stdout": 
+    "Package created
+
+
+    ⬆︎ package.json
+    ⬆︎ snippet.tsx
+    "@tsci/test-user.test-package@1.0.0-bugreport1" published!
+    https://tscircuit.com/test-user/test-package
+    "
+    ,
+    }
+  `)
+
+  const { stdout: stdout2, stderr: stderr2 } = await runCommand(
+    `tsci push --version-tag bugreport1 ${snippetFilePath}`,
+  )
+
+  expect({ stdout: stdout2, stderr: stderr2 }).toMatchInlineSnapshot(`
+    {
+      "stderr": "",
+      "stdout": 
+    "Incrementing Package Version 1.0.0 -> 1.0.1
+
+
+    ⬆︎ package.json
+    ⬆︎ snippet.tsx
+    "@tsci/test-user.test-package@1.0.1-bugreport1" published!
+    https://tscircuit.com/test-user/test-package
+    "
+    ,
+    }
+  `)
+}, 30_000)


### PR DESCRIPTION
## Summary
- add a --version-tag option to the tsci push command to publish non-latest releases
- update push workflow to append tags to release versions while keeping package.json versions stable
- add automated coverage for pushing tagged releases and incrementing tagged versions

## Testing
- bunx tsc --noEmit
- bun test tests/cli/push

------
https://chatgpt.com/codex/tasks/task_b_68f7cf5ace14832ea4ed74c5143bc69d