### PR TITLE
Prefer local @tscircuit/cli when available

### DIFF
--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -25,10 +25,11 @@ const globalPackageJson = require("../package.json")
 let mainPath = join(packageRoot, "dist/main.js")
 
 try {
-  const localPackageJsonPath = require.resolve("@tscircuit/cli/package.json", {
-    paths: [process.cwd()],
-  })
-  const localPackageJson = require(localPackageJsonPath)
+  const localRequire = createRequire(join(process.cwd(), "package.json"))
+  const localPackageJsonPath = localRequire.resolve(
+    "@tscircuit/cli/package.json",
+  )
+  const localPackageJson = localRequire(localPackageJsonPath)
   const localPackageRoot = dirname(localPackageJsonPath)
   const localMainPath = join(localPackageRoot, "dist/main.js")
 


### PR DESCRIPTION
## Summary
- resolve @tscircuit/cli using a require tied to the current working directory so local installs are preferred
- keep warning and execution paths pointing at the local build when it differs from the global install

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692533e22950832ebe631575b7119d43)