### PR TITLE
Add prebuildCommand to tscircuit config

### DIFF
--- a/cli/config/set/register.ts
+++ b/cli/config/set/register.ts
@@ -17,6 +17,7 @@ const availableGlobalConfigKeys = [
 const availableProjectConfigKeys = [
   "mainEntrypoint",
   "previewComponentPath",
+  "prebuildCommand",
   "buildCommand",
 ] satisfies (keyof TscircuitProjectConfig)[]
 
@@ -28,7 +29,7 @@ export const registerConfigSet = (program: Command) => {
     .description("Set a configuration value (global or project-specific)")
     .argument(
       "<key>",
-      "Configuration key (e.g., alwaysCloneWithAuthorName, mainEntrypoint, previewComponentPath, buildCommand)",
+      "Configuration key (e.g., alwaysCloneWithAuthorName, mainEntrypoint, previewComponentPath, prebuildCommand, buildCommand)",
     )
     .argument("<value>", "Value to set")
     .action((key: string, value: string) => {
@@ -47,6 +48,7 @@ export const registerConfigSet = (program: Command) => {
         if (
           key === "mainEntrypoint" ||
           key === "previewComponentPath" ||
+          key === "prebuildCommand" ||
           key === "buildCommand"
         ) {
           const projectConfig = loadProjectConfig(projectDir) ?? {}

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -6,6 +6,7 @@ export const projectConfigSchema = z.object({
   ignoredFiles: z.array(z.string()).optional(),
   includeBoardFiles: z.array(z.string()).optional(),
   snapshotsDir: z.string().optional(),
+  prebuildCommand: z.string().optional(),
   buildCommand: z.string().optional(),
   build: z
     .object({

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -36,6 +36,10 @@
       "type": "string",
       "description": "Directory path for storing snapshots."
     },
+    "prebuildCommand": {
+      "type": "string",
+      "description": "Command to run before builds."
+    },
     "buildCommand": {
       "type": "string",
       "description": "Override command used for cloud builds."


### PR DESCRIPTION
### Motivation
- Introduce a `prebuildCommand` project configuration option so projects can specify a command to run before builds.
- Expose `prebuildCommand` to the CLI so users can set it with the existing `config set` flow.

### Description
- Added `prebuildCommand` to the Zod project config schema in `lib/project-config/project-config-schema.ts`.
- Added `prebuildCommand` to the JSON config schema in `types/tscircuit.config.schema.json` with a description.
- Exposed `prebuildCommand` in the `config set` CLI command by adding it to `availableProjectConfigKeys` and the command handling in `cli/config/set/register.ts`.

### Testing
- Ran `bunx tsc --noEmit` to typecheck the TypeScript code, which succeeded.
- Ran `bun run format` to format the repository, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960087f9508832ea54539a92665d1fc)