### PR TITLE
feat: add support for schematic simulation SVG export format

### DIFF
--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -5,6 +5,7 @@ import { convertCircuitJsonToReadableNetlist } from "circuit-json-to-readable-ne
 import {
   convertCircuitJsonToPcbSvg,
   convertCircuitJsonToSchematicSvg,
+  convertCircuitJsonToSchematicSimulationSvg,
 } from "circuit-to-svg"
 import { convertCircuitJsonToGltf } from "circuit-json-to-gltf"
 import { convertCircuitJsonToDsnString } from "dsn-converter"
@@ -24,6 +25,7 @@ export const ALLOWED_EXPORT_FORMATS = [
   "json",
   "circuit-json",
   "schematic-svg",
+  "schematic-simulation-svg",
   "pcb-svg",
   "gerbers",
   "readable-netlist",
@@ -43,6 +45,7 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   json: ".circuit.json",
   "circuit-json": ".circuit.json",
   "schematic-svg": "-schematic.svg",
+  "schematic-simulation-svg": "-schematic-simulation.svg",
   "pcb-svg": "-pcb.svg",
   gerbers: "-gerbers.zip",
   "readable-netlist": "-readable.netlist",
@@ -106,6 +109,11 @@ export const exportSnippet = async ({
   switch (format) {
     case "schematic-svg":
       outputContent = convertCircuitJsonToSchematicSvg(circuitData.circuitJson)
+      break
+    case "schematic-simulation-svg":
+      outputContent = convertCircuitJsonToSchematicSimulationSvg(
+        circuitData.circuitJson,
+      )
       break
     case "pcb-svg":
       outputContent = convertCircuitJsonToPcbSvg(circuitData.circuitJson)

--- a/tests/cli/export/export-schematic-simulation-svg.test.ts
+++ b/tests/cli/export/export-schematic-simulation-svg.test.ts
@@ -1,0 +1,56 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readFile } from "node:fs/promises"
+import path from "node:path"
+import "bun-match-svg"
+
+const circuitCode = `export default () => (
+  <board schMaxTraceDistance={10} routingDisabled>
+    <voltagesource name="V1" voltage="5V" />
+    <resistor name="R_base" resistance="10k" schY={2} />
+    <switch name="SW1" simSwitchFrequency="1kHz" schX={1.5} schY={2} />
+    <transistor
+      name="Q1"
+      type="npn"
+      footprint="sot23"
+      schX={2}
+      schY={0.3}
+      schRotation={180}
+    />
+    <resistor name="R_collector" resistance="10k" schY={-2} />
+
+    <trace from=".V1 > .pin1" to=".R_base > .pin1" />
+    <trace from=".R_base > .pin2" to=".SW1 > .pin1" />
+    <trace from=".SW1 > .pin2" to=".Q1 > .base" />
+
+    <trace from=".V1 > .pin1" to=".R_collector > .pin1" />
+    <trace from=".R_collector > .pin2" to=".Q1 > .collector" />
+
+    <trace from=".Q1 > .emitter" to=".V1 > .pin2" />
+
+    <voltageprobe name="VP_COLLECTOR" connectsTo=".R_collector > .pin2" />
+
+    <analogsimulation duration="4ms" timePerStep="1us" />
+  </board>
+)`
+
+test("export schematic-simulation-svg", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "test-circuit.tsx")
+
+  await writeFile(circuitPath, circuitCode)
+
+  const { stdout, stderr } = await runCommand(
+    `tsci export ${circuitPath} -f schematic-simulation-svg`,
+  )
+  expect(stderr).toBe("")
+
+  const schematicSimulationSvg = await readFile(
+    path.join(tmpDir, "test-circuit-schematic-simulation.svg"),
+    "utf-8",
+  )
+  expect(schematicSimulationSvg).toMatchSvgSnapshot(
+    import.meta.path,
+    "schematic-simulation",
+  )
+})


### PR DESCRIPTION
This pull request adds support for exporting a new "schematic simulation SVG" format in the `exportSnippet` utility. The changes ensure this new format is properly integrated into the export workflow, including file extension handling and allowed formats.

**Support for new export format:**

* Added `convertCircuitJsonToSchematicSimulationSvg` import and integrated it into the export logic in `exportSnippet`, enabling conversion of circuit JSON to schematic simulation SVGs. [[1]](diffhunk://#diff-f94ad8fccfce0ee8f63cbf7d7dbeb8a90f3b3b3e98de73ff4b60899a38f58791R8) [[2]](diffhunk://#diff-f94ad8fccfce0ee8f63cbf7d7dbeb8a90f3b3b3e98de73ff4b60899a38f58791R113-R117)
* Included `"schematic-simulation-svg"` in the `ALLOWED_EXPORT_FORMATS` array to allow this format as an export option.
* Updated the `OUTPUT_EXTENSIONS` mapping to provide the correct file extension for the new format (`-schematic-simulation.svg`).

/fix #1502 