### PR TITLE
Prefer local CLI when available

### DIFF
--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process"
-import { fileURLToPath } from "node:url"
+import { existsSync, readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
+import { createRequire } from "node:module"
+import { fileURLToPath } from "node:url"
 
 function commandExists(cmd) {
   try {
@@ -12,10 +14,34 @@ function commandExists(cmd) {
   }
 }
 
-const runner = commandExists("bun") ? "bun" : "tsx"
-
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const mainPath = join(__dirname, "../dist/main.js")
+const require = createRequire(import.meta.url)
+
+const currentPackagePath = join(__dirname, "../package.json")
+let mainPath = join(__dirname, "../dist/main.js")
+
+try {
+  const localPackagePath = require.resolve("@tscircuit/cli/package.json", {
+    paths: [process.cwd()],
+  })
+
+  if (localPackagePath !== currentPackagePath) {
+    const localPackageJson = JSON.parse(readFileSync(localPackagePath, "utf-8"))
+    const globalPackageJson = JSON.parse(
+      readFileSync(currentPackagePath, "utf-8"),
+    )
+    const localMainPath = join(dirname(localPackagePath), "dist/main.js")
+
+    if (existsSync(localMainPath)) {
+      console.warn(
+        `Using local @tscircuit/cli v${localPackageJson.version} instead of global v${globalPackageJson.version}`,
+      )
+      mainPath = localMainPath
+    }
+  }
+} catch {}
+
+const runner = commandExists("bun") ? "bun" : "tsx"
 
 const { status } = spawnSync(runner, [mainPath, ...process.argv.slice(2)], {
   stdio: "inherit",

--- a/tests/entrypoint-local-resolution.test.ts
+++ b/tests/entrypoint-local-resolution.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+
+const GLOBAL_VERSION = JSON.parse(
+  readFileSync(path.join(process.cwd(), "package.json"), "utf-8"),
+).version
+
+test("entrypoint prefers local cli installation when available", () => {
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), "tsci-entrypoint-"))
+  const localCliDir = path.join(tmpDir, "node_modules", "@tscircuit", "cli")
+
+  try {
+    mkdirSync(path.join(localCliDir, "dist"), { recursive: true })
+
+    writeFileSync(
+      path.join(localCliDir, "package.json"),
+      JSON.stringify({ name: "@tscircuit/cli", version: "9.9.9" }),
+    )
+
+    writeFileSync(
+      path.join(localCliDir, "dist", "main.js"),
+      'console.log("LOCAL CLI EXECUTED")\n',
+    )
+
+    const entrypointPath = path.join(process.cwd(), "cli", "entrypoint.js")
+    const result = spawnSync("node", [entrypointPath], {
+      cwd: tmpDir,
+      encoding: "utf-8",
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("LOCAL CLI EXECUTED")
+    expect(result.stderr).toContain(
+      `Using local @tscircuit/cli v9.9.9 instead of global v${GLOBAL_VERSION}`,
+    )
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- prefer the local @tscircuit/cli installation from the project when available
- warn when the local CLI is used, showing both local and global versions
- add a regression test ensuring the entrypoint resolves the local CLI

## Testing
- bunx tsc --noEmit
- bun test tests/entrypoint-local-resolution.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924fe92bc44832ea1176b8325303cd0)