### PR TITLE
Add the option for `partsEngineDisabled` in the config

### DIFF
--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -95,11 +95,14 @@ export const registerBuild = (program: Command) => {
           return
         }
 
+        const projectConfig = loadProjectConfig(projectDir)
+
         const platformConfig: PlatformConfig | undefined = (() => {
-          if (
-            !resolvedOptions?.disablePcb &&
-            !resolvedOptions?.disablePartsEngine
-          ) {
+          const partsEngineDisabled =
+            resolvedOptions?.disablePartsEngine ||
+            projectConfig?.partsEngineDisabled
+
+          if (!resolvedOptions?.disablePcb && !partsEngineDisabled) {
             return
           }
 
@@ -109,7 +112,7 @@ export const registerBuild = (program: Command) => {
             config.pcbDisabled = true
           }
 
-          if (resolvedOptions?.disablePartsEngine) {
+          if (partsEngineDisabled) {
             config.partsEngineDisabled = true
           }
 

--- a/cli/export/register.ts
+++ b/cli/export/register.ts
@@ -6,6 +6,7 @@ import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { getSpiceWithPaddedSim } from "lib/shared/get-spice-with-sim"
 import { runSimulation } from "lib/eecircuit-engine/run-simulation"
 import { resultToCsv } from "lib/shared/result-to-csv"
+import { loadProjectConfig } from "lib/project-config"
 import path from "node:path"
 import { promises as fs } from "node:fs"
 import type { PlatformConfig } from "@tscircuit/props"
@@ -32,10 +33,16 @@ export const registerExport = (program: Command) => {
       ) => {
         const formatOption = options.format ?? "json"
 
-        const platformConfig: PlatformConfig | undefined =
-          options.disablePartsEngine === true
-            ? { partsEngineDisabled: true }
-            : undefined
+        const projectDir = path.dirname(path.resolve(file))
+        const projectConfig = loadProjectConfig(projectDir)
+
+        const partsEngineDisabled =
+          options.disablePartsEngine === true ||
+          projectConfig?.partsEngineDisabled === true
+
+        const platformConfig: PlatformConfig | undefined = partsEngineDisabled
+          ? { partsEngineDisabled: true }
+          : undefined
 
         if (formatOption === "spice") {
           const { circuitJson } = await generateCircuitJson({

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -11,6 +11,7 @@ export const projectConfigSchema = z.object({
   buildCommand: z.string().optional(),
   kicadLibraryEntrypointPath: z.string().optional(),
   alwaysUseLatestTscircuitOnCloud: z.boolean().optional(),
+  partsEngineDisabled: z.boolean().optional(),
   build: z
     .object({
       circuitJson: z.boolean().optional(),

--- a/tests/cli/build/build-parts-engine-disabled.test.ts
+++ b/tests/cli/build/build-parts-engine-disabled.test.ts
@@ -1,0 +1,43 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readFile } from "node:fs/promises"
+import path from "node:path"
+
+const circuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+    <capacitor capacitance="1000pF" footprint="0402" name="C1" schX={-3} pcbX={-3} />
+  </board>
+)`
+
+test("build with partsEngineDisabled in config produces source_component without supplier_part_numbers", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "test-circuit.tsx")
+
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ partsEngineDisabled: true }),
+  )
+
+  await runCommand(`tsci build ${circuitPath}`)
+
+  const data = await readFile(
+    path.join(tmpDir, "dist", "test-circuit", "circuit.json"),
+    "utf-8",
+  )
+  const circuitJson = JSON.parse(data)
+  const sourceComponents = circuitJson.filter(
+    (component: any) => component.type === "source_component",
+  )
+
+  expect(sourceComponents.length).toBe(2)
+  expect(sourceComponents[0].name).toBe("R1")
+  expect(sourceComponents[1].name).toBe("C1")
+
+  // When parts engine is disabled, supplier_part_numbers should be undefined
+  expect(sourceComponents[0].supplier_part_numbers).toBeUndefined()
+  expect(sourceComponents[1].supplier_part_numbers).toBeUndefined()
+}, 30_000)

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -52,6 +52,10 @@
       "type": "string",
       "description": "Entry file for KiCad footprint library generation."
     },
+    "partsEngineDisabled": {
+      "type": "boolean",
+      "description": "Disable the parts engine for builds. When true, supplier_part_numbers will not be populated on source_component elements."
+    },
     "build": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
Without the partsEngine phase being run, the build is quite fast

<img width="1950" height="1010" alt="image" src="https://github.com/user-attachments/assets/9880df13-bbaf-4ba8-a59a-a49e688c1197" />
