### PR TITLE
Remove the stringification of the err and use the native error formatting of bun with line number and file location

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -68,7 +68,7 @@ export const buildFile = async (
       }
     }
   } catch (err) {
-    console.error(`Build failed: ${err}`)
+    console.error(err)
     if (err instanceof Error) {
       logTsxExtensionHint(err, input)
       logTypeReexportHint(err, input)
@@ -106,7 +106,7 @@ const logTypeReexportHint = (error: Error, entryFilePath: string) => {
   console.error(
     [
       "",
-      `It looks like "${entryFileName}" re-exports the type-only symbol "${exportName}" from "${fromSpecifier}" without the \"type\" modifier.`,
+      `It looks like "${entryFileName}" re-exports the type-only symbol "${exportName}" from "${fromSpecifier}" without the "type" modifier.`,
       "Type-only exports must be re-exported with `export type { ... }`.",
       "Try rewriting the statement as:",
       `  export type { ${exportName} } from "${fromSpecifier}"`,

--- a/tests/cli/build/build-type-reexport.test.ts
+++ b/tests/cli/build/build-type-reexport.test.ts
@@ -48,7 +48,7 @@ test("build fails when re-exporting a type alias without type modifier", async (
 
   const { stderr } = await runCommand("tsci build")
 
-  expect(stderr).toContain("SyntaxError: export 'ExampleType' not found")
+  expect(stderr).toContain("export 'ExampleType' not found")
   expect(stderr).toContain(
     'export type { ExampleType } from "./lib/src/globals"',
   )


### PR DESCRIPTION
<img width="1301" height="555" alt="image" src="https://github.com/user-attachments/assets/bdd4bf75-134f-45c0-81cf-c1d78374ed6e" />

the step files are being parsed as javascript