### PR TITLE
Improve type reexport error messaging

### DIFF
--- a/tests/cli/build/build-type-reexport.test.ts
+++ b/tests/cli/build/build-type-reexport.test.ts
@@ -49,4 +49,7 @@ test("build fails when re-exporting a type alias without type modifier", async (
   const { stderr } = await runCommand("tsci build")
 
   expect(stderr).toContain("SyntaxError: export 'ExampleType' not found")
+  expect(stderr).toContain(
+    'export type { ExampleType } from "./lib/src/globals"',
+  )
 })


### PR DESCRIPTION
## Summary
- add a targeted hint when the build fails because a type-only export was re-exported without the `type` modifier
- update the CLI build test to assert that the new guidance is emitted alongside Bun's SyntaxError output

## Testing
- bun test tests/cli/build/build-type-reexport.test.ts
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691cc9c101bc832eb9152560c8922924)