### PR TITLE
Register Bun loader for static assets to prevent STEP files being parsed as TypeScript

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -29,10 +29,13 @@ import { registerConvert } from "./convert/register"
 import { registerSimulate } from "./simulate/register"
 import { registerInstall } from "./install/register"
 import { registerTranspile } from "./transpile/register"
+import { registerStaticAssetLoaders } from "lib/shared/register-static-asset-loaders"
 
 export const program = new Command()
 
 program.name("tsci").description("CLI for developing tscircuit packages")
+
+registerStaticAssetLoaders()
 
 registerInit(program)
 

--- a/lib/shared/register-static-asset-loaders.ts
+++ b/lib/shared/register-static-asset-loaders.ts
@@ -1,0 +1,44 @@
+const STATIC_ASSET_EXTENSIONS = [
+  ".glb",
+  ".gltf",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".svg",
+  ".webp",
+  ".gif",
+  ".bmp",
+  ".step",
+  ".kicad_mod",
+  ".kicad_pcb",
+  ".kicad_pro",
+  ".kicad_sch",
+]
+
+const staticAssetFilter = new RegExp(
+  `(${STATIC_ASSET_EXTENSIONS.map((ext) => ext.replace(".", "\\.")).join(
+    "|",
+  )})$`,
+  "i",
+)
+
+let registered = false
+
+export const registerStaticAssetLoaders = () => {
+  if (registered) return
+  registered = true
+
+  if (typeof Bun !== "undefined" && typeof Bun.plugin === "function") {
+    Bun.plugin({
+      name: "tsci-static-assets",
+      setup(build) {
+        build.onLoad({ filter: staticAssetFilter }, (args) => {
+          return {
+            contents: `export default ${JSON.stringify(args.path)};`,
+            loader: "js",
+          }
+        })
+      },
+    })
+  }
+}

--- a/lib/shared/register-static-asset-loaders.ts
+++ b/lib/shared/register-static-asset-loaders.ts
@@ -1,13 +1,5 @@
-const STATIC_ASSET_EXTENSIONS = [
-  ".glb",
+const TEXT_STATIC_ASSET_EXTENSIONS = [
   ".gltf",
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".svg",
-  ".webp",
-  ".gif",
-  ".bmp",
   ".step",
   ".kicad_mod",
   ".kicad_pcb",
@@ -16,7 +8,7 @@ const STATIC_ASSET_EXTENSIONS = [
 ]
 
 const staticAssetFilter = new RegExp(
-  `(${STATIC_ASSET_EXTENSIONS.map((ext) => ext.replace(".", "\\.")).join(
+  `(${TEXT_STATIC_ASSET_EXTENSIONS.map((ext) => ext.replace(".", "\\.")).join(
     "|",
   )})$`,
   "i",

--- a/tests/cli/build/build-step-assets-from-dependency.test.ts
+++ b/tests/cli/build/build-step-assets-from-dependency.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+import fs from "node:fs"
+
+test("build handles step imports from node_modules packages", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  const dependencyDir = path.join(
+    tmpDir,
+    "node_modules",
+    "@tsci",
+    "adom-inc.library",
+  )
+  const assetsDir = path.join(dependencyDir, "assets")
+
+  await mkdir(assetsDir, { recursive: true })
+
+  await writeFile(
+    path.join(dependencyDir, "package.json"),
+    JSON.stringify({
+      name: "@tsci/adom-inc.library",
+      version: "1.0.0",
+      type: "module",
+      main: "index.js",
+    }),
+  )
+
+  await writeFile(
+    path.join(assetsDir, "MachinePinMediumShort.step"),
+    `ISO-10303-21;\nDATA;\n#1=DUMMY();\nENDSEC;\nEND-ISO-10303-21;\n`,
+  )
+
+  await writeFile(
+    path.join(dependencyDir, "index.js"),
+    `import stepUrl from "./assets/MachinePinMediumShort.step"\nexport const modelUrl = stepUrl\n`,
+  )
+
+  const circuitPath = path.join(tmpDir, "circuit.tsx")
+  await writeFile(
+    circuitPath,
+    `import { modelUrl } from "@tsci/adom-inc.library"\n\nexport default () => (\n  <board width="20mm" height="20mm">\n    <chip\n      name="U1"\n      footprint="soic8"\n      cadModel={<cadmodel modelUrl={modelUrl} />}\n    />\n  </board>\n)\n`,
+  )
+
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ type: "module", dependencies: { react: "^19.1.0" } }),
+  )
+
+  await runCommand("tsci install")
+
+  const { stderr } = await runCommand(`tsci export ${circuitPath}`)
+
+  expect(stderr).toBe("")
+
+  const outputPath = path.join(tmpDir, "circuit.circuit.json")
+  expect(fs.existsSync(outputPath)).toBe(true)
+}, 120_000)


### PR DESCRIPTION
### Motivation
- STEP and other static asset imports from dependencies were being interpreted as TypeScript/JS and produced syntax errors at runtime; a runtime loader is needed so imports resolve to file paths instead of being parsed as code.

### Description
- Add `lib/shared/register-static-asset-loaders.ts` which registers a Bun plugin to `export default <absolute-path>` for known static asset extensions (including `.step`).
- Call `registerStaticAssetLoaders()` early in the CLI (`cli/main.ts`) so Bun resolves static asset imports during CLI execution.
- Add a regression test `tests/cli/build/build-step-assets-from-dependency.test.ts` that creates a fake `@tsci/adom-inc.library` package with a `.step` asset, installs `react`, runs `tsci export`, and asserts the export succeeds and the output file exists.

### Testing
- Ran `bun test tests/cli/build/build-step-assets-from-dependency.test.ts`, which passed (1 pass, 0 fail). 
- Ran TypeScript typecheck with `bunx tsc --noEmit`, which completed with no errors.
- Formatted code with `bun run format` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968371bd598832ebad5a88ea4c6c172)