### PR TITLE
Ignore dist directory when running `tsci push`

### DIFF
--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -318,7 +318,7 @@ export const pushSnippet = async ({
 
   log("\n")
 
-  const filePaths = getPackageFilePaths(projectDir)
+  const filePaths = getPackageFilePaths(projectDir, ["dist"])
 
   for (const fullFilePath of filePaths) {
     const relativeFilePath = path.relative(projectDir, fullFilePath)

--- a/tests/cli/push/push13-ignore-dist.test.ts
+++ b/tests/cli/push/push13-ignore-dist.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+test("tsci push ignores dist directory", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture({
+    loggedIn: true,
+  })
+  const snippetFilePath = path.resolve(tmpDir, "snippet.tsx")
+  const distFilePath = path.resolve(tmpDir, "dist", "output.js")
+
+  fs.mkdirSync(path.dirname(distFilePath), { recursive: true })
+  fs.writeFileSync(snippetFilePath, "// Snippet content")
+  fs.writeFileSync(distFilePath, "console.log('dist output')")
+  fs.writeFileSync(
+    path.resolve(tmpDir, "package.json"),
+    JSON.stringify({ name: "@tsci/test-user.test-package", version: "1.0.0" }),
+  )
+
+  const { stdout, stderr } = await runCommand(`tsci push ${snippetFilePath}`)
+
+  expect(stderr).toBe("")
+  expect(stdout).toContain("⬆︎ package.json")
+  expect(stdout).toContain("⬆︎ snippet.tsx")
+  expect(stdout).not.toContain("dist/output.js")
+})


### PR DESCRIPTION
### Motivation

- Prevent uploading build output under `dist/` when publishing a package with `tsci push`.
- Reduce unnecessary files sent to the registry and avoid duplicate/transpiled artifacts being published.
- Make push behavior consistent with other ignore patterns used by the CLI.

### Description

- Pass an ignore list to `getPackageFilePaths` in `lib/shared/push-snippet.ts` to exclude the `dist` directory by calling `getPackageFilePaths(projectDir, ["dist"])`.
- Add a new test `tests/cli/push/push13-ignore-dist.test.ts` that ensures `dist/output.js` is not uploaded during `tsci push`.
- No other upload logic or payload handling was changed.

### Testing

- Ran `bun test tests/cli/push/push13-ignore-dist.test.ts`, which passed.
- Ran `bunx tsc --noEmit` for type checking, which succeeded.
- Ran `bun run format` to apply project formatting (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695eb126de10832e9cb3c02a5619cb09)