### PR TITLE
Pin tscircuit version in generated projects

### DIFF
--- a/lib/shared/generate-package-json.ts
+++ b/lib/shared/generate-package-json.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path"
 import { writeFileIfNotExists } from "./write-file-if-not-exists"
+import { getDefaultTscircuitVersion } from "./get-default-tscircuit-version"
 
 export const generatePackageJson = (
   dir: string,
@@ -23,7 +24,7 @@ export const generatePackageJson = (
       start: "tsci dev",
     },
     devDependencies: {
-      tscircuit: "latest",
+      tscircuit: getDefaultTscircuitVersion(),
     },
   }
 

--- a/lib/shared/get-default-tscircuit-version.ts
+++ b/lib/shared/get-default-tscircuit-version.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+type PackageJson = {
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+const packageJsonPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "package.json",
+)
+
+const packageJson = JSON.parse(
+  fs.readFileSync(packageJsonPath, "utf-8"),
+) as PackageJson
+
+export const getDefaultTscircuitVersion = () =>
+  packageJson.devDependencies?.tscircuit ??
+  packageJson.peerDependencies?.tscircuit ??
+  "latest"

--- a/lib/shared/setup-tsci-packages.ts
+++ b/lib/shared/setup-tsci-packages.ts
@@ -1,10 +1,14 @@
 import fs from "node:fs"
 import path from "node:path"
 import { getPackageManager } from "./get-package-manager"
+import { getDefaultTscircuitVersion } from "./get-default-tscircuit-version"
 
 export async function setupTsciProject(
   directory = process.cwd(),
-  devDependencies = ["@types/react", "tscircuit"],
+  devDependencies = [
+    "@types/react",
+    `tscircuit@${getDefaultTscircuitVersion()}`,
+  ],
 ) {
   const projectPath = path.resolve(directory)
   if (!fs.existsSync(projectPath)) {

--- a/tests/test2-cli-init.test.ts
+++ b/tests/test2-cli-init.test.ts
@@ -2,12 +2,13 @@ import { getCliTestFixture } from "./fixtures/get-cli-test-fixture"
 import { test, expect } from "bun:test"
 import fs from "node:fs"
 import path from "node:path"
+import { getDefaultTscircuitVersion } from "lib/shared/get-default-tscircuit-version"
 
 test("basic init", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   // Run the `tsci init` command
-  const { stdout, stderr } = await runCommand("tsci init project")
+  const { stdout, stderr } = await runCommand("tsci init project --no-install")
 
   const dirContents = fs.readdirSync(path.join(tmpDir, "project"))
 
@@ -22,4 +23,12 @@ test("basic init", async () => {
   for (const file of expectedFiles) {
     expect(dirContents).toContain(file)
   }
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(tmpDir, "project", "package.json"), "utf-8"),
+  )
+
+  expect(packageJson.devDependencies.tscircuit).toBe(
+    getDefaultTscircuitVersion(),
+  )
 }, 15_000)


### PR DESCRIPTION
## Summary
- add a shared helper that derives the default tscircuit version from the CLI package metadata
- use the pinned tscircuit version when generating package.json files and installing dev dependencies during init
- update the init test to skip installs, verify the pinned version, and avoid slow CI flakiness

## Testing
- bun test tests/test2-cli-init.test.ts
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69437e088c70832ebc0a21587a56a3f1)