### PR TITLE
Render KiCad library components with name="REF**"

### DIFF
--- a/lib/shared/convert-to-kicad-library.tsx
+++ b/lib/shared/convert-to-kicad-library.tsx
@@ -46,7 +46,7 @@ export async function convertToKicadLibrary({
 
         // Create a circuit and render the component
         const runner = new userLandTscircuit.RootCircuit()
-        runner.add(<Component name={componentName} />)
+        runner.add(<Component name="REF**" />)
         await runner.renderUntilSettled()
         return await runner.getCircuitJson()
       } catch (error) {


### PR DESCRIPTION
### Motivation
- Ensure KiCad library conversion renders components with a stable reference name so generated circuit JSON and footprints use the expected placeholder instead of component-specific names.

### Description
- In `lib/shared/convert-to-kicad-library.tsx` replace `runner.add(<Component name={componentName} />)` with `runner.add(<Component name="REF**" />)` so components are instantiated with a fixed `name` during conversion.

### Testing
- Ran `bunx tsc --noEmit` and `bun run format`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697175735f28832eb4c1016bf1ea2756)