### PR TITLE
Fix package version output step

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get package version
         id: package-version
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: node -e "const { appendFileSync } = require('fs'); const { version } = require('./package.json'); appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}\\n`);"
 
       - name: Create Pull Request
         id: create-pr


### PR DESCRIPTION
## Summary
- update the publish workflow to write the package version to $GITHUB_OUTPUT using Node
- avoid shell parsing issues when retrieving the package version during release

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c7da01508832ea146abdbb1d7f72b)