### PR TITLE
refactor: execution in entrypoint.js 

### DIFF
--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -37,7 +37,7 @@ if (!useGlobal) {
 
 const { status } = spawnSync(
   process.execPath,
-  [mainPath, ...process.argv.slice(2)],
+  [mainPath, ...args],
   {
     stdio: "inherit",
   },

--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -35,12 +35,8 @@ if (!useGlobal) {
   } catch {}
 }
 
-const { status } = spawnSync(
-  process.execPath,
-  [mainPath, ...args],
-  {
-    stdio: "inherit",
-  },
-)
+const { status } = spawnSync(process.execPath, [mainPath, ...args], {
+  stdio: "inherit",
+})
 
 process.exit(status ?? 0)

--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -5,17 +5,6 @@ import { createRequire } from "node:module"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
-function commandExists(cmd) {
-  try {
-    const res = spawnSync(cmd, ["--version"], { stdio: "ignore" })
-    return res.status === 0
-  } catch {
-    return false
-  }
-}
-
-const runner = commandExists("bun") ? "bun" : "tsx"
-
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const packageRoot = join(__dirname, "..")
 const require = createRequire(import.meta.url)
@@ -41,8 +30,12 @@ try {
   }
 } catch {}
 
-const { status } = spawnSync(runner, [mainPath, ...process.argv.slice(2)], {
-  stdio: "inherit",
-})
+const { status } = spawnSync(
+  process.execPath,
+  [mainPath, ...process.argv.slice(2)],
+  {
+    stdio: "inherit",
+  },
+)
 
 process.exit(status ?? 0)


### PR DESCRIPTION
Since dist/main.js is compiled JavaScript (built with target: "node"), it runs directly with Node.js - no bun or tsx needed. Using process.execPath ensures it uses the exact Node.js that's already running the entrypoint.|
|
might fix this
<img width="820" height="294" alt="image" src="https://github.com/user-attachments/assets/82d059ab-68a5-4172-ae19-40481cae966b" />
