### PR TITLE
Fix snapshot dependency resolution (importFromUserLand now has a 3 tier resolution system, first from user, then from cli, then dynamic import)

### DIFF
--- a/lib/shared/importFromUserLand.ts
+++ b/lib/shared/importFromUserLand.ts
@@ -1,22 +1,35 @@
-import { relative, resolve } from "node:path"
+import { createRequire } from "node:module"
+import fs from "node:fs"
+import path, { relative, resolve } from "node:path"
 
 export async function importFromUserLand(moduleName: string) {
-  try {
-    // Create a temporary path that helps resolve from cwd
-    const resolvedPath = import.meta.resolve(
-      moduleName,
-      resolve(process.cwd(), "dummy.js"),
-    )
-    return await import(resolvedPath)
-  } catch (error) {
-    // Fallback: try resolving with Bun.resolve
+  // First try to resolve relative to the user's project without triggering
+  // Bun's auto-install (which can pull in inconsistent dependency versions)
+  const userModulePath = path.join(process.cwd(), "node_modules", moduleName)
+  if (fs.existsSync(userModulePath)) {
+    const userRequire = createRequire(path.join(process.cwd(), "noop.js"))
     try {
-      const modulePath = await Bun.resolve(moduleName, process.cwd())
-      return await import(modulePath)
-    } catch (error) {
-      // If we can't resolve the module, resolve via dynamic import
-      const module = await import(moduleName)
-      return module
+      const resolvedUserPath = userRequire.resolve(moduleName)
+      return await import(resolvedUserPath)
+    } catch (error: any) {
+      if (error?.code !== "MODULE_NOT_FOUND") {
+        throw error
+      }
     }
   }
+
+  // Next, fall back to the CLI's own dependencies to ensure we use the
+  // versions bundled with the tool when the user hasn't installed them.
+  const cliRequire = createRequire(import.meta.url)
+  try {
+    const resolvedCliPath = cliRequire.resolve(moduleName)
+    return await import(resolvedCliPath)
+  } catch (error: any) {
+    if (error?.code !== "MODULE_NOT_FOUND") {
+      throw error
+    }
+  }
+
+  // Final fallback to dynamic import (may trigger auto-install)
+  return import(moduleName)
 }

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -203,7 +203,7 @@ test("snapshot command --pcb-only", async () => {
 
   expect(pcbExists).toBe(true)
   expect(schExists).toBe(false)
-})
+}, 30_000)
 
 test("snapshot command --schematic-only", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
@@ -231,7 +231,7 @@ test("snapshot command --schematic-only", async () => {
 
   expect(pcbExists).toBe(false)
   expect(schExists).toBe(true)
-})
+}, 30_000)
 
 test("snapshot command with file path", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
@@ -268,7 +268,7 @@ test("snapshot command with file path", async () => {
 
   const rootSnapExists = await Bun.file(join(tmpDir, "__snapshots__")).exists()
   expect(rootSnapExists).toBe(false)
-})
+}, 30_000)
 
 test("snapshot command with directory path", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
@@ -314,7 +314,7 @@ test("snapshot command with directory path", async () => {
 
   const rootExists = await Bun.file(join(tmpDir, "__snapshots__")).exists()
   expect(rootExists).toBe(false)
-})
+}, 30_000)
 
 test("snapshot command skips updates when snapshots match visually", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()


### PR DESCRIPTION
## Summary
- avoid Bun auto-installs in user module resolution by preferring existing user or CLI dependencies
- increase snapshot CLI test timeouts to account for slower runs

## Testing
- BUN_UPDATE_SNAPSHOTS=1 bun test tests/cli/snapshot/snapshot.test.ts
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69437e088c70832ebc0a21587a56a3f1)