### PR TITLE
Add build output toggles to tscircuit config schema

### DIFF
--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -6,6 +6,14 @@ export const projectConfigSchema = z.object({
   ignoredFiles: z.array(z.string()).optional(),
   includeBoardFiles: z.array(z.string()).optional(),
   snapshotsDir: z.string().optional(),
+  build: z
+    .object({
+      circuitJson: z.boolean().optional(),
+      kicadLibrary: z.boolean().optional(),
+      previewImages: z.boolean().optional(),
+      typescriptLibrary: z.boolean().optional(),
+    })
+    .optional(),
 })
 
 export type TscircuitProjectConfigInput = z.input<typeof projectConfigSchema>

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -35,6 +35,29 @@
     "snapshotsDir": {
       "type": "string",
       "description": "Directory path for storing snapshots."
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "circuitJson": {
+          "type": "boolean",
+          "description": "Enable circuit JSON output in build."
+        },
+        "kicadLibrary": {
+          "type": "boolean",
+          "description": "Enable KiCad library output in build."
+        },
+        "previewImages": {
+          "type": "boolean",
+          "description": "Enable preview image outputs in build."
+        },
+        "typescriptLibrary": {
+          "type": "boolean",
+          "description": "Enable TypeScript library output in build."
+        }
+      },
+      "description": "Build output toggles."
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Provide a `build` section in `tscircuit.config.json` to allow configuring build outputs.
- Allow toggling specific build outputs via booleans instead of relying on ad-hoc defaults.
- Surface these options in both runtime validation and published JSON schema for editor/tooling support.

### Description

- Added an optional `build` object to the Zod project config schema in `lib/project-config/project-config-schema.ts` with boolean keys `circuitJson`, `kicadLibrary`, `previewImages`, and `typescriptLibrary`.
- Updated the published JSON schema in `types/tscircuit.config.schema.json` to document the new `build` object and its boolean properties.
- Kept all properties optional to preserve backward compatibility with existing configs.

### Testing

- Ran `bun run format` to normalize formatting and it completed successfully.
- Ran `bunx tsc --noEmit` to typecheck the TypeScript project and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c3b1a1d80832ea3266cf0cd0dfed9)