### PR TITLE
Revert "`tslib` is supplied in the execution context in eval"

### DIFF
--- a/lib/dependency-analysis/getNodeModuleDependencies.ts
+++ b/lib/dependency-analysis/getNodeModuleDependencies.ts
@@ -488,7 +488,6 @@ const RUNTIME_PROVIDED_PACKAGES = new Set([
   "tscircuit",
   "@tscircuit/core",
   "@tscircuit/props",
-  "tslib",
 ])
 
 /**


### PR DESCRIPTION
Reverts tscircuit/cli#1217