### PR TITLE
Add zod runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "tempy": "^3.1.0",
     "tscircuit": "^0.0.1014-libonly",
     "tsx": "^4.7.1",
-    "typed-ky": "^0.0.4",
+    "typed-ky": "^0.0.4"
+  },
+  "dependencies": {
     "zod": "^3.23.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- declare zod as a runtime dependency instead of only a dev dependency to avoid resolving incompatible project-installed versions at runtime

## Testing
- bun test tests/get-entrypoint.test.ts
- bunx tsc --noEmit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69437e088c70832ebc0a21587a56a3f1)