### PR TITLE
Allow importing @tscircuit/cli/lib

### DIFF
--- a/Dockerfile.smoketest
+++ b/Dockerfile.smoketest
@@ -27,7 +27,7 @@ RUN bun pm pack
 # Create a temporary directory for testing
 RUN mkdir /tmp/testdir
 
-RUN ./dist/main.js --version
+RUN ./dist/cli/main.js --version
 
 # Install the packed package globally
 RUN npm install -g $(ls *.tgz)

--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -25,7 +25,7 @@ const globalPackageJson = require("../package.json")
 const useGlobal = process.argv.includes("--use-global")
 const args = process.argv.slice(2).filter((arg) => arg !== "--use-global")
 
-let mainPath = join(packageRoot, "dist/main.js")
+let mainPath = join(packageRoot, "dist/cli/main.js")
 
 if (!useGlobal) {
   try {
@@ -35,7 +35,7 @@ if (!useGlobal) {
     )
     const localPackageJson = localRequire(localPackageJsonPath)
     const localPackageRoot = dirname(localPackageJsonPath)
-    const localMainPath = join(localPackageRoot, "dist/main.js")
+    const localMainPath = join(localPackageRoot, "dist/cli/main.js")
 
     if (localPackageRoot !== packageRoot && existsSync(localMainPath)) {
       console.warn(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tscircuit/cli",
   "version": "0.1.859",
-  "main": "dist/main.js",
+  "main": "dist/cli/main.js",
+  "exports": {
+    ".": "./dist/cli/main.js",
+    "./lib": "./dist/lib/index.js"
+  },
   "devDependencies": {
     "@babel/standalone": "^7.26.9",
     "@biomejs/biome": "^1.9.4",

--- a/scripts/bun-build.ts
+++ b/scripts/bun-build.ts
@@ -7,7 +7,11 @@ const tscircuitPackageJsonDeps = Object.keys(tscircuitPackageJson.dependencies)
 const ALLOW_BUNDLING = ["@tscircuit/runframe"]
 
 const result = await Bun.build({
-  entrypoints: ["./cli/main.ts", "./cli/build/build-worker-entrypoint.ts"],
+  entrypoints: [
+    "./cli/main.ts",
+    "./cli/build/build-worker-entrypoint.ts",
+    "./lib/index.ts",
+  ],
   target: "node",
   outdir: "./dist",
   external: [

--- a/tests/cli/entrypoint/use-global-flag.test.ts
+++ b/tests/cli/entrypoint/use-global-flag.test.ts
@@ -9,7 +9,7 @@ test("entrypoint uses local version by default when available", async () => {
   const localCliPath = join(tmpDir, "node_modules", "@tscircuit", "cli")
 
   mkdirSync(localCliPath, { recursive: true })
-  mkdirSync(join(localCliPath, "dist"), { recursive: true })
+  mkdirSync(join(localCliPath, "dist", "cli"), { recursive: true })
 
   writeFileSync(
     join(tmpDir, "package.json"),
@@ -22,7 +22,7 @@ test("entrypoint uses local version by default when available", async () => {
   )
 
   writeFileSync(
-    join(localCliPath, "dist", "main.js"),
+    join(localCliPath, "dist", "cli", "main.js"),
     'console.log("LOCAL_CLI_EXECUTED")',
   )
 
@@ -45,7 +45,7 @@ test("entrypoint skips local version when --use-global flag is passed", async ()
   const localCliPath = join(tmpDir, "node_modules", "@tscircuit", "cli")
 
   mkdirSync(localCliPath, { recursive: true })
-  mkdirSync(join(localCliPath, "dist"), { recursive: true })
+  mkdirSync(join(localCliPath, "dist", "cli"), { recursive: true })
 
   writeFileSync(
     join(tmpDir, "package.json"),
@@ -58,7 +58,7 @@ test("entrypoint skips local version when --use-global flag is passed", async ()
   )
 
   writeFileSync(
-    join(localCliPath, "dist", "main.js"),
+    join(localCliPath, "dist", "cli", "main.js"),
     'console.log("LOCAL_CLI_EXECUTED")',
   )
 


### PR DESCRIPTION
- **enable external generation of pcm/kicad library for better testing in circuit-json-to-kicad**
- **optional circuitJsonToKicadModule**
- **separate lib exports**
