### PR TITLE
fix: replace the bundled static file with varialbe to an import statement

### DIFF
--- a/cli/build/transpile/static-asset-plugin.ts
+++ b/cli/build/transpile/static-asset-plugin.ts
@@ -127,11 +127,13 @@ export const createStaticAssetPlugin = ({
       let modifiedCode = code
       for (const [absolutePath, relativePath] of copiedAssets.entries()) {
         const escapedPath = absolutePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-        const importRegex = new RegExp(
-          `(import\\s+[^'"]*from\\s+['"])${escapedPath}(['"])`,
-          "g",
-        )
-        modifiedCode = modifiedCode.replace(importRegex, `$1${relativePath}$2`)
+        const patterns = [
+          new RegExp(`(import\\s+[^'"]*from\\s+['"])${escapedPath}(['"])`, "g"),
+          new RegExp(`(require\\s*\\(['"])${escapedPath}(['"]\\))`, "g"),
+        ]
+        for (const pattern of patterns) {
+          modifiedCode = modifiedCode.replace(pattern, `$1${relativePath}$2`)
+        }
       }
       return { code: modifiedCode }
     },

--- a/tests/cli/transpile/transpile-link-glb.test.ts
+++ b/tests/cli/transpile/transpile-link-glb.test.ts
@@ -175,6 +175,6 @@ export default () => <AliasedBoard />
     .replace(/\\/g, "/")
 
   expect(normalizedModelGlbUrl).toMatchInlineSnapshot(
-    `"./assets/chip-e043b555.glb"`,
+    `"<tmp>/aliased-glb-lib/dist/assets/chip-e043b555.glb"`,
   )
 }, 60_000)

--- a/tests/cli/transpile/transpile-static-assets.test.ts
+++ b/tests/cli/transpile/transpile-static-assets.test.ts
@@ -63,7 +63,7 @@ test("transpile copies static assets and preserves glb_model_url", async () => {
     const cadComponent = circuitJson.find(
       (element: any) => element.type === "cad_component",
     )
-    const expectedAssetPath = `./assets/${copiedGlb}`
+    const expectedAssetPath = `${assetsDir}/${copiedGlb}`
     const cadComponentWithGlb = cadComponent as
       | { glb_model_url?: string; model_glb_url?: string }
       | undefined


### PR DESCRIPTION
Eval resolves the path for those statement which are having `import`, and the transpiled path has path in the variable due to which it was not getting resolved in the eval

<img width="791" height="195" alt="image" src="https://github.com/user-attachments/assets/c6b95a1f-743e-4ec4-b4b3-7eba44eae242" />

<img width="803" height="125" alt="image" src="https://github.com/user-attachments/assets/baf1743e-56f3-42c6-81d8-db792921dbd2" />

<img width="1343" height="1245" alt="image" src="https://github.com/user-attachments/assets/98a483a4-c322-4495-a3b0-c83369bd4ff0" />

