### PR TITLE
Sync config schema JSON with TS definition

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": false,
+    "resolveJsonModule": true,
     "noEmit": true,
 
     // Best practices

--- a/types/tscircuit.config.schema.assert.ts
+++ b/types/tscircuit.config.schema.assert.ts
@@ -1,0 +1,32 @@
+import type { z } from "zod"
+
+import { projectConfigSchema } from "../lib/project-config/project-config-schema"
+import schemaJson from "./tscircuit.config.schema.json"
+
+/**
+ * Ensure every property defined in the TypeScript config schema
+ * is represented in the JSON schema.
+ */
+type Config = z.infer<typeof projectConfigSchema>
+type ConfigKeys = keyof Config
+type JsonSchemaKeys = keyof typeof schemaJson.properties
+
+type MissingTopLevelKeys = Exclude<ConfigKeys, JsonSchemaKeys>
+type AssertNoMissingTopLevelKeys = MissingTopLevelKeys extends never
+  ? true
+  : never
+
+const _assertTopLevelKeys: AssertNoMissingTopLevelKeys = true
+
+/**
+ * Ensure nested build options stay in sync too.
+ */
+type ConfigBuildKeys = keyof NonNullable<Config["build"]>
+type JsonBuildKeys = keyof typeof schemaJson.properties.build.properties
+
+type MissingBuildKeys = Exclude<ConfigBuildKeys, JsonBuildKeys>
+type AssertNoMissingBuildKeys = MissingBuildKeys extends never ? true : never
+
+const _assertBuildKeys: AssertNoMissingBuildKeys = true
+
+void [_assertTopLevelKeys, _assertBuildKeys]

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -52,6 +52,10 @@
       "type": "string",
       "description": "Entry file for KiCad footprint library generation."
     },
+    "alwaysUseLatestTscircuitOnCloud": {
+      "type": "boolean",
+      "description": "Always use the latest TSCircuit version when building on the cloud."
+    },
     "build": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
### Motivation
- Keep the published JSON schema in sync with the TypeScript config shape so tooling and consumers see the same properties.
- Document the new cloud flag so it can be validated by editors and schema-aware tools.
- Prevent regressions where TypeScript schema additions are not mirrored into the JSON schema by enforcing a compile-time check.

### Description
- Add `alwaysUseLatestTscircuitOnCloud` to `types/tscircuit.config.schema.json` as a boolean with a description. 
- Add a type-level assertion file `types/tscircuit.config.schema.assert.ts` that imports the TS `projectConfigSchema` and the JSON schema and verifies top-level keys and nested `build` keys match via TypeScript conditional types. 
- Enable JSON module imports in `tsconfig.json` by setting `resolveJsonModule: true` so the assertion file can import the JSON schema.

### Testing
- Ran `bunx tsc --noEmit` to type-check the repository and validate the assertion file, which succeeded. 
- Ran `bun run format` to apply formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697153faa110832e874e0fb72956ecb1)