### PR TITLE
Auto-render named exports for kicad-library

### DIFF
--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -165,9 +165,12 @@ export const exportSnippet = async ({
     }
     case "kicad-library": {
       const libraryName = outputBaseName
-      const fpLibName = outputBaseName // Use same name for symbol and footprint libraries
+      const fpLibName = outputBaseName
 
-      // Use CircuitJsonToKicadLibraryConverter from circuit-json-to-kicad
+      // Create output directory
+      const libDir = outputDestination
+      fs.mkdirSync(libDir, { recursive: true })
+
       const libConverter = new CircuitJsonToKicadLibraryConverter(
         circuitData.circuitJson,
         {
@@ -177,10 +180,6 @@ export const exportSnippet = async ({
       )
       libConverter.runUntilFinished()
       const libOutput = libConverter.getOutput()
-
-      // Create output directory
-      const libDir = outputDestination
-      fs.mkdirSync(libDir, { recursive: true })
 
       // Write symbol library
       fs.writeFileSync(

--- a/lib/shared/generate-circuit-json.tsx
+++ b/lib/shared/generate-circuit-json.tsx
@@ -131,7 +131,7 @@ export async function generateCircuitJson({
       )
 
       const LibraryBoard = () => (
-        <board width="100mm" height="100mm">
+        <board>
           {componentExports.map(([exportName, Component]: [string, any], i) => (
             <Component key={exportName} name={exportName} pcbX={i * 10} />
           ))}


### PR DESCRIPTION
**Before**
<img width="457" height="197" alt="image" src="https://github.com/user-attachments/assets/6e1919cc-a3f6-4f31-9a26-f9167f64b765" />


**After**
<img width="471" height="328" alt="image" src="https://github.com/user-attachments/assets/9a2a3432-4973-4c54-9ec4-6e256113df7e" />


requires: https://github.com/tscircuit/circuit-json-to-kicad/pull/45