### PR TITLE
Add tscircuit.config.json JSON schema and include $schema when saving configs

### DIFF
--- a/lib/project-config/index.ts
+++ b/lib/project-config/index.ts
@@ -12,6 +12,8 @@ export const defineConfig = (config: TscircuitProjectConfig) => {
 }
 
 export const CONFIG_FILENAME = "tscircuit.config.json"
+export const CONFIG_SCHEMA_URL =
+  "https://cdn.jsdelivr.net/npm/@tscircuit/cli/types/tscircuit.config.schema.json"
 
 export const DEFAULT_BOARD_FILE_PATTERNS = [
   "**/*.board.tsx",
@@ -76,7 +78,11 @@ export const saveProjectConfig = (
   const configPath = path.join(projectDir, CONFIG_FILENAME)
 
   try {
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+    const configWithSchema = {
+      $schema: CONFIG_SCHEMA_URL,
+      ...config,
+    }
+    fs.writeFileSync(configPath, JSON.stringify(configWithSchema, null, 2))
     return true
   } catch (error) {
     console.error(`Error saving tscircuit config: ${error}`)

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdn.jsdelivr.net/npm/@tscircuit/cli/types/tscircuit.config.schema.json",
+  "title": "TSCircuit Config",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON schema reference for the config file."
+    },
+    "mainEntrypoint": {
+      "type": "string",
+      "description": "Entry file for the circuit project."
+    },
+    "previewComponentPath": {
+      "type": "string",
+      "description": "Optional component path used for previews."
+    },
+    "ignoredFiles": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "File globs to ignore."
+    },
+    "includeBoardFiles": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "File globs to include as board files."
+    },
+    "snapshotsDir": {
+      "type": "string",
+      "description": "Directory path for storing snapshots."
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a published JSON schema for `tscircuit.config.json` so editors and tooling can validate project configs via a stable CDN URL.
- Ensure newly saved project configs include a `$schema` field pointing to the jsDelivr-hosted schema for better DX and auto-completion.
- Ship the schema in the package `types` folder so it will be available when the package is published to npm.

### Description
- Add `types/tscircuit.config.schema.json` containing the JSON schema with an `$id` hosted on jsDelivr (`https://cdn.jsdelivr.net/npm/@tscircuit/cli/types/tscircuit.config.schema.json`).
- Introduce `CONFIG_SCHEMA_URL` in `lib/project-config/index.ts` and use it to prepend `$schema` when writing `tscircuit.config.json`.
- Update `saveProjectConfig` to write a config object that includes the `$schema` property before persisting to disk.
- The schema file is placed in the `types` directory which is already included in the package `files` for publishing.

### Testing
- Ran `bunx tsc --noEmit` to typecheck the project and it completed successfully.
- Ran `bun run format` (which invokes `biome format`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6954cefb7dc8832eb31a3c95cd117289)