### PR TITLE
Add `--ci` flag and extract CI build handling to `cli/build/build-ci.ts`

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -1,0 +1,67 @@
+import { execSync } from "node:child_process"
+import kleur from "kleur"
+import { loadProjectConfig } from "lib/project-config"
+import { installProjectDependencies } from "lib/shared/install-project-dependencies"
+
+export interface BuildCommandOptions {
+  ignoreErrors?: boolean
+  ignoreWarnings?: boolean
+  disablePcb?: boolean
+  disablePartsEngine?: boolean
+  ci?: boolean
+  site?: boolean
+  transpile?: boolean
+  previewImages?: boolean
+  allImages?: boolean
+  kicad?: boolean
+  kicadFootprintLibrary?: boolean
+  previewGltf?: boolean
+  useCdnJavascript?: boolean
+}
+
+const runCommand = (command: string, cwd: string) => {
+  console.log(kleur.cyan(`Running: ${command}`))
+  execSync(command, { stdio: "inherit", cwd })
+}
+
+export const applyCiBuildOptions = async ({
+  projectDir,
+  options,
+}: {
+  projectDir: string
+  options?: BuildCommandOptions
+}): Promise<{
+  resolvedOptions?: BuildCommandOptions
+  handled: boolean
+}> => {
+  if (!options?.ci) {
+    return { resolvedOptions: options, handled: false }
+  }
+
+  await installProjectDependencies({ cwd: projectDir })
+
+  const projectConfig = loadProjectConfig(projectDir)
+  const prebuildCommand = projectConfig?.prebuildCommand?.trim()
+  const buildCommand = projectConfig?.buildCommand?.trim()
+
+  if (prebuildCommand) {
+    runCommand(prebuildCommand, projectDir)
+  }
+
+  if (buildCommand) {
+    runCommand(buildCommand, projectDir)
+    return { resolvedOptions: options, handled: true }
+  }
+
+  return {
+    resolvedOptions: {
+      ...options,
+      previewImages: options?.previewImages ?? true,
+      transpile: options?.transpile ?? true,
+      site: options?.site ?? true,
+      useCdnJavascript: options?.useCdnJavascript ?? true,
+      ignoreErrors: options?.ignoreErrors ?? true,
+    },
+    handled: false,
+  }
+}

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander"
 import path from "node:path"
 import fs from "node:fs"
 import { buildFile } from "./build-file"
+import { applyCiBuildOptions, type BuildCommandOptions } from "./build-ci"
 import { getBuildEntrypoints } from "./get-build-entrypoints"
 import {
   getStaticIndexHtmlFile,
@@ -28,6 +29,10 @@ export const registerBuild = (program: Command) => {
     .command("build")
     .description("Run tscircuit eval and output circuit json")
     .argument("[file]", "Path to the entry file")
+    .option(
+      "--ci",
+      "Run install and optional prebuild/build commands (or default CI build)",
+    )
     .option("--ignore-errors", "Do not exit with code 1 on errors")
     .option("--ignore-warnings", "Do not log warnings")
     .option("--disable-pcb", "Disable PCB outputs")
@@ -51,241 +56,230 @@ export const registerBuild = (program: Command) => {
       "--use-cdn-javascript",
       "Use CDN-hosted JavaScript instead of bundled standalone file for --site",
     )
-    .action(
-      async (
-        file?: string,
-        options?: {
-          ignoreErrors?: boolean
-          ignoreWarnings?: boolean
-          disablePcb?: boolean
-          disablePartsEngine?: boolean
-          site?: boolean
-          transpile?: boolean
-          previewImages?: boolean
-          allImages?: boolean
-          kicad?: boolean
-          kicadFootprintLibrary?: boolean
-          previewGltf?: boolean
-          useCdnJavascript?: boolean
-        },
-      ) => {
-        try {
-          const {
+    .action(async (file?: string, options?: BuildCommandOptions) => {
+      try {
+        const {
+          projectDir,
+          circuitFiles,
+          mainEntrypoint,
+          previewComponentPath,
+        } = await getBuildEntrypoints({
+          fileOrDir: file,
+        })
+
+        const { resolvedOptions, handled } = await applyCiBuildOptions({
+          projectDir,
+          options,
+        })
+
+        if (handled) {
+          return
+        }
+
+        const platformConfig: PlatformConfig | undefined = (() => {
+          if (
+            !resolvedOptions?.disablePcb &&
+            !resolvedOptions?.disablePartsEngine
+          ) {
+            return
+          }
+
+          const config: PlatformConfig = {}
+
+          if (resolvedOptions?.disablePcb) {
+            config.pcbDisabled = true
+          }
+
+          if (resolvedOptions?.disablePartsEngine) {
+            config.partsEngineDisabled = true
+          }
+
+          return config
+        })()
+
+        const distDir = path.join(projectDir, "dist")
+        fs.mkdirSync(distDir, { recursive: true })
+
+        console.log(`Building ${circuitFiles.length} file(s)...`)
+
+        let hasErrors = false
+        const staticFileReferences: StaticBuildFileReference[] = []
+
+        const builtFiles: BuildFileResult[] = []
+        const kicadProjects: Array<
+          GeneratedKicadProject & { sourcePath: string }
+        > = []
+
+        const shouldGenerateKicad =
+          resolvedOptions?.kicad || resolvedOptions?.kicadFootprintLibrary
+
+        for (const filePath of circuitFiles) {
+          const relative = path.relative(projectDir, filePath)
+          console.log(`Building ${relative}...`)
+          const outputDirName = relative.replace(
+            /(\.board|\.circuit)?\.tsx$/,
+            "",
+          )
+          const outputPath = path.join(distDir, outputDirName, "circuit.json")
+          const buildOutcome = await buildFile(
+            filePath,
+            outputPath,
             projectDir,
-            circuitFiles,
-            mainEntrypoint,
-            previewComponentPath,
-          } = await getBuildEntrypoints({
-            fileOrDir: file,
+            {
+              ignoreErrors: resolvedOptions?.ignoreErrors,
+              ignoreWarnings: resolvedOptions?.ignoreWarnings,
+              platformConfig,
+            },
+          )
+          builtFiles.push({
+            sourcePath: filePath,
+            outputPath,
+            ok: buildOutcome.ok,
           })
+          if (!buildOutcome.ok) {
+            hasErrors = true
+          } else if (resolvedOptions?.site) {
+            const normalizedSourcePath = relative.split(path.sep).join("/")
+            const relativeOutputPath = path.join(outputDirName, "circuit.json")
+            const normalizedOutputPath = relativeOutputPath
+              .split(path.sep)
+              .join("/")
+            staticFileReferences.push({
+              filePath: normalizedSourcePath,
+              fileStaticAssetUrl: `./${normalizedOutputPath}`,
+            })
+          }
 
-          const platformConfig: PlatformConfig | undefined = (() => {
-            if (!options?.disablePcb && !options?.disablePartsEngine) return
-
-            const config: PlatformConfig = {}
-
-            if (options?.disablePcb) {
-              config.pcbDisabled = true
-            }
-
-            if (options?.disablePartsEngine) {
-              config.partsEngineDisabled = true
-            }
-
-            return config
-          })()
-
-          const distDir = path.join(projectDir, "dist")
-          fs.mkdirSync(distDir, { recursive: true })
-
-          console.log(`Building ${circuitFiles.length} file(s)...`)
-
-          let hasErrors = false
-          const staticFileReferences: StaticBuildFileReference[] = []
-
-          const builtFiles: BuildFileResult[] = []
-          const kicadProjects: Array<
-            GeneratedKicadProject & { sourcePath: string }
-          > = []
-
-          const shouldGenerateKicad =
-            options?.kicad || options?.kicadFootprintLibrary
-
-          for (const filePath of circuitFiles) {
-            const relative = path.relative(projectDir, filePath)
-            console.log(`Building ${relative}...`)
-            const outputDirName = relative.replace(
-              /(\.board|\.circuit)?\.tsx$/,
-              "",
-            )
-            const outputPath = path.join(distDir, outputDirName, "circuit.json")
-            const buildOutcome = await buildFile(
-              filePath,
-              outputPath,
-              projectDir,
-              {
-                ignoreErrors: options?.ignoreErrors,
-                ignoreWarnings: options?.ignoreWarnings,
-                platformConfig,
-              },
-            )
-            builtFiles.push({
+          if (
+            buildOutcome.ok &&
+            shouldGenerateKicad &&
+            buildOutcome.circuitJson
+          ) {
+            const projectOutputDir = path.join(distDir, outputDirName, "kicad")
+            const projectName = path.basename(outputDirName)
+            const project = await generateKicadProject({
+              circuitJson: buildOutcome.circuitJson,
+              outputDir: projectOutputDir,
+              projectName,
+              writeFiles: Boolean(resolvedOptions?.kicad),
+            })
+            kicadProjects.push({
+              ...project,
               sourcePath: filePath,
-              outputPath,
-              ok: buildOutcome.ok,
-            })
-            if (!buildOutcome.ok) {
-              hasErrors = true
-            } else if (options?.site) {
-              const normalizedSourcePath = relative.split(path.sep).join("/")
-              const relativeOutputPath = path.join(
-                outputDirName,
-                "circuit.json",
-              )
-              const normalizedOutputPath = relativeOutputPath
-                .split(path.sep)
-                .join("/")
-              staticFileReferences.push({
-                filePath: normalizedSourcePath,
-                fileStaticAssetUrl: `./${normalizedOutputPath}`,
-              })
-            }
-
-            if (
-              buildOutcome.ok &&
-              shouldGenerateKicad &&
-              buildOutcome.circuitJson
-            ) {
-              const projectOutputDir = path.join(
-                distDir,
-                outputDirName,
-                "kicad",
-              )
-              const projectName = path.basename(outputDirName)
-              const project = await generateKicadProject({
-                circuitJson: buildOutcome.circuitJson,
-                outputDir: projectOutputDir,
-                projectName,
-                writeFiles: Boolean(options?.kicad),
-              })
-              kicadProjects.push({
-                ...project,
-                sourcePath: filePath,
-              })
-            }
-          }
-
-          if (hasErrors && !options?.ignoreErrors) {
-            process.exit(1)
-          }
-
-          const shouldGeneratePreviewImages =
-            options?.previewImages || options?.allImages
-
-          if (shouldGeneratePreviewImages) {
-            console.log(
-              options?.allImages
-                ? "Generating preview images for all builds..."
-                : "Generating preview images...",
-            )
-            await buildPreviewImages({
-              builtFiles,
-              distDir,
-              mainEntrypoint,
-              previewComponentPath,
-              allImages: options?.allImages,
             })
           }
+        }
 
-          if (options?.previewGltf) {
-            console.log("Generating preview GLTF...")
-            await buildPreviewGltf({
-              builtFiles,
-              distDir,
-              mainEntrypoint,
-              previewComponentPath,
-            })
-          }
-
-          if (options?.transpile) {
-            validateMainInDist(projectDir, distDir)
-
-            console.log("Transpiling entry file...")
-            // For transpilation, we need to find the main library entrypoint
-            // (not board files).
-            const { mainEntrypoint: transpileEntrypoint } =
-              await getBuildEntrypoints({
-                fileOrDir: file,
-                includeBoardFiles: false,
-              })
-            const entryFile = transpileEntrypoint
-            if (!entryFile) {
-              console.error(
-                "No entry file found for transpilation. Make sure you have a lib/index.ts or set mainEntrypoint in tscircuit.config.json",
-              )
-              process.exit(1)
-            }
-            const transpileSuccess = await transpileFile({
-              input: entryFile,
-              outputDir: distDir,
-              projectDir,
-            })
-            if (!transpileSuccess) {
-              console.error("Transpilation failed")
-              process.exit(1)
-            }
-          }
-
-          if (options?.site) {
-            let standaloneScriptSrc = "./standalone.min.js"
-            if (options?.useCdnJavascript) {
-              standaloneScriptSrc = await getLatestTscircuitCdnUrl()
-            } else {
-              fs.writeFileSync(
-                path.join(distDir, "standalone.min.js"),
-                runFrameStandaloneBundleContent,
-              )
-            }
-            const indexHtml = getStaticIndexHtmlFile({
-              files: staticFileReferences,
-              standaloneScriptSrc,
-            })
-            fs.writeFileSync(path.join(distDir, "index.html"), indexHtml)
-          }
-
-          const successCount = builtFiles.filter((f) => f.ok).length
-          const failCount = builtFiles.length - successCount
-          const enabledOpts = [
-            options?.site && "site",
-            options?.transpile && "transpile",
-            options?.previewImages && "preview-images",
-            options?.allImages && "all-images",
-            options?.kicad && "kicad",
-            options?.previewGltf && "preview-gltf",
-          ].filter(Boolean) as string[]
-
-          console.log("")
-          console.log(kleur.bold("Build complete"))
-          console.log(
-            `  Circuits  ${kleur.green(`${successCount} passed`)}${failCount > 0 ? kleur.red(` ${failCount} failed`) : ""}`,
-          )
-          if (enabledOpts.length > 0) {
-            console.log(`  Options   ${kleur.cyan(enabledOpts.join(", "))}`)
-          }
-          console.log(
-            `  Output    ${kleur.dim(path.relative(process.cwd(), distDir) || "dist")}`,
-          )
-          console.log(
-            hasErrors
-              ? kleur.yellow("\n⚠ Build completed with errors")
-              : kleur.green("\n✓ Done"),
-          )
-          process.exit(0)
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error)
-          console.error(message)
+        if (hasErrors && !resolvedOptions?.ignoreErrors) {
           process.exit(1)
         }
-      },
-    )
+
+        const shouldGeneratePreviewImages =
+          resolvedOptions?.previewImages || resolvedOptions?.allImages
+
+        if (shouldGeneratePreviewImages) {
+          console.log(
+            resolvedOptions?.allImages
+              ? "Generating preview images for all builds..."
+              : "Generating preview images...",
+          )
+          await buildPreviewImages({
+            builtFiles,
+            distDir,
+            mainEntrypoint,
+            previewComponentPath,
+            allImages: resolvedOptions?.allImages,
+          })
+        }
+
+        if (resolvedOptions?.previewGltf) {
+          console.log("Generating preview GLTF...")
+          await buildPreviewGltf({
+            builtFiles,
+            distDir,
+            mainEntrypoint,
+            previewComponentPath,
+          })
+        }
+
+        if (resolvedOptions?.transpile) {
+          validateMainInDist(projectDir, distDir)
+
+          console.log("Transpiling entry file...")
+          // For transpilation, we need to find the main library entrypoint
+          // (not board files).
+          const { mainEntrypoint: transpileEntrypoint } =
+            await getBuildEntrypoints({
+              fileOrDir: file,
+              includeBoardFiles: false,
+            })
+          const entryFile = transpileEntrypoint
+          if (!entryFile) {
+            console.error(
+              "No entry file found for transpilation. Make sure you have a lib/index.ts or set mainEntrypoint in tscircuit.config.json",
+            )
+            process.exit(1)
+          }
+          const transpileSuccess = await transpileFile({
+            input: entryFile,
+            outputDir: distDir,
+            projectDir,
+          })
+          if (!transpileSuccess) {
+            console.error("Transpilation failed")
+            process.exit(1)
+          }
+        }
+
+        if (resolvedOptions?.site) {
+          let standaloneScriptSrc = "./standalone.min.js"
+          if (resolvedOptions?.useCdnJavascript) {
+            standaloneScriptSrc = await getLatestTscircuitCdnUrl()
+          } else {
+            fs.writeFileSync(
+              path.join(distDir, "standalone.min.js"),
+              runFrameStandaloneBundleContent,
+            )
+          }
+          const indexHtml = getStaticIndexHtmlFile({
+            files: staticFileReferences,
+            standaloneScriptSrc,
+          })
+          fs.writeFileSync(path.join(distDir, "index.html"), indexHtml)
+        }
+
+        const successCount = builtFiles.filter((f) => f.ok).length
+        const failCount = builtFiles.length - successCount
+        const enabledOpts = [
+          resolvedOptions?.site && "site",
+          resolvedOptions?.transpile && "transpile",
+          resolvedOptions?.previewImages && "preview-images",
+          resolvedOptions?.allImages && "all-images",
+          resolvedOptions?.kicad && "kicad",
+          resolvedOptions?.previewGltf && "preview-gltf",
+        ].filter(Boolean) as string[]
+
+        console.log("")
+        console.log(kleur.bold("Build complete"))
+        console.log(
+          `  Circuits  ${kleur.green(`${successCount} passed`)}${failCount > 0 ? kleur.red(` ${failCount} failed`) : ""}`,
+        )
+        if (enabledOpts.length > 0) {
+          console.log(`  Options   ${kleur.cyan(enabledOpts.join(", "))}`)
+        }
+        console.log(
+          `  Output    ${kleur.dim(path.relative(process.cwd(), distDir) || "dist")}`,
+        )
+        console.log(
+          hasErrors
+            ? kleur.yellow("\n⚠ Build completed with errors")
+            : kleur.green("\n✓ Done"),
+        )
+        process.exit(0)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        console.error(message)
+        process.exit(1)
+      }
+    })
 }


### PR DESCRIPTION
### Motivation
- Provide a CI-friendly mode for `tsci build` that installs dependencies and runs project-defined build steps before the normal build pipeline.
- Move the CI orchestration code out of the big `register.ts` action into a focused helper to improve readability and testability.
- Support projects that declare `prebuildCommand` and `buildCommand` in `tscircuit.config.json` so CI can run custom build steps or fall back to sensible default CI options.

### Description
- Added a new helper module `cli/build/build-ci.ts` that exports `applyCiBuildOptions`, installs project dependencies, runs optional `prebuildCommand`/`buildCommand` via `execSync`, and returns either handled=true or modified `resolvedOptions` for the remaining build flow.
- Wired the `--ci` CLI option in `cli/build/register.ts` to call `applyCiBuildOptions` and return early when a project `buildCommand` was executed, otherwise continue with the normal build flow using the resolved options.
- Introduced the `BuildCommandOptions` type and switched downstream checks to use `resolvedOptions` so CI can modify runtime options (e.g. enable `previewImages`, `transpile`, `site`, `useCdnJavascript`, and `ignoreErrors` by default).

### Testing
- Ran TypeScript typecheck with `bunx tsc --noEmit`, which succeeded.
- Ran code formatter with `bun run format`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960133e4bc8832e8305769b9209c8b3)