### PR TITLE
feat: parse .kicad_mod imports to circuit JSON

### DIFF
--- a/tests/fixtures/test-resistor.kicad_mod
+++ b/tests/fixtures/test-resistor.kicad_mod
@@ -1,0 +1,58 @@
+(footprint "R_0402_1005Metric"
+		(version 20241229)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC-7351 nominal")
+		(tags "resistor")
+		(property "Reference" "REF**"
+			(at 0 -1.17 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "R_0402_1005Metric"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(fp_line
+			(start -0.153641 -0.38)
+			(end 0.153641 -0.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -0.153641 0.38)
+			(end 0.153641 0.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(pad "1" smd roundrect
+			(at -0.51 0)
+			(size 0.54 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+		)
+		(pad "2" smd roundrect
+			(at 0.51 0)
+			(size 0.54 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+		)
+	)

--- a/tests/shared/kicad-mod-import-parsing.test.ts
+++ b/tests/shared/kicad-mod-import-parsing.test.ts
@@ -1,0 +1,66 @@
+import { test, expect, beforeAll } from "bun:test"
+import { plugin } from "bun"
+import path from "node:path"
+
+// Register the static asset loaders before running tests
+beforeAll(async () => {
+  const { registerStaticAssetLoaders } = await import(
+    "lib/shared/register-static-asset-loaders"
+  )
+  registerStaticAssetLoaders()
+})
+
+test("should load .kicad_mod file and export circuit JSON array", async () => {
+  const fixturePath = path.resolve(
+    import.meta.dir,
+    "../fixtures/test-resistor.kicad_mod",
+  )
+  const mod = await import(fixturePath)
+
+  // Should be an array of circuit elements
+  expect(Array.isArray(mod.default)).toBe(true)
+  expect(mod.default.length).toBeGreaterThan(0)
+})
+
+test("exported circuit JSON should contain pcb_smtpad elements", async () => {
+  const fixturePath = path.resolve(
+    import.meta.dir,
+    "../fixtures/test-resistor.kicad_mod",
+  )
+  const mod = await import(fixturePath)
+  const circuitJson = mod.default
+
+  // Should contain smtpad elements from the R_0402 resistor footprint
+  const smtpads = circuitJson.filter(
+    (el: { type: string }) => el.type === "pcb_smtpad",
+  )
+  expect(smtpads.length).toBeGreaterThan(0)
+})
+
+test("exported circuit JSON should have valid structure", async () => {
+  const fixturePath = path.resolve(
+    import.meta.dir,
+    "../fixtures/test-resistor.kicad_mod",
+  )
+  const mod = await import(fixturePath)
+  const circuitJson = mod.default
+
+  // Each element should have a type property
+  for (const element of circuitJson) {
+    expect(element).toHaveProperty("type")
+  }
+})
+
+test("can use footprint directly (array of circuit elements)", async () => {
+  const fixturePath = path.resolve(
+    import.meta.dir,
+    "../fixtures/test-resistor.kicad_mod",
+  )
+  const mod = await import(fixturePath)
+  const footprint = mod.default
+
+  // The footprint should be usable as-is (array of circuit elements)
+  // This simulates how it would be used: <chip footprint={footprint} />
+  expect(footprint).toBeDefined()
+  expect(Array.isArray(footprint)).toBe(true)
+})

--- a/types/static-assets/index.d.ts
+++ b/types/static-assets/index.d.ts
@@ -49,8 +49,9 @@ declare module "*.step" {
 }
 
 declare module "*.kicad_mod" {
-  const src: string
-  export default src
+  import type { AnyCircuitElement } from "circuit-json"
+  const circuitJson: AnyCircuitElement[]
+  export default circuitJson
 }
 
 declare module "*.kicad_pcb" {


### PR DESCRIPTION
## Summary
Parse `.kicad_mod` files at import time and export circuit JSON directly, enabling:
```tsx
import footprint from "./my-footprint.kicad_mod"
<chip footprint={footprint} name="U1" />
```

## Changes
- Modify `lib/shared/register-static-asset-loaders.ts` to parse `.kicad_mod` files using `kicad-component-converter` (already a dependency)
- Update TypeScript declaration to return `AnyCircuitElement[]` instead of `string`
- Add tests for the new behavior

## How It Works
The existing Bun plugin for static assets now has special handling for `.kicad_mod`:
1. Reads the file content at import time
2. Parses it using `parseKicadModToCircuitJson()`
3. Exports the circuit JSON array directly

Other static assets (`.gltf`, `.step`, etc.) continue to export file paths as before.

## Test Plan
- [x] Test that plugin exports circuit JSON array
- [x] Test that circuit JSON contains pcb_smtpad elements
- [x] Test that circuit JSON has valid structure
- [x] Test that footprint can be used directly

Closes tscircuit/tscircuit#768
/claim tscircuit/tscircuit#768