### PR TITLE
fix: glb files should also be returned as relative path and not absolute from bun static asset loader

### DIFF
--- a/cli/build/convert-model-urls-to-file-urls.ts
+++ b/cli/build/convert-model-urls-to-file-urls.ts
@@ -1,3 +1,4 @@
+import path from "node:path"
 import { pathToFileURL } from "node:url"
 
 /**
@@ -24,13 +25,15 @@ export const convertModelUrlsToFileUrls = (circuitJson: any[]): any[] => {
     for (const key of modelUrlKeys) {
       const value = updated[key]
       if (typeof value === "string" && value.length > 0) {
-        // Check if it's a local file path (starts with / or drive letter on Windows)
-        // and not already a URL (http://, https://, file://, etc.)
-        if (
-          !value.match(/^[a-zA-Z]+:\/\//) &&
-          (value.startsWith("/") || value.match(/^[a-zA-Z]:\\/))
-        ) {
+        // Skip values that are already URLs (http://, https://, file://, etc.)
+        if (value.match(/^[a-zA-Z]+:\/\//)) continue
+
+        if (value.startsWith("/") || value.match(/^[a-zA-Z]:\\/)) {
+          // Absolute path (Unix or Windows)
           updated[key] = pathToFileURL(value).href
+        } else if (value.startsWith(".")) {
+          // Relative path (e.g. ./chip.glb) — resolve against cwd
+          updated[key] = pathToFileURL(path.resolve(process.cwd(), value)).href
         }
       }
     }

--- a/lib/shared/register-static-asset-loaders.ts
+++ b/lib/shared/register-static-asset-loaders.ts
@@ -2,6 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 
 const TEXT_STATIC_ASSET_EXTENSIONS = [
+  ".glb",
   ".gltf",
   ".step",
   ".kicad_mod",

--- a/lib/shared/register-static-asset-loaders.ts
+++ b/lib/shared/register-static-asset-loaders.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs"
 import path from "node:path"
 
-const TEXT_STATIC_ASSET_EXTENSIONS = [
+const STATIC_ASSET_EXTENSIONS = [
   ".glb",
   ".gltf",
   ".step",
@@ -12,7 +12,7 @@ const TEXT_STATIC_ASSET_EXTENSIONS = [
 ]
 
 const staticAssetFilter = new RegExp(
-  `(${TEXT_STATIC_ASSET_EXTENSIONS.map((ext) => ext.replace(".", "\\.")).join(
+  `(${STATIC_ASSET_EXTENSIONS.map((ext) => ext.replace(".", "\\.")).join(
     "|",
   )})$`,
   "i",

--- a/tests/cli/transpile/transpile-link-glb.test.ts
+++ b/tests/cli/transpile/transpile-link-glb.test.ts
@@ -184,6 +184,6 @@ export default () => <AliasedBoard />
     .replace(/\\/g, "/")
 
   expect(normalizedModelGlbUrl).toMatchInlineSnapshot(
-    `"<tmp>/aliased-glb-lib/dist/assets/chip-e043b555.glb"`,
+    `"./aliased-glb-lib/dist/assets/chip-e043b555.glb"`,
   )
 }, 60_000)


### PR DESCRIPTION
<img width="593" height="395" alt="image" src="https://github.com/user-attachments/assets/a981dc09-61c9-4016-add0-1e748ffa5cdc" />
