### PR TITLE
Adjust pver release branch filtering

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '!version-bumps/**'
   workflow_dispatch:
 
 env:
@@ -12,7 +13,6 @@ env:
 
 jobs:
   publish:
-    if: ${{ !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'v')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,15 +31,19 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
-          
+
+      - name: Get package version
+        id: package-version
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "chore: bump version"
-          title: "chore: bump version"
+          title: "chore: bump version to v${{ steps.package-version.outputs.version }}"
           body: "Automated package update"
-          branch: bump-version-${{ github.run_number }}
+          branch: version-bumps/v${{ steps.package-version.outputs.version }}
           base: main
           token: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
           committer: tscircuitbot <githubbot@tscircuit.com>


### PR DESCRIPTION
## Summary
- filter the release workflow by branch name instead of runtime conditions and align version bump branches under version-bumps/
- include the bumped version number in the generated PR title and branch name
- update workflow tooling to the latest create-pull-request action version

## Testing
- bunx tsc --noEmit
- bun run format
- /root/.local/share/mise/installs/go/1.23.8/bin/actionlint .github/workflows/bun-pver-release.yml


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c75955374832e907816d3f702e521)