### PR TITLE
Ensure CLI fixture uses workspace dependencies

### DIFF
--- a/tests/fixtures/get-cli-test-fixture.ts
+++ b/tests/fixtures/get-cli-test-fixture.ts
@@ -93,6 +93,12 @@ export async function getCliTestFixture(
       FORCE_COLOR: "0",
       NODE_ENV: "test",
       TSCIRCUIT_CONFIG_DIR: testConfigDir,
+      // Keep installs hermetic per test run to avoid cache pollution across
+      // unrelated projects (e.g., mismatched zod versions in CI)
+      BUN_INSTALL_CACHE: path.join(tmpDir, ".bun-install-cache"),
+      // Ensure bun resolves dependencies from the workspace rather than trying
+      // to auto-install a fresh copy in the temp project
+      NODE_PATH: path.join(process.cwd(), "node_modules"),
     }
 
     let stdout = ""


### PR DESCRIPTION
## Summary
- isolate CLI test fixture installs by pointing Bun at a per-run cache
- force Bun to resolve packages from the workspace node_modules to avoid cross-test dependency drift

## Testing
- bun test tests/cli/snapshot/looks-same-visual-diff.test.ts --timeout 30000
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69437e088c70832ebc0a21587a56a3f1)