### PR TITLE
Enforce dist main for transpile

### DIFF
--- a/cli/transpile/register.ts
+++ b/cli/transpile/register.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander"
+import fs from "node:fs"
 import path from "node:path"
 import { transpileFile } from "../build/transpile/index"
 import { getBuildEntrypoints } from "../build/get-build-entrypoints"
@@ -18,6 +19,26 @@ export const registerTranspile = (program: Command) => {
           })
 
         const distDir = path.join(projectDir, "dist")
+
+        const packageJsonPath = path.join(projectDir, "package.json")
+        if (fs.existsSync(packageJsonPath)) {
+          const packageJson = JSON.parse(
+            fs.readFileSync(packageJsonPath, "utf-8"),
+          )
+
+          if (typeof packageJson.main === "string") {
+            const resolvedMainPath = path.resolve(projectDir, packageJson.main)
+            const isMainInDist =
+              resolvedMainPath === distDir ||
+              resolvedMainPath.startsWith(`${distDir}${path.sep}`)
+
+            if (!isMainInDist) {
+              throw new Error(
+                'When using transpilation, your package\'s "main" field should point inside the `dist/*` directory, usually to "dist/index.js"',
+              )
+            }
+          }
+        }
 
         console.log("Transpiling entry file...")
         const entryFile = mainEntrypoint || circuitFiles[0]

--- a/tests/cli/transpile/transpile.test.ts
+++ b/tests/cli/transpile/transpile.test.ts
@@ -48,7 +48,7 @@ test("transpile uses mainEntrypoint when available", async () => {
   await writeFile(otherPath, circuitCode)
   await writeFile(
     path.join(tmpDir, "package.json"),
-    JSON.stringify({ main: "index.tsx" }),
+    JSON.stringify({ main: "dist/index.js" }),
   )
 
   await runCommand(`tsci transpile`)
@@ -65,6 +65,23 @@ test("transpile uses mainEntrypoint when available", async () => {
   const dtsPath = path.join(tmpDir, "dist", "index.d.ts")
   const dtsStat = await stat(dtsPath)
   expect(dtsStat.isFile()).toBe(true)
+}, 30_000)
+
+test("transpile errors when main is outside dist", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const mainPath = path.join(tmpDir, "index.tsx")
+
+  await writeFile(mainPath, circuitCode)
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ main: "index.tsx" }),
+  )
+
+  const { stderr } = await runCommand(`tsci transpile`)
+
+  expect(stderr).toContain(
+    'When using transpilation, your package\'s "main" field should point inside the `dist/*` directory, usually to "dist/index.js"',
+  )
 }, 30_000)
 
 test("transpile transforms JSX correctly", async () => {


### PR DESCRIPTION
## Summary
- validate that package.json main points inside the dist directory before running transpilation
- add a clear error message when main is outside dist
- update transpile tests to require dist-based main entries and cover the failure case

## Testing
- bunx tsc --noEmit
- bun test tests/cli/transpile/transpile.test.ts
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69260dcde198832eb1bc6d52cb11d6ee)