### PR TITLE
Fix tsci search version display

### DIFF
--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -17,7 +17,8 @@ export const registerSearch = (program: Command) => {
       let results: {
         packages: Array<{
           name: string
-          version: string
+          version?: string
+          latest_version?: string | null
           description?: string
           star_count?: number
         }>
@@ -101,8 +102,9 @@ export const registerSearch = (program: Command) => {
 
         results.packages.forEach((pkg, idx) => {
           const star = pkg.star_count ?? 0
+          const version = pkg.version ?? pkg.latest_version ?? "unknown"
           console.log(
-            `${idx + 1}. ${pkg.name} (v${pkg.version}) - Stars: ${star}${
+            `${idx + 1}. ${pkg.name} (v${version}) - Stars: ${star}${
               pkg.description ? ` - ${pkg.description}` : ""
             }`,
           )

--- a/tests/cli/search/search.test.ts
+++ b/tests/cli/search/search.test.ts
@@ -10,3 +10,12 @@ test("search command returns registry and jlc results", async () => {
   expect(stdout).toContain("JLC search")
   expect(stdout.toLowerCase()).toContain("stars")
 })
+
+test("search shows latest package version when version is missing", async () => {
+  const { runCommand } = await getCliTestFixture()
+  const { stdout, stderr } = await runCommand("tsci search 555")
+
+  expect(stderr).toBe("")
+  expect(stdout).toContain("v0.0.1")
+  expect(stdout).not.toContain("vundefined")
+})


### PR DESCRIPTION
## Summary
- ensure `tsci search` displays a package version even when the registry omits the `version` field
- add a regression test to cover packages that only provide `latest_version`

## Testing
- bun test tests/cli/search/search.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f3d0d68ec83339bb84d7c928eecc5)