### PR TITLE
Document export formats in help

### DIFF
--- a/cli/export/register.ts
+++ b/cli/export/register.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander"
 import { exportSnippet } from "lib/shared/export-snippet"
 import type { ExportFormat } from "lib/shared/export-snippet"
+import { ALLOWED_EXPORT_FORMATS } from "lib/shared/export-snippet"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { getSpiceWithPaddedSim } from "lib/shared/get-spice-with-sim"
 import { runSimulation } from "lib/eecircuit-engine/run-simulation"
@@ -14,7 +15,10 @@ export const registerExport = (program: Command) => {
     .command("export")
     .description("Export tscircuit code to various formats")
     .argument("<file>", "Path to the package file")
-    .option("-f, --format <format>", "Output format")
+    .option(
+      "-f, --format <format>",
+      `Output format (${ALLOWED_EXPORT_FORMATS.join(", ")})`,
+    )
     .option("-o, --output <path>", "Output file path")
     .option("--disable-parts-engine", "Disable the parts engine")
     .action(

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -18,7 +18,7 @@ import type { PlatformConfig } from "@tscircuit/props"
 
 const writeFileAsync = promisify(fs.writeFile)
 
-const ALLOWED_FORMATS = [
+export const ALLOWED_EXPORT_FORMATS = [
   "json",
   "circuit-json",
   "schematic-svg",
@@ -33,7 +33,7 @@ const ALLOWED_FORMATS = [
   "kicad_zip",
 ] as const
 
-export type ExportFormat = (typeof ALLOWED_FORMATS)[number]
+export type ExportFormat = (typeof ALLOWED_EXPORT_FORMATS)[number]
 
 const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   json: ".circuit.json",
@@ -74,7 +74,7 @@ export const exportSnippet = async ({
   onError = (message) => console.error(message),
   onSuccess = (result: unknown) => console.log(result),
 }: ExportOptions) => {
-  if (!ALLOWED_FORMATS.includes(format)) {
+  if (!ALLOWED_EXPORT_FORMATS.includes(format)) {
     onError(`Invalid format: ${format}`)
     return onExit(1)
   }


### PR DESCRIPTION
## Summary
- export the list of allowed export formats so it can be re-used
- show the allowed formats in the `tsci export` help text so users can see their options

## Testing
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ba04b26a4832e89ce630431b59cec)