### PR TITLE
fix: Throw an error on transpile if the package.json main or exports is not set properly

### DIFF
--- a/cli/utils/validate-main-in-dist.ts
+++ b/cli/utils/validate-main-in-dist.ts
@@ -12,9 +12,10 @@ export const validateMainInDist = (projectDir: string, distDir: string) => {
     typeof packageJson.exports === "object" && packageJson.exports !== null
 
   if (!hasMain && !hasExports) {
-    throw new Error(
+    console.warn(
       'When using transpilation, your package.json must have either a "main" or "exports" field pointing to the output in the `dist/*` directory',
     )
+    return
   }
 
   if (hasMain) {
@@ -24,8 +25,8 @@ export const validateMainInDist = (projectDir: string, distDir: string) => {
       resolvedMainPath.startsWith(`${distDir}${path.sep}`)
 
     if (!isMainInDist) {
-      throw new Error(
-        'When using transpilation, your package\'s "main" field must point inside the `dist/*` directory, usually to "dist/index.js"',
+      console.warn(
+        'When using transpilation, your package\'s "main" field should point inside the `dist/*` directory, usually to "dist/index.js"',
       )
     }
   }
@@ -37,8 +38,8 @@ export const validateMainInDist = (projectDir: string, distDir: string) => {
       distDir,
     )
     if (!isExportsValid) {
-      throw new Error(
-        'When using transpilation, your package\'s "exports" field must point to outputs in the `dist/*` directory',
+      console.warn(
+        'When using transpilation, your package\'s "exports" field should point to outputs in the `dist/*` directory',
       )
     }
   }

--- a/cli/utils/validate-main-in-dist.ts
+++ b/cli/utils/validate-main-in-dist.ts
@@ -7,16 +7,74 @@ export const validateMainInDist = (projectDir: string, distDir: string) => {
 
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
 
-  if (typeof packageJson.main !== "string") return
+  const hasMain = typeof packageJson.main === "string"
+  const hasExports =
+    typeof packageJson.exports === "object" && packageJson.exports !== null
 
-  const resolvedMainPath = path.resolve(projectDir, packageJson.main)
-  const isMainInDist =
-    resolvedMainPath === distDir ||
-    resolvedMainPath.startsWith(`${distDir}${path.sep}`)
-
-  if (!isMainInDist) {
-    console.warn(
-      'When using transpilation, your package\'s "main" field should point inside the `dist/*` directory, usually to "dist/index.js"',
+  if (!hasMain && !hasExports) {
+    throw new Error(
+      'When using transpilation, your package.json must have either a "main" or "exports" field pointing to the output in the `dist/*` directory',
     )
   }
+
+  if (hasMain) {
+    const resolvedMainPath = path.resolve(projectDir, packageJson.main)
+    const isMainInDist =
+      resolvedMainPath === distDir ||
+      resolvedMainPath.startsWith(`${distDir}${path.sep}`)
+
+    if (!isMainInDist) {
+      throw new Error(
+        'When using transpilation, your package\'s "main" field must point inside the `dist/*` directory, usually to "dist/index.js"',
+      )
+    }
+  }
+
+  if (hasExports) {
+    const isExportsValid = validateExports(
+      packageJson.exports,
+      projectDir,
+      distDir,
+    )
+    if (!isExportsValid) {
+      throw new Error(
+        'When using transpilation, your package\'s "exports" field must point to outputs in the `dist/*` directory',
+      )
+    }
+  }
+}
+
+const validateExports = (
+  exports: any,
+  projectDir: string,
+  distDir: string,
+): boolean => {
+  if (typeof exports === "string") {
+    const resolvedPath = path.resolve(projectDir, exports)
+    return (
+      resolvedPath === distDir ||
+      resolvedPath.startsWith(`${distDir}${path.sep}`)
+    )
+  }
+
+  if (typeof exports === "object" && exports !== null) {
+    for (const key in exports) {
+      const value = exports[key]
+
+      if (typeof value === "string") {
+        const resolvedPath = path.resolve(projectDir, value)
+        const isInDist =
+          resolvedPath === distDir ||
+          resolvedPath.startsWith(`${distDir}${path.sep}`)
+        if (!isInDist) return false
+      } else if (typeof value === "object" && value !== null) {
+        if (!validateExports(value, projectDir, distDir)) {
+          return false
+        }
+      }
+    }
+    return true
+  }
+
+  return true
 }

--- a/tests/cli/build/build-transpile.test.ts
+++ b/tests/cli/build/build-transpile.test.ts
@@ -82,7 +82,7 @@ test("build with --transpile uses mainEntrypoint when available", async () => {
   expect(dtsStat.isFile()).toBe(true)
 }, 30_000)
 
-test("build with --transpile throws error when main is outside dist", async () => {
+test("build with --transpile warns when main is outside dist", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const mainPath = path.join(tmpDir, "index.tsx")
 
@@ -95,11 +95,11 @@ test("build with --transpile throws error when main is outside dist", async () =
   const { stderr } = await runCommand(`tsci build --transpile`)
 
   expect(stderr).toContain(
-    'When using transpilation, your package\'s "main" field must point inside the `dist/*` directory, usually to "dist/index.js"',
+    'When using transpilation, your package\'s "main" field should point inside the `dist/*` directory, usually to "dist/index.js"',
   )
 }, 30_000)
 
-test("build with --transpile throws error when main and exports are not set", async () => {
+test("build with --transpile warns when main and exports are not set", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const mainPath = path.join(tmpDir, "index.tsx")
 

--- a/tests/cli/build/build-transpile.test.ts
+++ b/tests/cli/build/build-transpile.test.ts
@@ -79,7 +79,7 @@ test("build with --transpile uses mainEntrypoint when available", async () => {
   expect(dtsStat.isFile()).toBe(true)
 }, 30_000)
 
-test("build with --transpile warns when main is outside dist", async () => {
+test("build with --transpile throws error when main is outside dist", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const mainPath = path.join(tmpDir, "index.tsx")
 
@@ -92,7 +92,24 @@ test("build with --transpile warns when main is outside dist", async () => {
   const { stderr } = await runCommand(`tsci build --transpile`)
 
   expect(stderr).toContain(
-    'When using transpilation, your package\'s "main" field should point inside the `dist/*` directory, usually to "dist/index.js"',
+    'When using transpilation, your package\'s "main" field must point inside the `dist/*` directory, usually to "dist/index.js"',
+  )
+}, 30_000)
+
+test("build with --transpile throws error when main and exports are not set", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const mainPath = path.join(tmpDir, "index.tsx")
+
+  await writeFile(mainPath, circuitCode)
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name: "test-package", version: "1.0.0" }),
+  )
+
+  const { stderr } = await runCommand(`tsci build --transpile`)
+
+  expect(stderr).toContain(
+    'When using transpilation, your package.json must have either a "main" or "exports" field',
   )
 }, 30_000)
 

--- a/tests/cli/build/build-transpile.test.ts
+++ b/tests/cli/build/build-transpile.test.ts
@@ -14,7 +14,10 @@ test("build with --transpile generates ESM, CommonJS, and type declarations", as
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "test-circuit.tsx")
   await writeFile(circuitPath, circuitCode)
-  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ main: "dist/index.js" }),
+  )
 
   await runCommand(`tsci build ${circuitPath} --transpile --ignore-errors`)
 
@@ -117,7 +120,10 @@ test("build with --transpile transforms JSX correctly", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "jsx-test.tsx")
   await writeFile(circuitPath, circuitCode)
-  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ main: "dist/index.js" }),
+  )
 
   await runCommand(`tsci build ${circuitPath} --transpile --ignore-errors`)
 
@@ -160,7 +166,10 @@ test("build with --transpile JSX with import from other files", async () => {
     )
   `,
   )
-  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ main: "dist/index.js" }),
+  )
 
   await runCommand(`tsci build ${circuitPath} --transpile --ignore-errors`)
 

--- a/tests/cli/transpile/transpile-static-assets.test.ts
+++ b/tests/cli/transpile/transpile-static-assets.test.ts
@@ -32,6 +32,7 @@ test("transpile copies static assets and preserves glb_model_url", async () => {
     path.join(tmpDir, "package.json"),
     JSON.stringify({
       type: "module",
+      main: "dist/index.js",
       dependencies: {
         react: "^19.1.0",
       },

--- a/tests/cli/transpile/transpile.test.ts
+++ b/tests/cli/transpile/transpile.test.ts
@@ -14,7 +14,10 @@ test("transpile command generates ESM, CommonJS, and type declarations", async (
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "test-circuit.tsx")
   await writeFile(circuitPath, circuitCode)
-  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ main: "dist/index.js" }),
+  )
 
   await runCommand(`tsci transpile ${circuitPath}`)
 
@@ -130,7 +133,10 @@ test("transpile transforms JSX correctly", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "jsx-test.tsx")
   await writeFile(circuitPath, circuitCode)
-  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ main: "dist/index.js" }),
+  )
 
   await runCommand(`tsci transpile ${circuitPath}`)
 

--- a/tests/cli/transpile/transpile.test.ts
+++ b/tests/cli/transpile/transpile.test.ts
@@ -92,7 +92,7 @@ test("transpile ignores includeBoardFiles globs in favor of detected entrypoint"
   expect(esmContent).not.toContain("BOARD_FILE_MARKER")
 }, 30_000)
 
-test("transpile warns when main is outside dist", async () => {
+test("transpile throws error when main is outside dist", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const mainPath = path.join(tmpDir, "index.tsx")
 
@@ -105,7 +105,24 @@ test("transpile warns when main is outside dist", async () => {
   const { stderr } = await runCommand(`tsci transpile`)
 
   expect(stderr).toContain(
-    'When using transpilation, your package\'s "main" field should point inside the `dist/*` directory, usually to "dist/index.js"',
+    'When using transpilation, your package\'s "main" field must point inside the `dist/*` directory, usually to "dist/index.js"',
+  )
+}, 30_000)
+
+test("transpile throws error when main and exports are not set", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const mainPath = path.join(tmpDir, "index.tsx")
+
+  await writeFile(mainPath, circuitCode)
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name: "test-package", version: "1.0.0" }),
+  )
+
+  const { stderr } = await runCommand(`tsci transpile`)
+
+  expect(stderr).toContain(
+    'When using transpilation, your package.json must have either a "main" or "exports" field',
   )
 }, 30_000)
 

--- a/tests/cli/transpile/transpile.test.ts
+++ b/tests/cli/transpile/transpile.test.ts
@@ -95,7 +95,7 @@ test("transpile ignores includeBoardFiles globs in favor of detected entrypoint"
   expect(esmContent).not.toContain("BOARD_FILE_MARKER")
 }, 30_000)
 
-test("transpile throws error when main is outside dist", async () => {
+test("transpile warns when main is outside dist", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const mainPath = path.join(tmpDir, "index.tsx")
 
@@ -108,11 +108,11 @@ test("transpile throws error when main is outside dist", async () => {
   const { stderr } = await runCommand(`tsci transpile`)
 
   expect(stderr).toContain(
-    'When using transpilation, your package\'s "main" field must point inside the `dist/*` directory, usually to "dist/index.js"',
+    'When using transpilation, your package\'s "main" field should point inside the `dist/*` directory, usually to "dist/index.js"',
   )
 }, 30_000)
 
-test("transpile throws error when main and exports are not set", async () => {
+test("transpile warns when main and exports are not set", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const mainPath = path.join(tmpDir, "index.tsx")
 

--- a/tests/windows/transpile-import-and-export-types.test.ts
+++ b/tests/windows/transpile-import-and-export-types.test.ts
@@ -77,10 +77,7 @@ windowsTest(
     await writeFile(path.join(srcDir, "index.tsx"), indexFile)
     await writeFile(
       path.join(tmpDir, "package.json"),
-      JSON.stringify({
-        name: "windows-transpile-test",
-        main: "dist/index.js",
-      }),
+      JSON.stringify({ name: "windows-transpile-test" }),
     )
 
     const entryFile = path.join(srcDir, "index.tsx")

--- a/tests/windows/transpile-import-and-export-types.test.ts
+++ b/tests/windows/transpile-import-and-export-types.test.ts
@@ -77,7 +77,7 @@ windowsTest(
     await writeFile(path.join(srcDir, "index.tsx"), indexFile)
     await writeFile(
       path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "windows-transpile-test" }),
+      JSON.stringify({ name: "windows-transpile-test", main: "dist/index.js" }),
     )
 
     const entryFile = path.join(srcDir, "index.tsx")

--- a/tests/windows/transpile-import-and-export-types.test.ts
+++ b/tests/windows/transpile-import-and-export-types.test.ts
@@ -59,41 +59,34 @@ const ExampleCircuit = () => {
 export default ExampleCircuit
 `
 
-test(
-  "tsci transpile handles import/export type statements on Windows",
-  async () => {
-    const { tmpDir, runCommand } = await getCliTestFixture()
-    const srcDir = path.join(tmpDir, "src")
-    await mkdir(path.join(srcDir, "components"), { recursive: true })
+test("tsci transpile handles import/export type statements on Windows", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const srcDir = path.join(tmpDir, "src")
+  await mkdir(path.join(srcDir, "components"), { recursive: true })
 
-    await writeFile(path.join(srcDir, "types.ts"), typesFile)
-    await writeFile(path.join(srcDir, "helpers.ts"), helperFile)
-    await writeFile(
-      path.join(srcDir, "components", "resistor.tsx"),
-      resistorFile,
-    )
-    await writeFile(path.join(srcDir, "index.tsx"), indexFile)
-    await writeFile(
-      path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "windows-transpile-test", main: "dist/index.js" }),
-    )
+  await writeFile(path.join(srcDir, "types.ts"), typesFile)
+  await writeFile(path.join(srcDir, "helpers.ts"), helperFile)
+  await writeFile(path.join(srcDir, "components", "resistor.tsx"), resistorFile)
+  await writeFile(path.join(srcDir, "index.tsx"), indexFile)
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name: "windows-transpile-test", main: "dist/index.js" }),
+  )
 
-    const entryFile = path.join(srcDir, "index.tsx")
-    await runCommand(`tsci transpile ${entryFile}`)
+  const entryFile = path.join(srcDir, "index.tsx")
+  await runCommand(`tsci transpile ${entryFile}`)
 
-    const esmContent = await readFile(
-      path.join(tmpDir, "dist", "index.js"),
-      "utf-8",
-    )
-    expect(esmContent).toMatch(/export.*exportedFootprint/)
-    expect(esmContent).toContain("createBoardSize")
+  const esmContent = await readFile(
+    path.join(tmpDir, "dist", "index.js"),
+    "utf-8",
+  )
+  expect(esmContent).toMatch(/export.*exportedFootprint/)
+  expect(esmContent).toContain("createBoardSize")
 
-    const dtsContent = await readFile(
-      path.join(tmpDir, "dist", "index.d.ts"),
-      "utf-8",
-    )
-    expect(dtsContent).toMatch(/export.*ExportedBoardSize/)
-    expect(dtsContent).toMatch(/export.*exportedFootprint/)
-  },
-  120_000,
-)
+  const dtsContent = await readFile(
+    path.join(tmpDir, "dist", "index.d.ts"),
+    "utf-8",
+  )
+  expect(dtsContent).toMatch(/export.*ExportedBoardSize/)
+  expect(dtsContent).toMatch(/export.*exportedFootprint/)
+}, 120_000)

--- a/tests/windows/transpile-import-and-export-types.test.ts
+++ b/tests/windows/transpile-import-and-export-types.test.ts
@@ -77,7 +77,10 @@ windowsTest(
     await writeFile(path.join(srcDir, "index.tsx"), indexFile)
     await writeFile(
       path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "windows-transpile-test" }),
+      JSON.stringify({
+        name: "windows-transpile-test",
+        main: "dist/index.js",
+      }),
     )
 
     const entryFile = path.join(srcDir, "index.tsx")

--- a/tests/windows/transpile-import-and-export-types.test.ts
+++ b/tests/windows/transpile-import-and-export-types.test.ts
@@ -3,8 +3,6 @@ import { mkdir, writeFile, readFile } from "node:fs/promises"
 import path from "node:path"
 import { getCliTestFixture } from "../fixtures/get-cli-test-fixture"
 
-const windowsTest = process.platform === "win32" ? test : test.skip
-
 const typesFile = `
 export type BoardSize = {
   width: string
@@ -61,7 +59,7 @@ const ExampleCircuit = () => {
 export default ExampleCircuit
 `
 
-windowsTest(
+test(
   "tsci transpile handles import/export type statements on Windows",
   async () => {
     const { tmpDir, runCommand } = await getCliTestFixture()

--- a/tests/windows/transpile-import-and-export-types.test.ts
+++ b/tests/windows/transpile-import-and-export-types.test.ts
@@ -3,6 +3,8 @@ import { mkdir, writeFile, readFile } from "node:fs/promises"
 import path from "node:path"
 import { getCliTestFixture } from "../fixtures/get-cli-test-fixture"
 
+const windowsTest = process.platform === "win32" ? test : test.skip
+
 const typesFile = `
 export type BoardSize = {
   width: string
@@ -59,34 +61,41 @@ const ExampleCircuit = () => {
 export default ExampleCircuit
 `
 
-test("tsci transpile handles import/export type statements on Windows", async () => {
-  const { tmpDir, runCommand } = await getCliTestFixture()
-  const srcDir = path.join(tmpDir, "src")
-  await mkdir(path.join(srcDir, "components"), { recursive: true })
+windowsTest(
+  "tsci transpile handles import/export type statements on Windows",
+  async () => {
+    const { tmpDir, runCommand } = await getCliTestFixture()
+    const srcDir = path.join(tmpDir, "src")
+    await mkdir(path.join(srcDir, "components"), { recursive: true })
 
-  await writeFile(path.join(srcDir, "types.ts"), typesFile)
-  await writeFile(path.join(srcDir, "helpers.ts"), helperFile)
-  await writeFile(path.join(srcDir, "components", "resistor.tsx"), resistorFile)
-  await writeFile(path.join(srcDir, "index.tsx"), indexFile)
-  await writeFile(
-    path.join(tmpDir, "package.json"),
-    JSON.stringify({ name: "windows-transpile-test", main: "dist/index.js" }),
-  )
+    await writeFile(path.join(srcDir, "types.ts"), typesFile)
+    await writeFile(path.join(srcDir, "helpers.ts"), helperFile)
+    await writeFile(
+      path.join(srcDir, "components", "resistor.tsx"),
+      resistorFile,
+    )
+    await writeFile(path.join(srcDir, "index.tsx"), indexFile)
+    await writeFile(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "windows-transpile-test" }),
+    )
 
-  const entryFile = path.join(srcDir, "index.tsx")
-  await runCommand(`tsci transpile ${entryFile}`)
+    const entryFile = path.join(srcDir, "index.tsx")
+    await runCommand(`tsci transpile ${entryFile}`)
 
-  const esmContent = await readFile(
-    path.join(tmpDir, "dist", "index.js"),
-    "utf-8",
-  )
-  expect(esmContent).toMatch(/export.*exportedFootprint/)
-  expect(esmContent).toContain("createBoardSize")
+    const esmContent = await readFile(
+      path.join(tmpDir, "dist", "index.js"),
+      "utf-8",
+    )
+    expect(esmContent).toMatch(/export.*exportedFootprint/)
+    expect(esmContent).toContain("createBoardSize")
 
-  const dtsContent = await readFile(
-    path.join(tmpDir, "dist", "index.d.ts"),
-    "utf-8",
-  )
-  expect(dtsContent).toMatch(/export.*ExportedBoardSize/)
-  expect(dtsContent).toMatch(/export.*exportedFootprint/)
-}, 120_000)
+    const dtsContent = await readFile(
+      path.join(tmpDir, "dist", "index.d.ts"),
+      "utf-8",
+    )
+    expect(dtsContent).toMatch(/export.*ExportedBoardSize/)
+    expect(dtsContent).toMatch(/export.*exportedFootprint/)
+  },
+  120_000,
+)


### PR DESCRIPTION
/fix #1167 
## Overview
Changed the transpile command to **throw an error** instead of **warning** when `package.json` `main` or `exports` fields are not properly configured to point to the `dist/` directory.

---

## Behavior Changes

### 1. Main Field Points Outside dist/

#### ❌ BEFORE
```bash
$ cat package.json
{
  "name": "my-package",
  "main": "index.tsx"
}

$ tsci transpile index.tsx
```
<img width="1126" height="163" alt="Screenshot 2025-12-09 at 10 20 28 AM" src="https://github.com/user-attachments/assets/caf7562e-f10c-4be8-ba6c-5487d7044c52" />

**Output:**
```

When using transpilation, your package's "main" field should point inside the `dist/*` directory, usually to "dist/index.js"
Transpiling entry file...
Building ESM bundle...
[... transpilation continues ...]
Transpile complete!
```

**Exit Code:** `0` (SUCCESS - continues despite misconfiguration)

---

#### ✅ AFTER
```bash
$ cat package.json
{
  "name": "my-package",
  "main": "index.tsx"
}

$ tsci transpile index.tsx
```

**Output:**
```
When using transpilation, your package's "main" field must point inside the `dist/*` directory, usually to "dist/index.js"
```

**Exit Code:** `1` (ERROR - stops immediately)

---

### 2. Missing Both main and exports Fields

#### ❌ BEFORE
```bash
$ cat package.json
{
  "name": "my-package",
  "version": "1.0.0"
}

$ tsci transpile index.tsx
```

**Output:**
```
Transpiling entry file...
Building ESM bundle...
[... transpilation continues despite missing fields ...]
```

**Exit Code:** `0` (SUCCESS - no validation for missing fields)

---

#### ✅ AFTER
```bash
$ cat package.json
{
  "name": "my-package",
  "version": "1.0.0"
}

$ tsci transpile index.tsx
```

<img width="1126" height="103" alt="Screenshot 2025-12-09 at 10 22 00 AM" src="https://github.com/user-attachments/assets/f7a43924-35c7-4b50-80c6-6f414dfe00bc" />

**Output:**
```
When using transpilation, your package.json must have either a "main" or "exports" field pointing to the output in the `dist/*` directory
```

**Exit Code:** `1` (ERROR - stops immediately)

---



### 3. Invalid exports Field (NEW - Only In AFTER)

#### ❌ BEFORE
```bash
$ cat package.json
{
  "exports": {
    ".": "./lib/index.js",
    "./utils": "./utils.js"
  }
}

$ tsci transpile index.tsx
```

**Output:**
```
Transpiling entry file...
[... transpilation continues with invalid exports ...]
```

**Exit Code:** `0` (SUCCESS - no exports validation)

---

#### ✅ AFTER
```bash
$ cat package.json
{
  "exports": {
    ".": "./lib/index.js",
    "./utils": "./utils.js"
  }
}

$ tsci transpile index.tsx
```

**Output:**
```
When using transpilation, your package's "exports" field must point to outputs in the `dist/*` directory
```

**Exit Code:** `1` (ERROR - validates all export paths)

---



## Error Messages Summary

| Scenario | BEFORE | AFTER |
|----------|--------|-------|
| **main outside dist** | ⚠️ Warning: "should point" | ❌ Error: "must point" |
| **Missing main & exports** | ✅ No validation | ❌ Error: "must have either" |
| **Invalid exports paths** | ✅ No validation | ❌ Error: "must point to outputs" |
| **Valid main/exports** | ✅ Proceeds | ✅ Proceeds |

---

## Implementation Details

### Files Modified

1. **`cli/utils/validate-main-in-dist.ts`**
   - Changed from `console.warn()` to `throw new Error()`
   - Added validation for missing `main` and `exports` fields
   - Added new `validateExports()` helper function
   - Recursive validation for nested export structures

2. **`tests/cli/transpile/transpile.test.ts`**
   - Test renamed: "warns when main is outside dist" → "throws error when main is outside dist"
   - Error message updated: "should point" → "must point"
   - New test: "throws error when main and exports are not set"

3. **`tests/cli/build/build-transpile.test.ts`**
   - Test renamed: "warns when main is outside dist" → "throws error when main is outside dist"
   - Error message updated: "should point" → "must point"
   - New test: "throws error when main and exports are not set"

### Error Handling

Both `cli/transpile/register.ts` and `cli/build/register.ts` already have try-catch blocks that catch and properly handle the thrown errors:

```typescript
try {
  validateMainInDist(projectDir, distDir)
  // ... transpile logic ...
} catch (error) {
  const message = error instanceof Error ? error.message : String(error)
  console.error(message)
  process.exit(1)
}
```

---

## Test Results

### Transpile Tests
```bash
$ bun test tests/cli/transpile/transpile.test.ts
(pass) transpile throws error when main is outside dist [656.39ms]
(pass) transpile throws error when main and exports are not set [728.92ms]
```

### Build Tests
```bash
$ bun test tests/cli/build/build-transpile.test.ts
(pass) build with --transpile throws error when main is outside dist [1465.01ms]
(pass) build with --transpile throws error when main and exports are not set [1549.87ms]
```


1. **Early Error Detection:** Catches misconfiguration before spending time on transpilation
2. **Clearer Intent:** "must point" is stronger and clearer than "should point"
3. **Comprehensive Validation:** Now validates both `main` and `exports` fields
4. **Nested Export Support:** Recursively validates complex export structures
5. **Prevents Package Issues:** Ensures published packages will have correct entry points

