### PR TITLE
Improve build hint for .ts entry files (suggest .tsx) (TSC-245)

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -70,10 +70,29 @@ export const buildFile = async (
   } catch (err) {
     console.error(`Build failed: ${err}`)
     if (err instanceof Error) {
+      logTsxExtensionHint(err, input)
       logTypeReexportHint(err, input)
     }
     return { ok: false }
   }
+}
+
+const logTsxExtensionHint = (error: Error, entryFilePath: string) => {
+  const lowerPath = entryFilePath.toLowerCase()
+  const isTsEntry = lowerPath.endsWith(".ts") && !lowerPath.endsWith(".d.ts")
+  const isAggregateError =
+    error instanceof AggregateError || String(error).includes("AggregateError")
+  if (!isTsEntry || !isAggregateError) return
+
+  const entryFileName = path.basename(entryFilePath)
+  console.error(
+    [
+      "",
+      `It looks like "${entryFileName}" is a ".ts" file. tscircuit component files must use the ".tsx" extension.`,
+      "Try renaming the file to .tsx and re-running the build.",
+      "",
+    ].join("\n"),
+  )
 }
 
 const TYPE_REEXPORT_ERROR_REGEX =

--- a/tests/cli/build/build-tsx-extension-hint.test.ts
+++ b/tests/cli/build/build-tsx-extension-hint.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "bun:test"
+import path from "node:path"
+import { writeFile } from "node:fs/promises"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const entrySource = `export default function ExampleBoard() {
+  return (
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+    </board>
+  )
+}
+`
+
+const tsconfigJson = JSON.stringify(
+  {
+    compilerOptions: {
+      jsx: "react-jsx",
+      module: "ESNext",
+      target: "ES2017",
+      moduleResolution: "node",
+      allowSyntheticDefaultImports: true,
+      esModuleInterop: true,
+      strict: true,
+      baseUrl: ".",
+    },
+  },
+  null,
+  2,
+)
+
+const pkgJson = JSON.stringify({ name: "ts-extension-hint-repro" })
+
+test("build hints to rename .ts entry files to .tsx", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const entryPath = path.join(tmpDir, "index.ts")
+  await writeFile(entryPath, entrySource)
+  await writeFile(path.join(tmpDir, "tsconfig.json"), `${tsconfigJson}\n`)
+  await writeFile(path.join(tmpDir, "package.json"), `${pkgJson}\n`)
+
+  const { stderr } = await runCommand("tsci build index.ts")
+
+  expect(stderr).toContain(
+    'tscircuit component files must use the ".tsx" extension.',
+  )
+  expect(stderr).toContain("Try renaming the file to .tsx")
+})


### PR DESCRIPTION
### Motivation

- Building a `.ts` entry file produced an unhelpful `AggregateError` message instead of a clear hint to use `.tsx` for tscircuit components.
- Provide a targeted, actionable message so users can quickly fix the common mistake of using `.ts` instead of `.tsx`.

### Description

- Added a new helper `logTsxExtensionHint` in `cli/build/build-file.ts` that detects non-declaration `.ts` entry files and AggregateError failures and prints a rename suggestion to `.tsx`.
- Invoke `logTsxExtensionHint` from the top-level `catch` before the existing `logTypeReexportHint` so the hint appears on relevant failures.
- The detection checks `entryFilePath` for a `.ts` suffix (excluding `.d.ts`) and checks the error via `error instanceof AggregateError` or `String(error).includes("AggregateError")`.
- Fixed casing in the printed hint to use the project name `tscircuit`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69464f8558c0832786b46b6373e5754d)