### PR TITLE
Add buildCommand support to tscircuit config

### DIFF
--- a/cli/config/set/register.ts
+++ b/cli/config/set/register.ts
@@ -17,6 +17,7 @@ const availableGlobalConfigKeys = [
 const availableProjectConfigKeys = [
   "mainEntrypoint",
   "previewComponentPath",
+  "buildCommand",
 ] satisfies (keyof TscircuitProjectConfig)[]
 
 export const registerConfigSet = (program: Command) => {
@@ -27,7 +28,7 @@ export const registerConfigSet = (program: Command) => {
     .description("Set a configuration value (global or project-specific)")
     .argument(
       "<key>",
-      "Configuration key (e.g., alwaysCloneWithAuthorName, mainEntrypoint, previewComponentPath)",
+      "Configuration key (e.g., alwaysCloneWithAuthorName, mainEntrypoint, previewComponentPath, buildCommand)",
     )
     .argument("<value>", "Value to set")
     .action((key: string, value: string) => {
@@ -43,7 +44,11 @@ export const registerConfigSet = (program: Command) => {
         }
       } else if (availableProjectConfigKeys.some((k) => k === key)) {
         const projectDir = process.cwd()
-        if (key === "mainEntrypoint" || key === "previewComponentPath") {
+        if (
+          key === "mainEntrypoint" ||
+          key === "previewComponentPath" ||
+          key === "buildCommand"
+        ) {
           const projectConfig = loadProjectConfig(projectDir) ?? {}
           projectConfig[key] = value
           if (saveProjectConfig(projectConfig, projectDir)) {

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -6,6 +6,7 @@ export const projectConfigSchema = z.object({
   ignoredFiles: z.array(z.string()).optional(),
   includeBoardFiles: z.array(z.string()).optional(),
   snapshotsDir: z.string().optional(),
+  buildCommand: z.string().optional(),
   build: z
     .object({
       circuitJson: z.boolean().optional(),

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -36,6 +36,10 @@
       "type": "string",
       "description": "Directory path for storing snapshots."
     },
+    "buildCommand": {
+      "type": "string",
+      "description": "Override command used for cloud builds."
+    },
     "build": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
### Motivation
- Allow projects to specify a `buildCommand` in `tscircuit.config.json` as an override for what to run during cloud builds, without changing local `tsci build` behavior.
- Make the new `buildCommand` configurable via the CLI so projects can set it with `tsci config set`.

### Description
- Add `buildCommand` to the project config Zod schema in `lib/project-config/project-config-schema.ts`.
- Add `buildCommand` to the JSON schema in `types/tscircuit.config.schema.json` so schema validation and editor tooling recognize it.
- Expose `buildCommand` in the CLI by adding it to `availableProjectConfigKeys` and supporting it in `cli/config/set/register.ts` with updated argument help text.
- No runtime build behavior changes were made; this change only surfaces the config option and persistence.

### Testing
- Ran TypeScript typecheck with `bunx tsc --noEmit`, which succeeded.
- Ran code formatting with `bun run format`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ecb66311c832eb11058b971189139)