### PR TITLE
Handle `tsci search` shows undefined versions 

### DIFF
--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -101,8 +101,9 @@ export const registerSearch = (program: Command) => {
 
         results.packages.forEach((pkg, idx) => {
           const star = pkg.star_count ?? 0
+          const versionStr = pkg.version ? ` (v${pkg.version})` : ""
           console.log(
-            `${idx + 1}. ${pkg.name} (v${pkg.version}) - Stars: ${star}${
+            `${idx + 1}. ${pkg.name}${versionStr} - Stars: ${star}${
               pkg.description ? ` - ${pkg.description}` : ""
             }`,
           )

--- a/tests/cli/search/search-undefined-version.test.ts
+++ b/tests/cli/search/search-undefined-version.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+
+/**
+ * Test to verify that packages with undefined versions don't show "vundefined"
+ * This tests the fix for issue #1505
+ */
+test("search output does not show 'undefined' for missing version", () => {
+  // Simulate the output formatting logic from cli/search/register.ts
+  const formatPackageOutput = (
+    pkg: {
+      name: string
+      version?: string
+      star_count?: number
+      description?: string
+    },
+    idx: number,
+  ) => {
+    const star = pkg.star_count ?? 0
+    const versionStr = pkg.version ? ` (v${pkg.version})` : ""
+    return `${idx + 1}. ${pkg.name}${versionStr} - Stars: ${star}${
+      pkg.description ? ` - ${pkg.description}` : ""
+    }`
+  }
+
+  // Test package with version
+  const pkgWithVersion = {
+    name: "test/package",
+    version: "1.0.0",
+    star_count: 5,
+  }
+  const outputWithVersion = formatPackageOutput(pkgWithVersion, 0)
+  expect(outputWithVersion).toBe("1. test/package (v1.0.0) - Stars: 5")
+  expect(outputWithVersion).not.toContain("undefined")
+
+  // Test package with undefined version
+  const pkgWithUndefined = {
+    name: "test/package",
+    version: undefined,
+    star_count: 3,
+  }
+  const outputWithUndefined = formatPackageOutput(pkgWithUndefined, 0)
+  expect(outputWithUndefined).toBe("1. test/package - Stars: 3")
+  expect(outputWithUndefined).not.toContain("undefined")
+
+  // Test package with missing version property
+  const pkgMissingVersion = { name: "test/package", star_count: 0 }
+  const outputMissingVersion = formatPackageOutput(pkgMissingVersion, 0)
+  expect(outputMissingVersion).toBe("1. test/package - Stars: 0")
+  expect(outputMissingVersion).not.toContain("undefined")
+
+  // Test package with empty string version (should not show version)
+  const pkgEmptyVersion = { name: "test/package", version: "", star_count: 10 }
+  const outputEmptyVersion = formatPackageOutput(pkgEmptyVersion, 0)
+  expect(outputEmptyVersion).toBe("1. test/package - Stars: 10")
+  expect(outputEmptyVersion).not.toContain("(v)")
+})


### PR DESCRIPTION
Ref: https://github.com/tscircuit/tscircuit/issues/1505

Input:
`tsci search resistor`
### Before (bug - when API returns packages with undefined version):
```
Found 3 package(s) in the tscircuit registry:
1. tscircuit/smd-resistor (vundefined) - Stars: 12 - SMD resistor component
2. user/power-resistor (v1.2.0) - Stars: 5 - Power resistor
3. another/resistor-pack (vundefined) - Stars: 0
```

### After (fix - handles missing versions):
```
Found 3 package(s) in the tscircuit registry:
1. tscircuit/smd-resistor - Stars: 12 - SMD resistor component
2. user/power-resistor (v1.2.0) - Stars: 5 - Power resistor
3. another/resistor-pack - Stars: 0
```