### PR TITLE
Add kicadLibraryName to tscircuit config

### DIFF
--- a/cli/build/build-kicad-pcm.ts
+++ b/cli/build/build-kicad-pcm.ts
@@ -4,6 +4,7 @@ import kleur from "kleur"
 import { convertToKicadLibrary } from "lib/shared/convert-to-kicad-library"
 import { generatePcmAssets } from "lib/shared/generate-pcm-assets"
 import { getPackageAuthor } from "lib/utils/get-package-author"
+import { loadProjectConfig } from "lib/project-config"
 
 export interface BuildKicadPcmOptions {
   entryFile: string
@@ -30,7 +31,9 @@ export async function buildKicadPcm({
   const author = getPackageAuthor(packageJson.name || "") || "tscircuit"
   const description = packageJson.description || ""
 
-  const libraryName = path.basename(projectDir)
+  const projectConfig = loadProjectConfig(projectDir)
+  const libraryName =
+    projectConfig?.kicadLibraryName ?? path.basename(projectDir)
   const kicadLibOutputDir = path.join(distDir, "kicad-library")
 
   // First generate kicad-library if not already done

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -384,7 +384,8 @@ export const registerBuild = (program: Command) => {
               process.exit(1)
             }
           } else {
-            const libraryName = path.basename(projectDir)
+            const libraryName =
+              projectConfig?.kicadLibraryName ?? path.basename(projectDir)
             const kicadLibOutputDir = path.join(distDir, "kicad-library")
             try {
               await convertToKicadLibrary({

--- a/cli/config/set/register.ts
+++ b/cli/config/set/register.ts
@@ -17,6 +17,7 @@ const availableGlobalConfigKeys = [
 const availableProjectConfigKeys = [
   "mainEntrypoint",
   "kicadLibraryEntrypointPath",
+  "kicadLibraryName",
   "previewComponentPath",
   "siteDefaultComponentPath",
   "prebuildCommand",
@@ -31,7 +32,7 @@ export const registerConfigSet = (program: Command) => {
     .description("Set a configuration value (global or project-specific)")
     .argument(
       "<key>",
-      "Configuration key (e.g., alwaysCloneWithAuthorName, mainEntrypoint, kicadLibraryEntrypointPath, previewComponentPath, siteDefaultComponentPath, prebuildCommand, buildCommand)",
+      "Configuration key (e.g., alwaysCloneWithAuthorName, mainEntrypoint, kicadLibraryEntrypointPath, kicadLibraryName, previewComponentPath, siteDefaultComponentPath, prebuildCommand, buildCommand)",
     )
     .argument("<value>", "Value to set")
     .action((key: string, value: string) => {
@@ -50,6 +51,7 @@ export const registerConfigSet = (program: Command) => {
         if (
           key === "mainEntrypoint" ||
           key === "kicadLibraryEntrypointPath" ||
+          key === "kicadLibraryName" ||
           key === "previewComponentPath" ||
           key === "siteDefaultComponentPath" ||
           key === "prebuildCommand" ||

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -10,6 +10,7 @@ export const projectConfigSchema = z.object({
   prebuildCommand: z.string().optional(),
   buildCommand: z.string().optional(),
   kicadLibraryEntrypointPath: z.string().optional(),
+  kicadLibraryName: z.string().optional(),
   alwaysUseLatestTscircuitOnCloud: z.boolean().optional(),
   build: z
     .object({

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -52,6 +52,10 @@
       "type": "string",
       "description": "Entry file for KiCad footprint library generation."
     },
+    "kicadLibraryName": {
+      "type": "string",
+      "description": "Name for the generated KiCad library."
+    },
     "build": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
### Motivation
- Allow projects to specify a custom KiCad library name in `tscircuit.config.json` so generated KiCad library and PCM assets use a stable or preferred library name instead of defaulting to the project directory basename.

### Description
- Add `kicadLibraryName` to the project config Zod schema (`lib/project-config/project-config-schema.ts`) and the JSON schema (`types/tscircuit.config.schema.json`), expose it in the CLI config setter (`cli/config/set/register.ts`), and prefer `projectConfig?.kicadLibraryName` when computing the library name in KiCad library/PCM generation (`cli/build/register.ts` and `cli/build/build-kicad-pcm.ts`).

### Testing
- Ran `bunx tsc --noEmit` for typechecking and `bun run format` for formatting, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697147eb5524832e97a8e2087f9527ec)