### PR TITLE
Add bug report test for STEP file loading issue

### DIFF
--- a/tests/bug-reports/bug-report-1a0fdc2b-step-file-loading-issue.test.tsx
+++ b/tests/bug-reports/bug-report-1a0fdc2b-step-file-loading-issue.test.tsx
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import { runBrowserTest } from "../fixtures/runBrowserTest"
+
+/**
+ * Bug report: 1a0fdc2b-2e84-41b9-ac01-520fd1195fdb
+ * Issue: STEP file included in the bug report fails to load/render correctly
+ *        when run through the dev server.
+ */
+test("STEP files from bug report 1a0fdc2b should load without execution errors", async () => {
+  const result = await runBrowserTest({
+    bugReportId: "1a0fdc2b-2e84-41b9-ac01-520fd1195fdb",
+    timeout: 120_000,
+  })
+
+  console.log("Render logs:", result.renderLogs)
+  console.log("Errors:", result.errors)
+  console.log("Has execution error:", result.hasExecutionError)
+
+  // TODO: Uncomment these expectations once the STEP file loading issue is fixed
+  // expect(result.hasExecutionError).toBe(false)
+  // expect(result.errors.length).toBe(0)
+}, 120_000)


### PR DESCRIPTION
## Summary
- add a bug report regression test for 1a0fdc2b covering STEP file loading
- log render output and outline expected assertions once the issue is fixed

## Testing
- bun test tests/bug-reports/bug-report-1a0fdc2b-step-file-loading-issue.test.tsx *(fails: test timeout while waiting for run completion)*
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f44d7e5d8832e91b2e8b3970207b0)