### PR TITLE
Ensure tsconfig types and dev warning

### DIFF
--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -31,6 +31,27 @@ const findSelectableTsxFiles = (projectDir: string): string[] => {
     .sort()
 }
 
+const warnIfTsconfigMissingTscircuitType = (projectDir: string) => {
+  const tsconfigPath = path.join(projectDir, "tsconfig.json")
+  if (!fs.existsSync(tsconfigPath)) {
+    return
+  }
+
+  try {
+    const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, "utf-8"))
+    const types = tsconfig?.compilerOptions?.types
+    if (!Array.isArray(types) || !types.includes("tscircuit")) {
+      console.warn(
+        kleur.yellow(
+          'Warning: "tscircuit" is missing from tsconfig.json compilerOptions.types. Add it (e.g. "types": ["tscircuit"]) to ensure CLI-provided types work correctly.',
+        ),
+      )
+    }
+  } catch {
+    // ignore JSON parse errors here; other parts of the CLI will surface them if needed
+  }
+}
+
 export const registerDev = (program: Command) => {
   program
     .command("dev")
@@ -91,6 +112,8 @@ export const registerDev = (program: Command) => {
           )
         }
       }
+
+      warnIfTsconfigMissingTscircuitType(process.cwd())
 
       try {
         process.stdout.write(

--- a/tests/cli/init/init.test.ts
+++ b/tests/cli/init/init.test.ts
@@ -28,6 +28,11 @@ test("init command installs @types/react and passes type-checking", async () => 
   const tsconfigExists = await Bun.file(tsconfigPath).exists()
   expect(tsconfigExists).toBeTrue()
 
+  const tsconfig = await Bun.file(tsconfigPath).json()
+  expect(tsconfig?.compilerOptions?.types).toEqual(
+    expect.arrayContaining(["tscircuit"]),
+  )
+
   try {
     const typeCheckResult = execSync("bunx tsc --noEmit", {
       cwd: join(tmpDir, projectDir),
@@ -39,4 +44,4 @@ test("init command installs @types/react and passes type-checking", async () => 
       `Type-checking failed for init'd project. ${tmpDir}/${projectDir} ${(error as any).toString()}`,
     )
   }
-}, 10_000)
+}, 30_000)


### PR DESCRIPTION
## Summary
- add coverage to the init CLI test to assert the generated tsconfig includes the `tscircuit` type definition
- emit a yellow warning from `tsci dev` when the project's tsconfig is missing the `tscircuit` type so users can fix it proactively

## Testing
- bun test tests/cli/init/init.test.ts
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691bc6598504832eb616111da790f8b7)