### PR TITLE
Use TSCIRCUIT_DEPLOYMENT_URL for KiCad PCM base URL

### DIFF
--- a/cli/build/build-kicad-pcm.ts
+++ b/cli/build/build-kicad-pcm.ts
@@ -45,7 +45,12 @@ export async function buildKicadPcm({
   // Generate PCM assets
   const pcmOutputDir = path.join(distDir, "pcm")
   // Base URL format: https://{author}--{packageName}.tscircuit.app
-  const baseUrl = `https://${author}--${packageName}.tscircuit.app`
+  const envDeploymentUrl = process.env.TSCIRCUIT_DEPLOYMENT_URL?.replace(
+    /\/+$/,
+    "",
+  )
+  const baseUrl =
+    envDeploymentUrl ?? `https://${author}--${packageName}.tscircuit.app`
 
   await generatePcmAssets({
     packageName,


### PR DESCRIPTION
### Motivation
- Allow KiCad PCM generation to use a custom deployment URL so generated PCM repository and package download URLs can point to non-default deployments.

### Description
- Read `TSCIRCUIT_DEPLOYMENT_URL`, trim trailing slashes, and use it as the `baseUrl` when generating PCM assets with a fallback to the existing `https://{author}--{packageName}.tscircuit.app` pattern; change applied in `cli/build/build-kicad-pcm.ts`.

### Testing
- Ran `bunx tsc --noEmit` and it passed.
- Ran `bun run format` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69710ec0478c832ea7fb6c80ca753904)