### PR TITLE
Add `siteDefaultComponentPath` config (TSC-318)

### DIFF
--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -38,6 +38,7 @@ export async function getBuildEntrypoints({
   projectDir: string
   mainEntrypoint?: string
   previewComponentPath?: string
+  siteDefaultComponentPath?: string
   circuitFiles: string[]
 }> {
   const resolvedRoot = path.resolve(rootDir)
@@ -50,6 +51,10 @@ export async function getBuildEntrypoints({
     const resolvedPreviewComponentPath = projectConfig?.previewComponentPath
       ? path.resolve(resolvedRoot, projectConfig.previewComponentPath)
       : undefined
+    const resolvedSiteDefaultComponentPath =
+      projectConfig?.siteDefaultComponentPath
+        ? path.resolve(resolvedRoot, projectConfig.siteDefaultComponentPath)
+        : undefined
 
     if (includeBoardFiles) {
       const files = findBoardFiles({ projectDir: resolvedRoot })
@@ -58,6 +63,7 @@ export async function getBuildEntrypoints({
         return {
           projectDir: resolvedRoot,
           previewComponentPath: resolvedPreviewComponentPath,
+          siteDefaultComponentPath: resolvedSiteDefaultComponentPath,
           circuitFiles: files,
         }
       }
@@ -74,6 +80,7 @@ export async function getBuildEntrypoints({
         projectDir: resolvedRoot,
         mainEntrypoint,
         previewComponentPath: resolvedPreviewComponentPath,
+        siteDefaultComponentPath: resolvedSiteDefaultComponentPath,
         circuitFiles: [mainEntrypoint],
       }
     }
@@ -81,6 +88,7 @@ export async function getBuildEntrypoints({
     return {
       projectDir: resolvedRoot,
       previewComponentPath: resolvedPreviewComponentPath,
+      siteDefaultComponentPath: resolvedSiteDefaultComponentPath,
       circuitFiles: [],
     }
   }
@@ -92,6 +100,10 @@ export async function getBuildEntrypoints({
       const resolvedPreviewComponentPath = projectConfig?.previewComponentPath
         ? path.resolve(resolvedRoot, projectConfig.previewComponentPath)
         : undefined
+      const resolvedSiteDefaultComponentPath =
+        projectConfig?.siteDefaultComponentPath
+          ? path.resolve(resolvedRoot, projectConfig.siteDefaultComponentPath)
+          : undefined
 
       if (includeBoardFiles) {
         const circuitFiles = findBoardFiles({
@@ -108,6 +120,7 @@ export async function getBuildEntrypoints({
         return {
           projectDir: resolvedRoot,
           previewComponentPath: resolvedPreviewComponentPath,
+          siteDefaultComponentPath: resolvedSiteDefaultComponentPath,
           circuitFiles,
         }
       }
@@ -123,6 +136,7 @@ export async function getBuildEntrypoints({
         projectDir,
         mainEntrypoint: mainEntrypoint || undefined,
         previewComponentPath: resolvedPreviewComponentPath,
+        siteDefaultComponentPath: resolvedSiteDefaultComponentPath,
         circuitFiles: mainEntrypoint ? [mainEntrypoint] : [],
       }
     }
@@ -133,9 +147,14 @@ export async function getBuildEntrypoints({
     const resolvedPreviewComponentPath = projectConfig?.previewComponentPath
       ? path.resolve(projectDir, projectConfig.previewComponentPath)
       : undefined
+    const resolvedSiteDefaultComponentPath =
+      projectConfig?.siteDefaultComponentPath
+        ? path.resolve(projectDir, projectConfig.siteDefaultComponentPath)
+        : undefined
     return {
       projectDir,
       previewComponentPath: resolvedPreviewComponentPath,
+      siteDefaultComponentPath: resolvedSiteDefaultComponentPath,
       circuitFiles: [resolved],
     }
   }

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -24,6 +24,9 @@ import runFrameStandaloneBundleContent from "@tscircuit/runframe/standalone" wit
   type: "text",
 }
 
+const normalizeRelativePath = (projectDir: string, targetPath: string) =>
+  path.relative(projectDir, targetPath).split(path.sep).join("/")
+
 export const registerBuild = (program: Command) => {
   program
     .command("build")
@@ -63,6 +66,7 @@ export const registerBuild = (program: Command) => {
           circuitFiles,
           mainEntrypoint,
           previewComponentPath,
+          siteDefaultComponentPath,
         } = await getBuildEntrypoints({
           fileOrDir: file,
         })
@@ -244,6 +248,9 @@ export const registerBuild = (program: Command) => {
           const indexHtml = getStaticIndexHtmlFile({
             files: staticFileReferences,
             standaloneScriptSrc,
+            defaultMainComponentPath: siteDefaultComponentPath
+              ? normalizeRelativePath(projectDir, siteDefaultComponentPath)
+              : undefined,
           })
           fs.writeFileSync(path.join(distDir, "index.html"), indexHtml)
         }

--- a/cli/config/set/register.ts
+++ b/cli/config/set/register.ts
@@ -17,6 +17,7 @@ const availableGlobalConfigKeys = [
 const availableProjectConfigKeys = [
   "mainEntrypoint",
   "previewComponentPath",
+  "siteDefaultComponentPath",
   "prebuildCommand",
   "buildCommand",
 ] satisfies (keyof TscircuitProjectConfig)[]
@@ -29,7 +30,7 @@ export const registerConfigSet = (program: Command) => {
     .description("Set a configuration value (global or project-specific)")
     .argument(
       "<key>",
-      "Configuration key (e.g., alwaysCloneWithAuthorName, mainEntrypoint, previewComponentPath, prebuildCommand, buildCommand)",
+      "Configuration key (e.g., alwaysCloneWithAuthorName, mainEntrypoint, previewComponentPath, siteDefaultComponentPath, prebuildCommand, buildCommand)",
     )
     .argument("<value>", "Value to set")
     .action((key: string, value: string) => {
@@ -48,6 +49,7 @@ export const registerConfigSet = (program: Command) => {
         if (
           key === "mainEntrypoint" ||
           key === "previewComponentPath" ||
+          key === "siteDefaultComponentPath" ||
           key === "prebuildCommand" ||
           key === "buildCommand"
         ) {

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 export const projectConfigSchema = z.object({
   mainEntrypoint: z.string().optional(),
   previewComponentPath: z.string().optional(),
+  siteDefaultComponentPath: z.string().optional(),
   ignoredFiles: z.array(z.string()).optional(),
   includeBoardFiles: z.array(z.string()).optional(),
   snapshotsDir: z.string().optional(),

--- a/lib/site/getStaticIndexHtmlFile.ts
+++ b/lib/site/getStaticIndexHtmlFile.ts
@@ -6,15 +6,22 @@ export interface StaticBuildFileReference {
 export interface GetStaticIndexHtmlFileOptions {
   files: StaticBuildFileReference[]
   standaloneScriptSrc?: string
+  defaultMainComponentPath?: string
 }
 
 export const getStaticIndexHtmlFile = ({
   files,
   standaloneScriptSrc = "./standalone.min.js",
+  defaultMainComponentPath,
 }: GetStaticIndexHtmlFileOptions) => {
   const scriptLines = [
     "window.TSCIRCUIT_USE_RUNFRAME_FOR_CLI = false;",
     `window.TSCIRCUIT_RUNFRAME_STATIC_FILE_LIST = ${JSON.stringify(files)};`,
+    ...(defaultMainComponentPath
+      ? [
+          `window.TSCIRCUIT_DEFAULT_MAIN_COMPONENT_PATH = ${JSON.stringify(defaultMainComponentPath)};`,
+        ]
+      : []),
   ]
 
   const scriptBlock = `      <script>\n        ${scriptLines.join("\n        ")}\n      </script>\n`

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -18,6 +18,10 @@
       "type": "string",
       "description": "Optional component path used for previews."
     },
+    "siteDefaultComponentPath": {
+      "type": "string",
+      "description": "Default component path to show in generated static sites."
+    },
     "ignoredFiles": {
       "type": "array",
       "items": {


### PR DESCRIPTION
### Motivation
- Add a project config option to let a project declare the default component to show when generating a static site so the generated site can open a chosen circuit by default.

### Description
- Add `siteDefaultComponentPath` to the JSON schema (`types/tscircuit.config.schema.json`) and to the Zod project schema (`lib/project-config/project-config-schema.ts`).
- Expose `siteDefaultComponentPath` in the `tsci config set` command (`cli/config/set/register.ts`).
- Plumb `siteDefaultComponentPath` through entrypoint discovery (`cli/build/get-build-entrypoints.ts`) and pass a normalized relative path into static index generation in `build --site` (`cli/build/register.ts`).
- Extend `getStaticIndexHtmlFile` (`lib/site/getStaticIndexHtmlFile.ts`) to include `window.TSCIRCUIT_DEFAULT_MAIN_COMPONENT_PATH` when a default component path is provided.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a44bfc5b4832792d630cea8028d0b)