### PR TITLE
make tsci build use tscircuit.config.json settings

### DIFF
--- a/tests/cli/build/build-config.test.ts
+++ b/tests/cli/build/build-config.test.ts
@@ -1,0 +1,54 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readdir, mkdir } from "node:fs/promises"
+import path from "node:path"
+import fs from "node:fs"
+
+test("build (without --ci) with build.kicadLibrary config generates KiCad library", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  // Create lib directory with a component
+  await mkdir(path.join(tmpDir, "lib"), { recursive: true })
+
+  const componentCode = `
+export const MyResistor = () => (
+  <resistor resistance="1k" footprint="0402" name="R1" />
+)
+`
+
+  await writeFile(path.join(tmpDir, "lib", "index.tsx"), componentCode)
+
+  // Create tscircuit.config.json with build.kicadLibrary enabled
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({
+      mainEntrypoint: "./lib/index.tsx",
+      build: {
+        kicadLibrary: true,
+      },
+    }),
+  )
+
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({
+      name: "test-kicad-library-no-ci",
+      version: "1.0.0",
+      type: "module",
+      dependencies: {
+        react: "^19.1.0",
+      },
+    }),
+  )
+
+  await runCommand("tsci install")
+
+  const { stdout, stderr } = await runCommand("tsci build")
+
+  expect(stdout).toContain("Generating KiCad footprint library")
+  expect(stdout).toContain("kicad-footprint-library")
+
+  // Check that the kicad-library directory was created
+  const kicadLibDir = path.join(tmpDir, "dist", "kicad-library")
+  expect(fs.existsSync(kicadLibDir)).toBe(true)
+}, 120_000)


### PR DESCRIPTION
/fix #1701 

Test Output:
``` bash
USER@DESKTOP-1PHUG1C MINGW64 ~/3D Objects/cli (main)
$ bun test tests/cli/build/build-config.test.ts
bun test v1.2.23 (cf136713)

tests\cli\build\build-config.test.ts:
Found existing package.json.
Creating .npmrc with tscircuit registry configuration.
Installing dependencies using bun...
> bun install
bun install v1.2.23 (cf136713)

+ react@19.2.3

1 package installed [196.00ms]
Dependencies installed successfully.
Building 1 file(s)...
Building lib\index.tsx...
Generating circuit JSON...
Circuit JSON written to dist\lib\index\circuit.json
Port pin1 on R1 is missing a trace
Port pin1 on R1 is missing a trace
Port pin2 on R1 is missing a trace
Port pin2 on R1 is missing a trace
Generating KiCad footprint library...
  KiCad library generated at dist\kicad-library

Build complete
  Circuits  1 passed
  Options   kicad-footprint-library
  Output    dist

✓ Done
✓ build (without --ci) with build.kicadLibrary config generates KiCad library [25984.00ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [27.02s]
```