### PR TITLE
Upload direct dependency node_modules files

### DIFF
--- a/lib/dependency-analysis/getNodeModuleDependencies.ts
+++ b/lib/dependency-analysis/getNodeModuleDependencies.ts
@@ -508,6 +508,21 @@ export function getAllNodeModuleFilePaths(
     projectDir,
   )
 
+  // Ensure all direct dependencies are included even if not imported
+  for (const packageName of allDependencyPackages) {
+    if (dependencies.has(packageName)) continue
+
+    const resolvedFiles = resolveNodeModuleImport({
+      importPath: packageName,
+      projectDir,
+      searchFromDir: entryFilePath,
+    })
+
+    if (resolvedFiles.length > 0) {
+      dependencies.set(packageName, resolvedFiles)
+    }
+  }
+
   const processedPackages = new Set<string>()
   const allFiles = new Set<string>()
 


### PR DESCRIPTION
## Summary
- ensure direct dependencies from package.json are resolved and uploaded even when not imported
- add coverage verifying npm dependencies are sent to the file server without explicit imports

## Testing
- bunx tsc --noEmit
- bun test tests/cli/dev/node-modules-upload-with-deps.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e13202ee8832e81a9edaf3683603b)