### PR TITLE
test: skip flaky build-concurrency tests

### DIFF
--- a/tests/cli/build/build-concurrency.test.ts
+++ b/tests/cli/build/build-concurrency.test.ts
@@ -3,6 +3,7 @@ import { test, expect } from "bun:test"
 import { writeFile, readFile } from "node:fs/promises"
 import path from "node:path"
 
+// TODO: Re-enable once build concurrency flakiness is resolved.
 const packageJson = JSON.stringify({
   name: "test-project",
   dependencies: {
@@ -18,7 +19,7 @@ export default () => (
   </board>
 )`
 
-test("build with --concurrency builds multiple files in parallel", async () => {
+test.skip("build with --concurrency builds multiple files in parallel", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   // Create multiple circuit files
@@ -52,7 +53,7 @@ test("build with --concurrency builds multiple files in parallel", async () => {
   }
 }, 60_000)
 
-test("build without --concurrency defaults to sequential", async () => {
+test.skip("build without --concurrency defaults to sequential", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   await writeFile(path.join(tmpDir, "test.circuit.tsx"), circuitCode("R1"))
@@ -72,7 +73,7 @@ test("build without --concurrency defaults to sequential", async () => {
   expect(component.name).toBe("R1")
 }, 30_000)
 
-test("build with --concurrency handles errors correctly", async () => {
+test.skip("build with --concurrency handles errors correctly", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   // Create one valid and one invalid circuit file


### PR DESCRIPTION
### Motivation
- Temporarily skip flaky build concurrency tests to stabilize test runs while the underlying flakiness is investigated.

### Description
- Marked the three tests in `tests/cli/build/build-concurrency.test.ts` with `test.skip` and added a `// TODO: Re-enable once build concurrency flakiness is resolved.` comment.

### Testing
- Ran `bun test tests/cli/build/build-concurrency.test.ts` (results: 3 skipped, 0 fail), `bunx tsc --noEmit` (typecheck passed), and `bun run format` (files formatted) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697170567acc832e8b72c4fe15fe784c)