### PR TITLE
Bundle dependencies during transpile command

### DIFF
--- a/tests/cli/transpile/transpile-dependencies.test.ts
+++ b/tests/cli/transpile/transpile-dependencies.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test"
+import { readFile, symlink, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("transpile bundles dependencies except for tscircuit", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "with-deps.ts")
+
+  await writeFile(
+    circuitPath,
+    `import kleur from "kleur"
+import * as tscircuit from "tscircuit"
+
+export const coloredText = kleur.red("ok")
+export const usesTscircuit = () =>
+  typeof tscircuit === "object" ? "tscircuit-present" : "missing"
+`,
+  )
+
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await symlink(
+    path.resolve(process.cwd(), "node_modules"),
+    path.join(tmpDir, "node_modules"),
+    "dir",
+  )
+
+  await runCommand(`tsci transpile ${circuitPath}`)
+
+  const esmPath = path.join(tmpDir, "dist", "index.js")
+  const esmContent = await readFile(esmPath, "utf-8")
+
+  expect(esmContent).toMatch(/from ['\"]tscircuit['\"]/)
+  expect(esmContent).not.toContain('from "kleur"')
+  expect(esmContent).not.toContain('require("kleur")')
+  expect(esmContent).toContain("tscircuit-present")
+}, 30_000)


### PR DESCRIPTION
## Summary
- ensure transpile bundling includes third-party dependencies while keeping tscircuit and node built-ins external
- add coverage verifying transpiled output bundles dependencies but leaves tscircuit external

## Testing
- bun test tests/cli/transpile/transpile-dependencies.test.ts
- bunx tsc --noEmit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e6a7e34f4832eb996ded06095473f)