### PR TITLE
Add CLAUDE.md generation during tsci init

### DIFF
--- a/cli/init/register.ts
+++ b/cli/init/register.ts
@@ -94,6 +94,34 @@ export default () => (
 `,
       )
 
+      try {
+        const response = await fetch(
+          "https://raw.githubusercontent.com/tscircuit/tscircuit-prompts/main/lib/prompts/tscircuit-syntax.ts",
+        )
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch CLAUDE.md content: ${response.status}`,
+          )
+        }
+
+        let claudeContent = await response.text()
+        const firstBacktick = claudeContent.indexOf("`")
+        const lastBacktick = claudeContent.lastIndexOf("`")
+        if (
+          firstBacktick !== -1 &&
+          lastBacktick !== -1 &&
+          lastBacktick > firstBacktick
+        ) {
+          claudeContent = claudeContent.slice(firstBacktick + 1, lastBacktick)
+        }
+
+        fs.writeFileSync(path.join(projectDir, "CLAUDE.md"), claudeContent)
+      } catch (error) {
+        console.warn(
+          `⚠️  Unable to create CLAUDE.md from remote source: ${(error as Error).message}`,
+        )
+      }
+
       const projectConfig = loadProjectConfig(projectDir) ?? {}
       projectConfig.mainEntrypoint = "index.tsx"
       if (saveProjectConfig(projectConfig, projectDir)) {

--- a/tests/cli/init/init.test.ts
+++ b/tests/cli/init/init.test.ts
@@ -28,6 +28,25 @@ test("init command installs @types/react and passes type-checking", async () => 
   const tsconfigExists = await Bun.file(tsconfigPath).exists()
   expect(tsconfigExists).toBeTrue()
 
+  const claudePath = join(tmpDir, projectDir, "CLAUDE.md")
+  const claudeExists = await Bun.file(claudePath).exists()
+  expect(claudeExists).toBeTrue()
+
+  const claudeContent = await Bun.file(claudePath).text()
+  const remoteResponse = await fetch(
+    "https://raw.githubusercontent.com/tscircuit/tscircuit-prompts/main/lib/prompts/tscircuit-syntax.ts",
+  )
+  expect(remoteResponse.ok).toBeTrue()
+  const remoteText = await remoteResponse.text()
+  const firstTick = remoteText.indexOf("`")
+  const lastTick = remoteText.lastIndexOf("`")
+  const expectedClaudeContent =
+    firstTick !== -1 && lastTick !== -1 && lastTick > firstTick
+      ? remoteText.slice(firstTick + 1, lastTick)
+      : remoteText
+
+  expect(claudeContent).toBe(expectedClaudeContent)
+
   try {
     const typeCheckResult = execSync("bunx tsc --noEmit", {
       cwd: join(tmpDir, projectDir),
@@ -39,4 +58,4 @@ test("init command installs @types/react and passes type-checking", async () => 
       `Type-checking failed for init'd project. ${tmpDir}/${projectDir} ${(error as any).toString()}`,
     )
   }
-}, 10_000)
+}, 20_000)

--- a/tests/test2-cli-init.test.ts
+++ b/tests/test2-cli-init.test.ts
@@ -14,6 +14,7 @@ test("basic init", async () => {
   const expectedFiles = [
     ".gitignore",
     ".npmrc",
+    "CLAUDE.md",
     "index.tsx",
     "package.json",
     "tsconfig.json",
@@ -22,4 +23,4 @@ test("basic init", async () => {
   for (const file of expectedFiles) {
     expect(dirContents).toContain(file)
   }
-}, 10_000)
+}, 20_000)


### PR DESCRIPTION
## Summary
- fetch the latest CLAUDE.md content during `tsci init` and write it into the new project
- verify the generated CLAUDE.md file in the init test suite and allow more time for installs

## Testing
- bun test tests/cli/init/init.test.ts
- bun test tests/test2-cli-init.test.ts
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690d1e6a1188832e889c06ed66588006)