### PR TITLE
Enable cloning of bug reports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@babel/standalone": "^7.26.9",
         "@biomejs/biome": "^1.9.4",
         "@tscircuit/circuit-json-util": "0.0.67",
-        "@tscircuit/fake-snippets": "^0.0.110",
+        "@tscircuit/fake-snippets": "^0.0.128",
         "@tscircuit/file-server": "^0.0.32",
         "@tscircuit/math-utils": "0.0.21",
         "@tscircuit/props": "^0.0.371",
@@ -231,7 +231,7 @@
 
     "@tscircuit/eval": ["@tscircuit/eval@0.0.392", "", { "peerDependencies": { "@tscircuit/core": "*", "circuit-json": "*", "typescript": "^5.0.0", "zod": "3" } }, "sha512-7821h9OP1BJvZb68WR1/zVI65Ids0YMjWxs7UypM+aX7te5JWkcVnrcQPnRXssKtffQ1hr4OylzoUKZLql0XYw=="],
 
-    "@tscircuit/fake-snippets": ["@tscircuit/fake-snippets@0.0.110", "", {}, "sha512-NEk7+HfjXL2kSRfKek58ss+Zm/QfvmbjGPKxsG0MRcHDA4wZVry843iZcTkkN40mfi+LOELaRcuGyaPBtplFIw=="],
+    "@tscircuit/fake-snippets": ["@tscircuit/fake-snippets@0.0.128", "", {}, "sha512-HKRFpJZL3stHrTuYrRN3JCSJHrzvUBx3tHHr4jYkNbo+cYSpOZDMvh+PzhwYG9OSm9pox71Hl2Aq6dXAtFgnuw=="],
 
     "@tscircuit/file-server": ["@tscircuit/file-server@0.0.32", "", { "dependencies": { "winterspec": "^0.0.86", "zod": "^3.23.8", "zustand": "^4.5.5", "zustand-hoist": "^2.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "file-server": "dist/cli.js" } }, "sha512-RQDYRjwENDvVK/p0Wtw5rWCZAW2ZL2iKYspEhFr/oWiOC54brtQnL4udgwvyibE0qJxg8v3xR0AxOoebn3HeAA=="],
 
@@ -387,7 +387,7 @@
 
     "circuit-json-to-tscircuit": ["circuit-json-to-tscircuit@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-2B4E3kOU9zFbJ6SyCKcp9ktlay/Xf2gbLuGcWE8rBL3uuypJU3uX4MFjHVfwx8cbvB/0LTF5v3gHTYbxpiZMOg=="],
 
-    "circuit-to-svg": ["circuit-to-svg@0.0.230", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" } }, "sha512-rEIHa0D2khvWhQZ8X+4Smv83k1F0bUj0f4bfgnToOJrD7LPFFPlQhPGmdvg9oWDt8VvWR5K3djL80f5nMkHpXQ=="],
+    "circuit-to-svg": ["circuit-to-svg@0.0.238", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" } }, "sha512-gRLKDhj/PrbFu+xMNRJqbU0C9l8HrZiFNebG1o9hs6GdpTf+H93nR/BltzQNHNXULGEO1NG+cgMeFahGMuBSbQ=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -1068,8 +1068,6 @@
     "tscircuit/circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.7", "", { "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-wasm"] }, "sha512-MbTAxzqgcfKho0veYceEM2LamAmIqax1rG2cnR6MhnEowDLFPO8Sd2qoXStqDbWADXQpIglJ0NdICTu8igUvFg=="],
 
     "tscircuit/circuit-json-to-spice": ["circuit-json-to-spice@0.0.14", "", { "dependencies": { "@tscircuit/soup-util": "^0.0.41", "circuit-json": "^0.0.274", "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-rgnPOgX55sqIlXEVwRVJEq5pB9bHVWKbY//oS0M0O0VXZaESdD2aQmapfEIth01qHL5aXxVm+aC1eoL0/jM5DQ=="],
-
-    "tscircuit/circuit-to-svg": ["circuit-to-svg@0.0.238", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" } }, "sha512-gRLKDhj/PrbFu+xMNRJqbU0C9l8HrZiFNebG1o9hs6GdpTf+H93nR/BltzQNHNXULGEO1NG+cgMeFahGMuBSbQ=="],
 
     "tscircuit/poppygl": ["poppygl@0.0.6", "", { "dependencies": { "gl-matrix": "^3.4.4", "pureimage": "^0.4.18", "readable-stream": "^4.7.0" }, "peerDependencies": { "typescript": "^5" } }, "sha512-q5y6X/S2zFVktAT8mSlzzuxCjOOpwPxWEy5bYfnJkaJmCJ+fWM3vVjE6Acgt5TLyL1l72E/Qlq2zBNIa1wqqNQ=="],
 

--- a/cli/clone/clone-bug-report.ts
+++ b/cli/clone/clone-bug-report.ts
@@ -1,0 +1,129 @@
+import JSZip from "jszip"
+import { getRegistryApiKy } from "lib/registry-api/get-ky"
+import { generateTsConfig } from "lib/shared/generate-ts-config"
+import { setupTsciProject } from "lib/shared/setup-tsci-packages"
+import kleur from "kleur"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { handleExistingDirectory } from "./handle-existing-directory"
+
+const getCommonDirectoryPrefix = (paths: string[]) => {
+  if (paths.length === 0) return ""
+  const splitPaths = paths.map((p) => p.split("/").filter(Boolean))
+  const minLength = Math.min(
+    ...splitPaths.map((parts) => (parts.length === 0 ? 0 : parts.length)),
+  )
+  const commonSegments: string[] = []
+
+  for (let i = 0; i < Math.max(0, minLength - 1); i++) {
+    const segment = splitPaths[0][i]
+    if (!segment) break
+    const allMatch = splitPaths.every((parts) => parts[i] === segment)
+    if (!allMatch) break
+    commonSegments.push(segment)
+  }
+
+  return commonSegments.join("/")
+}
+
+const sanitizeRelativePath = (relativePath: string) => {
+  const normalizedPath = path.normalize(relativePath)
+  if (!normalizedPath) return null
+  if (path.isAbsolute(normalizedPath)) return null
+  const segments = normalizedPath.split(path.sep)
+  if (segments.some((segment) => segment === ".." || segment === "")) {
+    return null
+  }
+  return normalizedPath
+}
+
+export const cloneBugReport = async ({
+  bugReportId,
+  originalCwd,
+}: {
+  bugReportId: string
+  originalCwd: string
+}) => {
+  const trimmedBugReportId = bugReportId.trim()
+
+  if (!trimmedBugReportId) {
+    console.error("Bug report ID must not be empty.")
+    process.exit(1)
+  }
+
+  const dirPath = path.resolve(`bug-report-${trimmedBugReportId}`)
+  await handleExistingDirectory(dirPath)
+
+  const ky = getRegistryApiKy()
+  let zipBuffer: ArrayBuffer
+  try {
+    zipBuffer = await ky
+      .get("bug_reports/download_zip", {
+        searchParams: {
+          bug_report_id: trimmedBugReportId,
+        },
+      })
+      .arrayBuffer()
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "status" in error &&
+      (error as any).status === 404
+    ) {
+      console.error(
+        `Bug report "${trimmedBugReportId}" not found. Please check the ID and try again.`,
+      )
+    } else {
+      console.error(
+        "Failed to download bug report:",
+        error instanceof Error ? error.message : error,
+      )
+    }
+    process.exit(1)
+  }
+
+  fs.mkdirSync(dirPath, { recursive: true })
+
+  const zip = await JSZip.loadAsync(zipBuffer)
+  const fileEntries = Object.entries(zip.files).filter(
+    ([, entry]) => !entry.dir,
+  )
+  const commonPrefix = getCommonDirectoryPrefix(
+    fileEntries.map(([fileName]) => fileName),
+  )
+
+  for (const [fileName, entry] of fileEntries) {
+    const prefixWithSlash = commonPrefix ? `${commonPrefix}/` : ""
+    const withoutPrefix = fileName.startsWith(prefixWithSlash)
+      ? fileName.slice(prefixWithSlash.length)
+      : fileName
+    const sanitizedRelativePath = sanitizeRelativePath(withoutPrefix)
+
+    if (!sanitizedRelativePath) {
+      console.warn(`Skipping potentially unsafe path: ${fileName}`)
+      continue
+    }
+
+    const fullPath = path.join(dirPath, sanitizedRelativePath)
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+    const fileContent = await entry.async("nodebuffer")
+    fs.writeFileSync(fullPath, fileContent)
+  }
+
+  fs.writeFileSync(
+    path.join(dirPath, ".npmrc"),
+    "@tsci:registry=https://npm.tscircuit.com",
+  )
+
+  generateTsConfig(dirPath)
+  await setupTsciProject(dirPath)
+
+  const relativeDirPath = path.relative(originalCwd, dirPath)
+
+  console.log(kleur.green("\nSuccessfully cloned bug report to:"))
+  console.log(`  ${dirPath}/\n`)
+  console.log(kleur.bold("Start reviewing:"))
+  console.log(kleur.cyan(`  cd ${relativeDirPath}`))
+  console.log(kleur.cyan("  tsci dev\n"))
+}

--- a/cli/clone/handle-existing-directory.ts
+++ b/cli/clone/handle-existing-directory.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+export const handleExistingDirectory = async (dirPath: string) => {
+  if (!fs.existsSync(dirPath)) return
+
+  const prompts = await import("prompts")
+  const response = await prompts.default({
+    type: "select",
+    name: "action",
+    message: `Directory "${path.basename(dirPath)}" already exists. What would you like to do?`,
+    choices: [
+      { title: "Merge files into existing directory", value: "merge" },
+      {
+        title: "Delete existing directory and clone fresh",
+        value: "delete",
+      },
+      { title: "Cancel", value: "cancel" },
+    ],
+  })
+
+  if (!response.action || response.action === "cancel") {
+    console.log("Clone cancelled.")
+    process.exit(0)
+  }
+
+  if (response.action === "delete") {
+    fs.rmSync(dirPath, { recursive: true, force: true })
+    console.log(`Deleted existing directory: ${dirPath}`)
+  } else if (response.action === "merge") {
+    console.log(`Merging files into existing directory: ${dirPath}`)
+  }
+}

--- a/cli/clone/handle-existing-directory.ts
+++ b/cli/clone/handle-existing-directory.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
+import prompts from "prompts"
 
 export const handleExistingDirectory = async (dirPath: string) => {
   if (!fs.existsSync(dirPath)) return
 
-  const prompts = await import("prompts")
-  const response = await prompts.default({
+  const response = await prompts({
     type: "select",
     name: "action",
     message: `Directory "${path.basename(dirPath)}" already exists. What would you like to do?`,

--- a/cli/clone/register.ts
+++ b/cli/clone/register.ts
@@ -6,33 +6,53 @@ import { setupTsciProject } from "lib/shared/setup-tsci-packages"
 import { generateTsConfig } from "lib/shared/generate-ts-config"
 import kleur from "kleur"
 import { cliConfig } from "lib/cli-config"
+import { cloneBugReport } from "./clone-bug-report"
+import { handleExistingDirectory } from "./handle-existing-directory"
 
 export const registerClone = (program: Command) => {
   program
     .command("clone")
     .description("Clone a package from the registry")
     .argument(
-      "<package>",
+      "[package]",
       "Package to clone (e.g. author/packageName or https://tscircuit.com/author/packageName)",
     )
     .option("-a, --include-author", "Include author name in the directory path")
+    .option("--bug-report <bugReportId>", "Clone a bug report project")
     .action(
-      async (packagePath: string, options: { includeAuthor?: boolean }) => {
+      async (
+        packagePath: string | undefined,
+        options: { includeAuthor?: boolean; bugReport?: string },
+      ) => {
         // First try to match URL format (strict tscircuit.com only)
+        const originalCwd = process.cwd()
+
+        if (options.bugReport) {
+          if (packagePath) {
+            console.warn(
+              "Package argument is ignored when --bug-report is provided.",
+            )
+          }
+          await cloneBugReport({
+            bugReportId: options.bugReport,
+            originalCwd,
+          })
+          return
+        }
+
+        if (!packagePath) {
+          console.error(
+            "Package argument is required unless --bug-report is provided.",
+          )
+          process.exit(1)
+        }
+
         const urlMatch = packagePath.match(
           /^https:\/\/tscircuit\.com\/([^\/]+)\/([^\/]+)\/?$/i,
         )
         // Then try the original format
         const originalMatch =
           !urlMatch && packagePath.match(/^(?:@tsci\/)?([^/.]+)[/.]([^/.]+)$/)
-        const originalCwd = process.cwd()
-
-        if (!urlMatch && !originalMatch) {
-          console.error(
-            `Invalid package path "${packagePath}". Accepted formats:\n - author/packageName\n - author.packageName \n - @tsci/author.packageName\n - https://tscircuit.com/author/packageName`,
-          )
-          process.exit(1)
-        }
 
         const match = urlMatch || originalMatch
         if (!match) throw new Error("No valid match found") // Should never happen due to earlier check
@@ -45,34 +65,7 @@ export const registerClone = (program: Command) => {
           : path.resolve(packageName)
 
         // Check if directory already exists
-        if (fs.existsSync(dirPath)) {
-          const prompts = await import("prompts")
-          const response = await prompts.default({
-            type: "select",
-            name: "action",
-            message: `Directory "${path.basename(dirPath)}" already exists. What would you like to do?`,
-            choices: [
-              { title: "Merge files into existing directory", value: "merge" },
-              {
-                title: "Delete existing directory and clone fresh",
-                value: "delete",
-              },
-              { title: "Cancel", value: "cancel" },
-            ],
-          })
-
-          if (!response.action || response.action === "cancel") {
-            console.log("Clone cancelled.")
-            process.exit(0)
-          }
-
-          if (response.action === "delete") {
-            fs.rmSync(dirPath, { recursive: true, force: true })
-            console.log(`Deleted existing directory: ${dirPath}`)
-          } else if (response.action === "merge") {
-            console.log(`Merging files into existing directory: ${dirPath}`)
-          }
-        }
+        await handleExistingDirectory(dirPath)
         const ky = getRegistryApiKy()
         let packageFileList: { package_files: Array<{ file_path: string }> } = {
           package_files: [],
@@ -147,7 +140,7 @@ export const registerClone = (program: Command) => {
         )
 
         generateTsConfig(dirPath)
-        setupTsciProject(dirPath)
+        await setupTsciProject(dirPath)
 
         const relativeDirPath = path.relative(originalCwd, dirPath)
 

--- a/cli/clone/register.ts
+++ b/cli/clone/register.ts
@@ -55,7 +55,12 @@ export const registerClone = (program: Command) => {
           !urlMatch && packagePath.match(/^(?:@tsci\/)?([^/.]+)[/.]([^/.]+)$/)
 
         const match = urlMatch || originalMatch
-        if (!match) throw new Error("No valid match found") // Should never happen due to earlier check
+        if (!match) {
+          console.error(
+            "Invalid package path. Please use author/packageName or https://tscircuit.com/author/packageName.",
+          )
+          process.exit(1)
+        }
         const [, author, packageName] = match
         console.log(`Cloning ${author}/${packageName}...`)
         const userSettingToIncludeAuthor =

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/standalone": "^7.26.9",
     "@biomejs/biome": "^1.9.4",
     "@tscircuit/circuit-json-util": "0.0.67",
-    "@tscircuit/fake-snippets": "^0.0.110",
+    "@tscircuit/fake-snippets": "^0.0.128",
     "@tscircuit/file-server": "^0.0.32",
     "@tscircuit/math-utils": "0.0.21",
     "@tscircuit/props": "^0.0.371",


### PR DESCRIPTION
## Summary
- extract the bug report clone workflow into a dedicated `cloneBugReport` helper
- share the existing-directory prompt between package and bug-report clones
- keep the clone command handler focused on dispatching between package and bug report flows

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68fbe98d94e8832eb903eb4e27f2a9f7