### PR TITLE
Fix kicad_mod files not uploading to the file server

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/cli",
@@ -58,7 +59,7 @@
         "semver": "^7.6.3",
         "sharp": "0.32.6",
         "tempy": "^3.1.0",
-        "tscircuit": "^0.0.997-libonly",
+        "tscircuit": "^0.0.1000-libonly",
         "tsx": "^4.7.1",
         "typed-ky": "^0.0.4",
         "zod": "^3.23.8",
@@ -281,7 +282,7 @@
 
     "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.67", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-ErTCyrW/zOBq+Ulqan8weUNNgcJNpelJ7gIq2G3OZGcI3xUrZBB+BE7oZeritvDtG1ofKrVMgvHTnENdxXjIug=="],
 
-    "@tscircuit/cli": ["@tscircuit/cli@0.1.587", "", { "peerDependencies": { "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-RJTSc1Nnd2r5nsMQT0he7Xd+UeevHquaG+brBIFf0vfcWcnq3UIObN6oNHXlYbNV6jkH+Xi1OA46DrTcaOB9kA=="],
+    "@tscircuit/cli": ["@tscircuit/cli@0.1.590", "", { "peerDependencies": { "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-TWUNLe36KR8h1VuMGGPMJ+/0Mr/sKs+iMP5pe7cyOVBRvQkJ99UvNSPHnoGNv34I3TUVSXZdL1tHG0Q9BPOhUQ=="],
 
     "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.14", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-kOZfgMXo/jw6G+b3JilhdPYVnfBespChkA542GsLNzR79bB+tn/zdR8tfsqCr/qvHMPG34tELr/XrUhvNOagVw=="],
 
@@ -1027,7 +1028,7 @@
 
     "ts-morph": ["ts-morph@21.0.1", "", { "dependencies": { "@ts-morph/common": "~0.22.0", "code-block-writer": "^12.0.0" } }, "sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg=="],
 
-    "tscircuit": ["tscircuit@0.0.997", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "@resvg/resvg-js": "^2.6.2", "@rollup/plugin-commonjs": "^29.0.0", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.3", "@rollup/plugin-typescript": "^12.3.0", "@tscircuit/capacity-autorouter": "^0.0.140", "@tscircuit/checks": "^0.0.87", "@tscircuit/circuit-json-flex": "^0.0.3", "@tscircuit/circuit-json-util": "^0.0.72", "@tscircuit/cli": "^0.1.587", "@tscircuit/copper-pour-solver": "^0.0.14", "@tscircuit/core": "^0.0.893", "@tscircuit/eval": "^0.0.509", "@tscircuit/footprinter": "^0.0.236", "@tscircuit/infgrid-ijump-astar": "^0.0.33", "@tscircuit/matchpack": "^0.0.16", "@tscircuit/math-utils": "^0.0.29", "@tscircuit/miniflex": "^0.0.4", "@tscircuit/ngspice-spice-engine": "^0.0.4", "@tscircuit/props": "^0.0.423", "@tscircuit/runframe": "^0.0.1324", "@tscircuit/schematic-match-adapt": "^0.0.16", "@tscircuit/schematic-trace-solver": "^v0.0.45", "@tscircuit/simple-3d-svg": "^0.0.41", "@tscircuit/solver-utils": "^0.0.3", "bpc-graph": "^0.0.57", "calculate-elbow": "^0.0.12", "calculate-packing": "0.0.62", "circuit-json": "^0.0.325", "circuit-json-to-bpc": "^0.0.13", "circuit-json-to-connectivity-map": "^0.0.22", "circuit-json-to-gltf": "^0.0.31", "circuit-json-to-simple-3d": "^0.0.9", "circuit-json-to-spice": "^0.0.27", "circuit-to-svg": "^0.0.280", "comlink": "^4.4.2", "connectivity-map": "^1.0.0", "css-select": "5.1.0", "debug": "^4.3.6", "flatbush": "^4.5.0", "format-si-unit": "^0.0.3", "graphics-debug": "^0.0.60", "jscad-planner": "^0.0.13", "kicad-component-converter": "^0.1.30", "kicad-to-circuit-json": "^0.0.15", "kicadts": "^0.0.22", "minicssgrid": "^0.0.9", "performance-now": "^2.1.0", "poppygl": "^0.0.16", "react": "^19.1.0", "react-dom": "^19.1.0", "rollup": "^4.53.2", "rollup-plugin-dts": "^6.2.3", "s-expression": "^3.1.1", "schematic-symbols": "^0.0.202", "spicey": "^0.0.14", "sucrase": "^3.35.0", "transformation-matrix": "^2.16.1", "zod": "^3.25.67" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "tsci": "cli.mjs", "tscircuit": "cli.mjs" } }, "sha512-ob3oVC5kMXK7l4CAirF4Ugydx1sDEgrq3hmhL6cNj86ELtMDRl/U1/eLUH0fJ3cHEmt/AwaqDBfpVou+Qfij9Q=="],
+    "tscircuit": ["tscircuit@0.0.1000", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "@resvg/resvg-js": "^2.6.2", "@rollup/plugin-commonjs": "^29.0.0", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.3", "@rollup/plugin-typescript": "^12.3.0", "@tscircuit/capacity-autorouter": "^0.0.140", "@tscircuit/checks": "^0.0.87", "@tscircuit/circuit-json-flex": "^0.0.3", "@tscircuit/circuit-json-util": "^0.0.72", "@tscircuit/cli": "^0.1.590", "@tscircuit/copper-pour-solver": "^0.0.14", "@tscircuit/core": "^0.0.893", "@tscircuit/eval": "^0.0.509", "@tscircuit/footprinter": "^0.0.236", "@tscircuit/infgrid-ijump-astar": "^0.0.33", "@tscircuit/matchpack": "^0.0.16", "@tscircuit/math-utils": "^0.0.29", "@tscircuit/miniflex": "^0.0.4", "@tscircuit/ngspice-spice-engine": "^0.0.4", "@tscircuit/props": "^0.0.423", "@tscircuit/runframe": "^0.0.1325", "@tscircuit/schematic-match-adapt": "^0.0.16", "@tscircuit/schematic-trace-solver": "^v0.0.45", "@tscircuit/simple-3d-svg": "^0.0.41", "@tscircuit/solver-utils": "^0.0.3", "bpc-graph": "^0.0.57", "calculate-elbow": "^0.0.12", "calculate-packing": "0.0.62", "circuit-json": "^0.0.325", "circuit-json-to-bpc": "^0.0.13", "circuit-json-to-connectivity-map": "^0.0.22", "circuit-json-to-gltf": "^0.0.31", "circuit-json-to-simple-3d": "^0.0.9", "circuit-json-to-spice": "^0.0.27", "circuit-to-svg": "^0.0.280", "comlink": "^4.4.2", "connectivity-map": "^1.0.0", "css-select": "5.1.0", "debug": "^4.3.6", "flatbush": "^4.5.0", "format-si-unit": "^0.0.3", "graphics-debug": "^0.0.60", "jscad-planner": "^0.0.13", "kicad-component-converter": "^0.1.30", "kicad-to-circuit-json": "^0.0.15", "kicadts": "^0.0.22", "minicssgrid": "^0.0.9", "performance-now": "^2.1.0", "poppygl": "^0.0.16", "react": "^19.1.0", "react-dom": "^19.1.0", "rollup": "^4.53.2", "rollup-plugin-dts": "^6.2.3", "s-expression": "^3.1.1", "schematic-symbols": "^0.0.202", "spicey": "^0.0.14", "sucrase": "^3.35.0", "transformation-matrix": "^2.16.1", "zod": "^3.25.67" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "tsci": "cli.mjs", "tscircuit": "cli.mjs" } }, "sha512-TSiM+7QBLHwM3YV+HEzz+ZOPCGdiItqvik0xt96IM2s9bwXK/ozzEbqoYC+n3wtWMcOxjQWNWqDezvXs5EfZDA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1174,6 +1175,8 @@
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "tscircuit/@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.72", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-8KqdPYz1Q+rYgPuP9VBBxusLgq0MmpVw4FjLORNHYr2qfWmM1m/1OQEokZHZZZLTUbfcn86zUOcv69+LqHa0FA=="],
+
+    "tscircuit/@tscircuit/runframe": ["@tscircuit/runframe@0.0.1325", "", {}, "sha512-8XsdC6i064y2R3Jx5NZL0SFXXQMdGBDfGGHSOomeA4veq936dlZs9NMErNEA8uL7OODaQZFs1LsB20Vin43B1w=="],
 
     "tscircuit/@tscircuit/schematic-match-adapt": ["@tscircuit/schematic-match-adapt@0.0.16", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-85e6Pq58zrhZqivyW4bPVZfGfg8xLBCj3yjHl5LZslwfsDRgtWVob4bjJMhCfNL/mLsPUQKnpiDNnFKl9ugUZw=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "semver": "^7.6.3",
     "sharp": "0.32.6",
     "tempy": "^3.1.0",
-    "tscircuit": "^0.0.997-libonly",
+    "tscircuit": "^0.0.1000-libonly",
     "tsx": "^4.7.1",
     "typed-ky": "^0.0.4",
     "zod": "^3.23.8"

--- a/tests/cli/dev/node-modules-github-package.test.ts
+++ b/tests/cli/dev/node-modules-github-package.test.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "bun:test"
+import { DevServer } from "../../../cli/dev/DevServer"
+import * as path from "node:path"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import ky from "ky"
+import getPort from "get-port"
+
+/**
+ * This test reproduces a bug where packages installed from GitHub URLs
+ * (e.g., `tsci install https://github.com/espressif/kicad-libraries`)
+ * don't have their files uploaded to the dev server.
+ *
+ * The issue is that when a KiCad library is installed from GitHub, the repository
+ * typically does NOT have a package.json file (it's a KiCad library, not an npm package).
+ * This causes the CLI to fail to:
+ * 1. Recognize the package as needing to be uploaded
+ * 2. Collect files from the package directory
+ *
+ * This causes imports like:
+ *   import kicadMod from "kicad-libraries/footprints/Espressif.pretty/ESP32-S2-MINI-1.kicad_mod"
+ * to fail with:
+ *   "Node module has no files in the node_modules directory"
+ */
+
+/**
+ * BUG REPRODUCTION TEST
+ *
+ * This test reproduces the actual bug: when a KiCad library is installed from GitHub,
+ * the repository does NOT have a package.json file. The CLI fails to upload the files
+ * because resolveNodeModuleImport() returns empty when there's no package.json.
+ */
+test(
+  "BUG: DevServer fails to upload GitHub packages WITHOUT package.json (like real kicad-libraries)",
+  async () => {
+    // Create a temporary directory for testing
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "tsci-test-github-no-pkgjson-"),
+    )
+
+    try {
+      // Create package.json with a GitHub URL dependency
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({
+          name: "test-project",
+          version: "1.0.0",
+          dependencies: {
+            "kicad-libraries": "https://github.com/espressif/kicad-libraries",
+          },
+        }),
+      )
+
+      // Create node_modules structure WITHOUT package.json in the kicad-libraries folder
+      // This matches the real kicad-libraries repo structure
+      const nodeModulesDir = path.join(tmpDir, "node_modules")
+      const kicadLibDir = path.join(nodeModulesDir, "kicad-libraries")
+      const footprintsDir = path.join(
+        kicadLibDir,
+        "footprints",
+        "Espressif.pretty",
+      )
+      fs.mkdirSync(footprintsDir, { recursive: true })
+
+      // NO package.json in kicad-libraries - this is the bug!
+      // Real kicad-libraries repo doesn't have package.json
+
+      // Create a .kicad_mod file
+      const kicadModContent = `(module ESP32-S2-MINI-1 (layer F.Cu)
+  (fp_text reference REF** (at 0 -1) (layer F.SilkS))
+  (fp_text value ESP32-S2-MINI-1 (at 0 1) (layer F.Fab))
+  (pad 1 smd rect (at -7.5 -4.5) (size 0.9 0.5) (layers F.Cu F.Paste F.Mask))
+)`
+      fs.writeFileSync(
+        path.join(footprintsDir, "ESP32-S2-MINI-1.kicad_mod"),
+        kicadModContent,
+      )
+
+      // Create a component that imports from the kicad-libraries package
+      const componentPath = path.join(tmpDir, "index.tsx")
+      fs.writeFileSync(
+        componentPath,
+        `import kicadMod from "kicad-libraries/footprints/Espressif.pretty/ESP32-S2-MINI-1.kicad_mod"
+
+export default () => {
+  return (
+    <board width="20mm" height="20mm">
+      <chip footprint={kicadMod} name="U1" />
+    </board>
+  )
+}`,
+      )
+
+      // Start the dev server
+      const port = await getPort()
+      const devServer = new DevServer({
+        port,
+        componentFilePath: componentPath,
+        projectDir: tmpDir,
+      })
+
+      await devServer.start()
+
+      // Wait for files to upload
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      // Check if node_modules files were uploaded
+      const fsKy = ky.create({ prefixUrl: `http://localhost:${port}` }) as any
+
+      const fileListResponse = await fsKy.get("api/files/list").json()
+      const fileList = fileListResponse.file_list as Array<{
+        file_id: string
+        file_path: string
+      }>
+
+      // Debug: print all uploaded files
+      console.log(
+        "Uploaded files:",
+        fileList.map((f) => f.file_path),
+      )
+
+      // BUG: The .kicad_mod file should be uploaded but it's NOT because
+      // there's no package.json in the kicad-libraries folder
+      const esp32S2ModFile = fileList.find((f) =>
+        f.file_path.includes(
+          "node_modules/kicad-libraries/footprints/Espressif.pretty/ESP32-S2-MINI-1.kicad_mod",
+        ),
+      )
+
+      console.log("esp32S2ModFile:", esp32S2ModFile)
+
+      // This assertion currently FAILS - proving the bug exists
+      expect(esp32S2ModFile).toBeDefined()
+
+      await devServer.stop()
+    } finally {
+      // Cleanup
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  },
+  { timeout: 10_000 },
+)


### PR DESCRIPTION
Test result before the fix:
<img width="1160" height="750" alt="image" src="https://github.com/user-attachments/assets/ddbbebb0-2a01-4e2f-af55-8b2f49cfb5b3" />

The bug: When a package installed from GitHub URL (like kicad-libraries) doesn't have a package.json file in its directory, the CLI fails to upload its files to the dev server.

Output shows: Found 0 node_modules files to upload - meaning the CLI didn't detect any node_modules files to upload, even though kicad-libraries is in the dependencies and its files exist.

Result: Only index.tsx and package.json (project files) are uploaded, but the .kicad_mod file from node_modules/kicad-libraries/ is NOT uploaded.

Root cause: The resolveNodeModuleImport() function in getNodeModuleDependencies.ts returns empty when there's no package.json in the package directory, causing collectLocalPackageFiles() to never be called for that package.


After the fix:
<img width="1171" height="588" alt="image" src="https://github.com/user-attachments/assets/3644985c-949d-4f79-bd07-df45bf03789b" />
