### PR TITLE
Add bun link integration test for transpiled packages

### DIFF
--- a/tests/cli/transpile/transpile-bun-link.test.ts
+++ b/tests/cli/transpile/transpile-bun-link.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { temporaryDirectory } from "tempy"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const runShellCommand = async (
+  command: string,
+  cwd: string,
+  env: Record<string, string> = {},
+) => {
+  const [bin, ...args] = command.split(" ")
+  const task = Bun.spawn([bin, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      ...env,
+      FORCE_COLOR: "0",
+      NODE_ENV: "test",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  const stdout = await new Response(task.stdout).text()
+  const stderr = await new Response(task.stderr).text()
+
+  if (task.exitCode !== 0) {
+    throw new Error(`Command failed (${command}): ${stderr || stdout}`)
+  }
+
+  return { stdout, stderr }
+}
+
+test("tsci transpile output can be consumed via bun link", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const producerDir = path.join(tmpDir, "producer-package")
+  const consumerDir = temporaryDirectory()
+
+  await mkdir(producerDir, { recursive: true })
+  await mkdir(consumerDir, { recursive: true })
+
+  const producerEntry = path.join(producerDir, "index.ts")
+
+  await writeFile(
+    producerEntry,
+    `export const linkedValue = 42
+
+export default () => linkedValue
+`,
+  )
+
+  await writeFile(
+    path.join(producerDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "linked-transpile-package",
+        version: "1.0.0",
+        main: "dist/index.cjs",
+        module: "dist/index.js",
+        types: "dist/index.d.ts",
+      },
+      null,
+      2,
+    ),
+  )
+
+  await runCommand(`tsci transpile ${producerEntry}`, {
+    cwd: producerDir,
+    env: { NODE_PATH: path.resolve(process.cwd(), "node_modules") },
+  })
+  await runShellCommand("bun link", producerDir)
+
+  await writeFile(
+    path.join(consumerDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "linked-consumer",
+        version: "1.0.0",
+      },
+      null,
+      2,
+    ),
+  )
+
+  await runShellCommand("bun link linked-transpile-package", consumerDir)
+
+  const consumerEntry = path.join(consumerDir, "use-linked.ts")
+
+  await writeFile(
+    consumerEntry,
+    `import linkedDefault from "linked-transpile-package"
+
+export const useLinkedValue = () => linkedDefault()
+`,
+  )
+
+  const imported = await import(pathToFileURL(consumerEntry).href)
+
+  expect(typeof imported.useLinkedValue).toBe("function")
+
+  const distIndex = path.join(
+    consumerDir,
+    "node_modules",
+    "linked-transpile-package",
+    "dist",
+    "index.js",
+  )
+  const transpiledOutput = await readFile(distIndex, "utf-8")
+  expect(transpiledOutput).toContain("linkedValue")
+}, 60_000)

--- a/tests/fixtures/get-cli-test-fixture.ts
+++ b/tests/fixtures/get-cli-test-fixture.ts
@@ -11,7 +11,10 @@ import * as path from "node:path"
 
 export interface CliTestFixture {
   tmpDir: string
-  runCommand: (command: string) => Promise<{ stdout: string; stderr: string }>
+  runCommand: (
+    command: string,
+    options?: { cwd?: string; env?: Record<string, string> },
+  ) => Promise<{ stdout: string; stderr: string }>
   registryServer: any
   registryDb: DbClient
   registryApiUrl: string
@@ -77,7 +80,10 @@ export async function getCliTestFixture(
   }
 
   // Create command runner
-  const runCommand = async (command: string) => {
+  const runCommand = async (
+    command: string,
+    options: { cwd?: string; env?: Record<string, string> } = {},
+  ) => {
     const args = command.split(" ")
     if (args[0] !== "tsci") {
       throw new Error(
@@ -89,6 +95,7 @@ export async function getCliTestFixture(
     // Set test mode environment variable
     const env = {
       ...process.env,
+      ...options.env,
       TSCI_TEST_MODE: "true",
       FORCE_COLOR: "0",
       NODE_ENV: "test",
@@ -99,7 +106,7 @@ export async function getCliTestFixture(
     let stderr = ""
 
     const task = Bun.spawn(["bun", ...args], {
-      cwd: tmpDir,
+      cwd: options.cwd ?? tmpDir,
       stdout: "pipe",
       stderr: "pipe",
       env,


### PR DESCRIPTION
## Summary
- allow CLI test runner to override working directory and environment
- add integration test covering bun linking of a transpiled package into another project

## Testing
- bun test tests/cli/transpile/transpile-bun-link.test.ts
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692500684c90832e8766f3132f4335c0)