### PR TITLE
refactor and remove the local package check which looked for `link`, `yalc` or `file:`

### DIFF
--- a/lib/utils/collectPackageFiles.ts
+++ b/lib/utils/collectPackageFiles.ts
@@ -1,0 +1,45 @@
+import path from "node:path"
+import fs from "node:fs"
+import { walkDirectory } from "./walkDirectory"
+
+/**
+ * Directories that should be excluded when collecting package files
+ */
+const EXCLUDED_DIRECTORIES = new Set([
+  "node_modules",
+  ".git",
+  ".next",
+  ".turbo",
+  "coverage",
+  ".cache",
+  "tmp",
+  "temp",
+])
+
+/**
+ * Collects all files from a package directory.
+ * Prioritizes transpiled files (dist/, build/) over source files to avoid
+ * path alias resolution issues in the browser.
+ */
+export function collectPackageFiles(packageDir: string): string[] {
+  const buildDirs = ["dist", "build"]
+
+  // Check build directories first
+  for (const dirName of buildDirs) {
+    const dirPath = path.join(packageDir, dirName)
+    if (fs.existsSync(dirPath)) {
+      const files = walkDirectory(dirPath, new Set())
+      if (files.length > 0) {
+        // Also include package.json for metadata if it exists
+        const packageJsonPath = path.join(packageDir, "package.json")
+        if (fs.existsSync(packageJsonPath)) {
+          files.push(packageJsonPath)
+        }
+        return files
+      }
+    }
+  }
+
+  // Fall back to collecting all source files (excluding build directories)
+  return walkDirectory(packageDir, EXCLUDED_DIRECTORIES)
+}

--- a/lib/utils/findPackageDir.ts
+++ b/lib/utils/findPackageDir.ts
@@ -1,0 +1,45 @@
+import path from "node:path"
+import fs from "node:fs"
+
+/**
+ * Finds the package directory in node_modules for a given package name.
+ * Searches in the project's node_modules and parent directories for hoisted packages.
+ */
+export function findPackageDir({
+  packageName,
+  projectDir,
+  searchFromDir,
+}: {
+  packageName: string
+  projectDir: string
+  searchFromDir?: string
+}): string | undefined {
+  const searchPaths: string[] = [
+    path.join(projectDir, "node_modules", packageName),
+  ]
+
+  if (searchFromDir) {
+    // Walk up the directory tree from searchFromDir to find node_modules
+    let currentDir = path.dirname(searchFromDir)
+    const projectDirNormalized = path.normalize(projectDir)
+
+    while (currentDir.startsWith(projectDirNormalized)) {
+      const candidatePath = path.join(currentDir, "node_modules", packageName)
+      if (!searchPaths.includes(candidatePath)) {
+        searchPaths.push(candidatePath)
+      }
+
+      const parentDir = path.dirname(currentDir)
+      if (parentDir === currentDir) break
+      currentDir = parentDir
+    }
+  }
+
+  for (const candidatePath of searchPaths) {
+    if (fs.existsSync(candidatePath)) {
+      return candidatePath
+    }
+  }
+
+  return undefined
+}

--- a/lib/utils/findPackageDirFromResolvedFile.ts
+++ b/lib/utils/findPackageDirFromResolvedFile.ts
@@ -1,0 +1,33 @@
+import path from "node:path"
+import fs from "node:fs"
+
+/**
+ * Finds the package directory from a resolved file path by walking up
+ * and looking for a package.json with a matching name.
+ */
+export function findPackageDirFromResolvedFile(
+  resolvedFile: string,
+  packageName: string,
+): string | undefined {
+  let packageDir = path.dirname(resolvedFile)
+
+  while (packageDir.includes("node_modules")) {
+    const packageJsonPath = path.join(packageDir, "package.json")
+    if (fs.existsSync(packageJsonPath)) {
+      try {
+        const pkgJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
+        if (pkgJson.name === packageName) {
+          return packageDir
+        }
+      } catch {
+        // Continue searching
+      }
+    }
+
+    const nextParentDir = path.dirname(packageDir)
+    if (nextParentDir === packageDir) break
+    packageDir = nextParentDir
+  }
+
+  return undefined
+}

--- a/lib/utils/getAllDependencyPackages.ts
+++ b/lib/utils/getAllDependencyPackages.ts
@@ -1,0 +1,27 @@
+import path from "node:path"
+import fs from "node:fs"
+
+/**
+ * Gets all dependency package names from a project's package.json
+ */
+export function getAllDependencyPackages(projectDir: string): Set<string> {
+  const packageJsonPath = path.join(projectDir, "package.json")
+  const allPackages = new Set<string>()
+
+  if (!fs.existsSync(packageJsonPath)) {
+    return allPackages
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
+    const deps = packageJson.dependencies || {}
+
+    for (const packageName of Object.keys(deps)) {
+      allPackages.add(packageName)
+    }
+  } catch (error) {
+    console.warn("Failed to parse package.json for dependencies:", error)
+  }
+
+  return allPackages
+}

--- a/lib/utils/getPackageNameFromFilePath.ts
+++ b/lib/utils/getPackageNameFromFilePath.ts
@@ -1,0 +1,29 @@
+import path from "node:path"
+
+/**
+ * Extracts the package name from a file path inside node_modules.
+ * Returns null if the file is not inside node_modules.
+ *
+ * e.g., "/project/node_modules/react/index.js" -> "react"
+ * e.g., "/project/node_modules/@tscircuit/core/dist/index.js" -> "@tscircuit/core"
+ */
+export function getPackageNameFromFilePath(filePath: string): string | null {
+  const normalizedPath = path.normalize(filePath)
+  const pathSegments = normalizedPath.split(path.sep)
+
+  // Find the last node_modules occurrence
+  for (let i = pathSegments.length - 1; i >= 0; i--) {
+    if (pathSegments[i] === "node_modules") {
+      const nextSegment = pathSegments[i + 1]
+      if (!nextSegment) return null
+
+      if (nextSegment.startsWith("@") && pathSegments[i + 2]) {
+        // Scoped package: @scope/package
+        return `${nextSegment}/${pathSegments[i + 2]}`
+      }
+      return nextSegment
+    }
+  }
+
+  return null
+}

--- a/lib/utils/getPackageNameFromImport.ts
+++ b/lib/utils/getPackageNameFromImport.ts
@@ -1,0 +1,14 @@
+/**
+ * Extracts the package name from an import path
+ * e.g., "react/jsx-runtime" -> "react"
+ * e.g., "@tscircuit/core/components" -> "@tscircuit/core"
+ */
+export function getPackageNameFromImport(importPath: string): string {
+  if (importPath.startsWith("@")) {
+    // Scoped package
+    const parts = importPath.split("/")
+    return `${parts[0]}/${parts[1]}`
+  }
+  // Regular package
+  return importPath.split("/")[0]
+}

--- a/lib/utils/isRuntimeProvidedPackage.ts
+++ b/lib/utils/isRuntimeProvidedPackage.ts
@@ -1,0 +1,30 @@
+/**
+ * Packages that are provided by the runtime and should not be uploaded.
+ * These are available in the browser environment.
+ */
+export const RUNTIME_PROVIDED_PACKAGES = new Set([
+  "react",
+  "react-dom",
+  "react/jsx-runtime",
+  "tscircuit",
+  "@tscircuit/core",
+  "@tscircuit/props",
+])
+
+/**
+ * Check if a package is provided by the runtime and should not be uploaded
+ */
+export function isRuntimeProvidedPackage(packageName: string): boolean {
+  if (RUNTIME_PROVIDED_PACKAGES.has(packageName)) {
+    return true
+  }
+
+  // Check if it's a subpath of a runtime package (e.g., "react/jsx-runtime")
+  for (const runtimePkg of Array.from(RUNTIME_PROVIDED_PACKAGES)) {
+    if (packageName.startsWith(`${runtimePkg}/`)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/lib/utils/walkDirectory.ts
+++ b/lib/utils/walkDirectory.ts
@@ -1,0 +1,46 @@
+import path from "node:path"
+import fs from "node:fs"
+
+/**
+ * Directories that should be excluded when collecting package files
+ */
+const EXCLUDED_DIRECTORIES = new Set([
+  "node_modules",
+  ".git",
+  ".next",
+  ".turbo",
+  "coverage",
+  ".cache",
+  "tmp",
+  "temp",
+])
+
+/**
+ * Recursively walks a directory and collects all file paths.
+ * Skips directories in the excluded set.
+ */
+export function walkDirectory(
+  dir: string,
+  excludedDirs: Set<string> = EXCLUDED_DIRECTORIES,
+): string[] {
+  const files: string[] = []
+
+  if (!fs.existsSync(dir)) return files
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      if (excludedDirs.has(entry.name)) {
+        continue
+      }
+      files.push(...walkDirectory(fullPath, excludedDirs))
+    } else if (entry.isFile()) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}

--- a/tests/cli/dev/node-modules-upload-with-deps.test.ts
+++ b/tests/cli/dev/node-modules-upload-with-deps.test.ts
@@ -6,13 +6,14 @@ import * as os from "node:os"
 import ky from "ky"
 
 test(
-  "DevServer uploads dependencies of yalc/bun link packages",
+  "DevServer uploads all explicit dependencies from package.json",
   async () => {
     // Create a temporary directory for testing
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsci-test-deps-"))
 
     try {
-      // Create package.json with a yalc package that has npm dependencies
+      // Create package.json with multiple dependencies
+      // All dependencies in package.json should be uploaded
       fs.writeFileSync(
         path.join(tmpDir, "package.json"),
         JSON.stringify({
@@ -20,6 +21,7 @@ test(
           version: "1.0.0",
           dependencies: {
             "my-local-lib": "file:.yalc/my-local-lib",
+            "is-even": "^1.0.0",
           },
         }),
       )
@@ -47,7 +49,7 @@ test(
 module.exports = { checkEven: isEven };`,
       )
 
-      // Create is-even package (dependency of my-local-lib)
+      // Create is-even package (also listed in dependencies)
       const isEvenDir = path.join(nodeModulesDir, "is-even")
       fs.mkdirSync(isEvenDir, { recursive: true })
 

--- a/tests/cli/dev/node-modules-upload.test.ts
+++ b/tests/cli/dev/node-modules-upload.test.ts
@@ -6,13 +6,13 @@ import * as os from "node:os"
 import ky from "ky"
 
 test(
-  "DevServer does NOT upload regular npm packages from node_modules",
+  "DevServer does NOT upload runtime-provided packages from node_modules",
   async () => {
     // Create a temporary directory for testing
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsci-test-"))
 
     try {
-      // Create a simple package.json with a regular npm package (no file: or .yalc)
+      // Create a simple package.json with a runtime-provided package (react)
       fs.writeFileSync(
         path.join(tmpDir, "package.json"),
         JSON.stringify({
@@ -72,7 +72,7 @@ test(
         file_path: string
       }>
 
-      // Check that react package.json was NOT uploaded (since it's not a local package)
+      // Check that react package.json was NOT uploaded (since it's runtime-provided)
       const reactPackageJson = fileList.find((f) =>
         f.file_path.includes("node_modules/react/package.json"),
       )
@@ -94,49 +94,48 @@ test(
 )
 
 test(
-  "DevServer uploads yalc packages from node_modules",
+  "DevServer uploads regular npm packages from node_modules",
   async () => {
     // Create a temporary directory for testing
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsci-test-yalc-"))
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsci-test-npm-"))
 
     try {
-      // Create a simple package.json
+      // Create a simple package.json with a regular npm package (not runtime-provided)
       fs.writeFileSync(
         path.join(tmpDir, "package.json"),
         JSON.stringify({
           name: "test-project",
           version: "1.0.0",
           dependencies: {
-            "@tscircuit/core": "file:.yalc/@tscircuit/core",
+            "test-package": "^1.0.0",
           },
         }),
       )
 
-      // Simulate yalc installing a package to node_modules
+      // Create node_modules with a minimal test package
       const nodeModulesDir = path.join(tmpDir, "node_modules")
-      const tscircuitDir = path.join(nodeModulesDir, "@tscircuit")
-      const coreDir = path.join(tscircuitDir, "core")
-      fs.mkdirSync(coreDir, { recursive: true })
+      const testPkgDir = path.join(nodeModulesDir, "test-package")
+      fs.mkdirSync(testPkgDir, { recursive: true })
 
       fs.writeFileSync(
-        path.join(coreDir, "package.json"),
+        path.join(testPkgDir, "package.json"),
         JSON.stringify({
-          name: "@tscircuit/core",
-          version: "0.0.1-local",
+          name: "test-package",
+          version: "1.0.0",
           main: "index.js",
         }),
       )
 
       fs.writeFileSync(
-        path.join(coreDir, "index.js"),
-        "module.exports = { createBoard: () => {} }",
+        path.join(testPkgDir, "index.js"),
+        "module.exports = { testFunction: () => {} }",
       )
 
-      // Create a component that imports from the yalc package
+      // Create a component that imports from the test package
       const componentPath = path.join(tmpDir, "component.tsx")
       fs.writeFileSync(
         componentPath,
-        `import { createBoard } from "@tscircuit/core"\n\nexport default createBoard`,
+        `import { testFunction } from "test-package"\n\nexport default () => <board width={10} height={10} />`,
       )
 
       // Start the dev server
@@ -161,17 +160,122 @@ test(
         file_path: string
       }>
 
-      // Check that @tscircuit/core package.json was uploaded
-      const corePackageJson = fileList.find((f) =>
-        f.file_path.includes("node_modules/@tscircuit/core/package.json"),
+      // Check that test-package package.json WAS uploaded
+      const testPackageJson = fileList.find((f) =>
+        f.file_path.includes("node_modules/test-package/package.json"),
       )
-      expect(corePackageJson).toBeDefined()
+      expect(testPackageJson).toBeDefined()
 
-      // Check that @tscircuit/core index.js was uploaded
-      const coreIndex = fileList.find((f) =>
-        f.file_path.includes("node_modules/@tscircuit/core/index.js"),
+      // Check that test-package index.js WAS uploaded
+      const testIndex = fileList.find((f) =>
+        f.file_path.includes("node_modules/test-package/index.js"),
       )
-      expect(coreIndex).toBeDefined()
+      expect(testIndex).toBeDefined()
+
+      await devServer.stop()
+    } finally {
+      // Cleanup
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  },
+  { timeout: 10_000 },
+)
+
+test(
+  "DevServer uploads symlinked (link:) packages from node_modules",
+  async () => {
+    // Create a temporary directory for testing
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsci-test-link-"))
+
+    try {
+      // Create a separate directory to simulate an external linked package
+      const externalPkgDir = path.join(
+        tmpDir,
+        "external-packages",
+        "my-linked-package",
+      )
+      fs.mkdirSync(externalPkgDir, { recursive: true })
+
+      fs.writeFileSync(
+        path.join(externalPkgDir, "package.json"),
+        JSON.stringify({
+          name: "my-linked-package",
+          version: "1.0.0",
+          main: "index.js",
+        }),
+      )
+
+      fs.writeFileSync(
+        path.join(externalPkgDir, "index.js"),
+        "module.exports = { linkedFunction: () => {} }",
+      )
+
+      // Create project with a link: dependency
+      const projectDir = path.join(tmpDir, "project")
+      fs.mkdirSync(projectDir, { recursive: true })
+
+      fs.writeFileSync(
+        path.join(projectDir, "package.json"),
+        JSON.stringify({
+          name: "test-project",
+          version: "1.0.0",
+          dependencies: {
+            "my-linked-package": "link:../external-packages/my-linked-package",
+          },
+        }),
+      )
+
+      // Create node_modules with a symlink to the external package
+      const nodeModulesDir = path.join(projectDir, "node_modules")
+      fs.mkdirSync(nodeModulesDir, { recursive: true })
+
+      // Create symlink in node_modules pointing to external package
+      fs.symlinkSync(
+        externalPkgDir,
+        path.join(nodeModulesDir, "my-linked-package"),
+        "dir",
+      )
+
+      // Create a component that imports from the linked package
+      const componentPath = path.join(projectDir, "component.tsx")
+      fs.writeFileSync(
+        componentPath,
+        `import { linkedFunction } from "my-linked-package"\n\nexport default () => <board width={10} height={10} />`,
+      )
+
+      // Start the dev server
+      const port = 8766 // Use a different port for testing
+      const devServer = new DevServer({
+        port,
+        componentFilePath: componentPath,
+        projectDir: projectDir,
+      })
+
+      await devServer.start()
+
+      // Wait a bit for files to upload
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      // Check if node_modules files were uploaded
+      const fsKy = ky.create({ prefixUrl: `http://localhost:${port}` }) as any
+
+      const fileListResponse = await fsKy.get("api/files/list").json()
+      const fileList = fileListResponse.file_list as Array<{
+        file_id: string
+        file_path: string
+      }>
+
+      // Check that my-linked-package package.json was uploaded
+      const pkgPackageJson = fileList.find((f) =>
+        f.file_path.includes("my-linked-package/package.json"),
+      )
+      expect(pkgPackageJson).toBeDefined()
+
+      // Check that my-linked-package index.js was uploaded
+      const pkgIndex = fileList.find((f) =>
+        f.file_path.includes("my-linked-package/index.js"),
+      )
+      expect(pkgIndex).toBeDefined()
 
       await devServer.stop()
     } finally {


### PR DESCRIPTION
Have separated out the methods used in the `getAllNodeModuleFilePaths` to make it more readable

DevServer now uploads all the packages listed in the package.json `dependencies`