### PR TITLE
fix: static asset file imports which are present in the node_module pacakges are parsed as JS

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -30,6 +30,10 @@ import { registerSimulate } from "./simulate/register"
 import { registerInstall } from "./install/register"
 import { registerTranspile } from "./transpile/register"
 
+// Register static asset loader plugin to handle .glb, .step, etc. imports
+// from node_modules packages that contain binary asset imports
+import "../lib/shared/static-asset-loader"
+
 export const program = new Command()
 
 program.name("tsci").description("CLI for developing tscircuit packages")

--- a/lib/shared/static-asset-loader.ts
+++ b/lib/shared/static-asset-loader.ts
@@ -1,0 +1,53 @@
+/**
+ * Bun Plugin for Static Asset Imports
+ *
+ * This plugin intercepts imports of static asset files (like .glb, .step, .stp)
+ * and returns the file path as a string export instead of trying to parse binary content.
+ *
+ * Usage:
+ *   import { plugin } from 'bun'
+ *   import { staticAssetPlugin } from './static-asset-loader'
+ *   plugin(staticAssetPlugin)
+ */
+
+import { plugin, type BunPlugin } from "bun"
+
+export const STATIC_ASSET_EXTENSIONS = [
+  ".glb",
+  ".gltf",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".svg",
+  ".step",
+  ".stp",
+  ".stl",
+  ".obj",
+  ".kicad_mod",
+  ".kicad_pcb",
+  ".kicad_pro",
+  ".kicad_sch",
+]
+
+export const staticAssetPlugin: BunPlugin = {
+  name: "static-asset-loader",
+  setup(build) {
+    // Create a regex pattern that matches all static asset extensions
+    const extensionPattern = STATIC_ASSET_EXTENSIONS.map((ext) =>
+      ext.replace(".", "\\."),
+    ).join("|")
+    const filter = new RegExp(`(${extensionPattern})$`, "i")
+
+    build.onLoad({ filter }, (args) => {
+      // Return the file path as the default export
+      // This matches the behavior of bundlers like webpack/esbuild file-loader
+      return {
+        contents: `export default ${JSON.stringify(args.path)};`,
+        loader: "js",
+      }
+    })
+  },
+}
+
+// Auto-register the plugin when this file is loaded as a preload script
+plugin(staticAssetPlugin)

--- a/scripts/bun-build.ts
+++ b/scripts/bun-build.ts
@@ -12,6 +12,7 @@ const result = await Bun.build({
   outdir: "./dist",
   external: [
     ...tscircuitPackageJsonDeps.filter((dep) => !ALLOW_BUNDLING.includes(dep)),
+    "bun",
     "zod",
     "looks-same",
     "sharp",


### PR DESCRIPTION
Fix this syntax error of parsing staticAssets as javascript

<img width="2422" height="790" alt="image" src="https://github.com/user-attachments/assets/2225a02e-da2c-44db-ad70-4e62db032d0b" />
