### PR TITLE
Static asset handling in transpilation

### DIFF
--- a/cli/build/transpile/static-asset-plugin.ts
+++ b/cli/build/transpile/static-asset-plugin.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs"
+import path from "node:path"
+import { createHash } from "node:crypto"
+
+export const STATIC_ASSET_EXTENSIONS = new Set([
+  ".glb",
+  ".gltf",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".svg",
+  ".webp",
+  ".gif",
+  ".bmp",
+  ".step",
+  ".kicad_mod",
+  ".kicad_pcb",
+  ".kicad_pro",
+  ".kicad_sch",
+])
+
+export const createStaticAssetPlugin = ({
+  outputDir,
+}: {
+  outputDir: string
+}) => {
+  const copiedAssets = new Map<string, string>()
+  return {
+    name: "tsci-static-assets",
+    load(id: string) {
+      const ext = path.extname(id).toLowerCase()
+      if (!STATIC_ASSET_EXTENSIONS.has(ext)) return null
+
+      const assetDir = path.join(outputDir, "assets")
+      fs.mkdirSync(assetDir, { recursive: true })
+
+      const fileBuffer = fs.readFileSync(id)
+      const hash = createHash("sha1")
+        .update(fileBuffer)
+        .digest("hex")
+        .slice(0, 8)
+      const fileName = `${path.basename(id, ext)}-${hash}${ext}`
+      const outputPath = path.join(assetDir, fileName)
+
+      if (!copiedAssets.has(id)) {
+        fs.writeFileSync(outputPath, fileBuffer)
+        copiedAssets.set(id, outputPath)
+      }
+
+      const relativePath = `./assets/${fileName}`
+      return `export default ${JSON.stringify(relativePath)};`
+    },
+  }
+}

--- a/cli/transpile/register.ts
+++ b/cli/transpile/register.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander"
 import path from "node:path"
-import { transpileFile } from "../build/transpile"
+import { transpileFile } from "../build/transpile/index"
 import { getBuildEntrypoints } from "../build/get-build-entrypoints"
 
 export const registerTranspile = (program: Command) => {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
   },
   "files": [
     "dist",
-    "cli/entrypoint.js"
+    "cli/entrypoint.js",
+    "types"
   ],
   "scripts": {
     "start": "bun run dev",

--- a/tests/cli/transpile/transpile-static-assets.test.ts
+++ b/tests/cli/transpile/transpile-static-assets.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { writeFile, readFile, readdir } from "node:fs/promises"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { CircuitRunner } from "tscircuit"
+
+const glbCircuitCode = `
+import cadModelUrl from "./chip.glb"
+
+export default () => (
+  <board width="20mm" height="20mm">
+    <chip
+      name="H1"
+      footprint="soic8"
+      cadModel={<cadmodel modelUrl={cadModelUrl} />}
+    />
+  </board>
+)
+`
+
+test("transpile copies static assets and preserves glb_model_url", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "glb-test.tsx")
+  const glbPath = path.join(tmpDir, "chip.glb")
+
+  const glbBytes = Buffer.from([0x67, 0x6c, 0x54, 0x46, 0x01, 0x00, 0x00, 0x00])
+
+  await writeFile(circuitPath, glbCircuitCode)
+  await writeFile(glbPath, glbBytes)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci transpile ${circuitPath}`)
+
+  const assetsDir = path.join(tmpDir, "dist", "assets")
+  const assetFiles = await readdir(assetsDir)
+  const copiedGlb = assetFiles.find((file) => file.endsWith(".glb"))
+  expect(copiedGlb).toBeDefined()
+
+  const copiedContent = await readFile(path.join(assetsDir, copiedGlb!))
+  const originalContent = await readFile(glbPath)
+  expect(copiedContent.equals(originalContent)).toBe(true)
+
+  const moduleUrl = pathToFileURL(path.join(tmpDir, "dist", "index.js")).href
+  const transpiledModule = await import(moduleUrl)
+  const Component = transpiledModule.default
+  expect(typeof Component).toBe("function")
+
+  const runner = new CircuitRunner()
+  try {
+    await runner.executeComponent(Component)
+    await runner.renderUntilSettled()
+    const circuitJson = await runner.getCircuitJson()
+    const cadComponent = circuitJson.find(
+      (element: any) => element.type === "cad_component",
+    )
+    const expectedAssetPath = `./assets/${copiedGlb}`
+    const cadComponentWithGlb = cadComponent as
+      | { glb_model_url?: string; model_glb_url?: string }
+      | undefined
+    const glbUrl =
+      cadComponentWithGlb?.glb_model_url ?? cadComponentWithGlb?.model_glb_url
+    expect(glbUrl).toBe(expectedAssetPath)
+  } finally {
+    await runner.kill()
+  }
+}, 60_000)

--- a/types/static-assets/index.d.ts
+++ b/types/static-assets/index.d.ts
@@ -1,0 +1,69 @@
+declare module "*.glb" {
+  const src: string
+  export default src
+}
+
+declare module "*.gltf" {
+  const src: string
+  export default src
+}
+
+declare module "*.png" {
+  const src: string
+  export default src
+}
+
+declare module "*.jpg" {
+  const src: string
+  export default src
+}
+
+declare module "*.jpeg" {
+  const src: string
+  export default src
+}
+
+declare module "*.svg" {
+  const src: string
+  export default src
+}
+
+declare module "*.gif" {
+  const src: string
+  export default src
+}
+
+declare module "*.webp" {
+  const src: string
+  export default src
+}
+
+declare module "*.bmp" {
+  const src: string
+  export default src
+}
+
+declare module "*.step" {
+  const src: string
+  export default src
+}
+
+declare module "*.kicad_mod" {
+  const src: string
+  export default src
+}
+
+declare module "*.kicad_pcb" {
+  const src: string
+  export default src
+}
+
+declare module "*.kicad_pro" {
+  const src: string
+  export default src
+}
+
+declare module "*.kicad_sch" {
+  const src: string
+  export default src
+}


### PR DESCRIPTION
## Summary
- move the transpile build logic into cli/build/transpile with a dedicated static asset Rollup plugin that recognizes CAD assets
- extend the bundled static-asset module declarations so new CAD-related extensions are accepted by TypeScript
- split the GLB/static-asset transpile regression into its own test file to exercise the new plugin

## Testing
- bun test tests/cli/transpile
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691d1d77d880832e8ddc6788dccec5da)