### PR TITLE
Add override for zod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "typed-ky": "^0.0.4",
     "zod": "^3.23.8"
   },
+  "overrides": {
+    "zod": "3.23.8"
+  },
   "peerDependencies": {
     "tscircuit": "*"
   },


### PR DESCRIPTION
## Summary
- add an overrides section to pin zod resolution to 3.23.8

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6931df303d38832ebf30491ef1603fda)