### PR TITLE
Isolate bun install cache per test run

### DIFF
--- a/tests/fixtures/runBrowserTest.ts
+++ b/tests/fixtures/runBrowserTest.ts
@@ -244,6 +244,13 @@ export async function runBrowserTest(
     execSync("bun install", {
       cwd: tmpDir,
       stdio: "inherit",
+      env: {
+        ...process.env,
+        // Isolate bun's install cache per-test to avoid cross-test pollution that
+        // can lead to different dependency resolutions (e.g., zod). Using a
+        // tmp-local cache keeps installs hermetic regardless of execution order.
+        BUN_INSTALL_CACHE: path.join(tmpDir, ".bun-install-cache"),
+      },
     })
   } catch (error) {
     console.warn(

--- a/tests/fixtures/runBrowserTestWithSteps.ts
+++ b/tests/fixtures/runBrowserTestWithSteps.ts
@@ -303,6 +303,12 @@ async function executeCloneBugReportStep(
     execSync("bun install", {
       cwd: clonedReport.tmpDir,
       stdio: "inherit",
+      env: {
+        ...process.env,
+        // Isolate bun's install cache per cloned report so dependency resolution
+        // stays consistent regardless of test execution order.
+        BUN_INSTALL_CACHE: path.join(clonedReport.tmpDir, ".bun-install-cache"),
+      },
     })
   } catch (error) {
     console.warn(


### PR DESCRIPTION
## Summary
- scope bun install operations in browser test fixtures to unique per-test cache directories
- prevent cross-test dependency resolution differences (e.g., zod) by setting BUN_INSTALL_CACHE during installs

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69346034f8fc832e9357bb060b801a84)