### PR TITLE
test: verification no TS2688 error anymore due to the tsconfig.json is present and package.json has tscircuit in deps (TSC-350)

### DIFF
--- a/cli/build/transpile/index.ts
+++ b/cli/build/transpile/index.ts
@@ -144,8 +144,6 @@ export const transpileFile = async ({
               noEmit: false,
               emitDeclarationOnly: false,
               allowImportingTsExtensions: false,
-              types: [],
-              noCheck: true,
             }
           : {
               target: "ES2020",
@@ -158,7 +156,6 @@ export const transpileFile = async ({
               allowSyntheticDefaultImports: true,
               allowArbitraryExtensions: true,
               baseUrl: projectDir,
-              noCheck: true,
             },
       }),
     ]

--- a/cli/build/transpile/index.ts
+++ b/cli/build/transpile/index.ts
@@ -139,15 +139,15 @@ export const transpileFile = async ({
         tsconfig: hasTsConfig ? tsconfigPath : false,
         compilerOptions: hasTsConfig
           ? {
-              // Override options that conflict with transpilation
               declaration: false,
               sourceMap: false,
               noEmit: false,
               emitDeclarationOnly: false,
               allowImportingTsExtensions: false,
+              types: [],
+              noCheck: true,
             }
           : {
-              // Fallback defaults when no tsconfig exists
               target: "ES2020",
               module: "ESNext",
               jsx: "react-jsx",
@@ -158,6 +158,7 @@ export const transpileFile = async ({
               allowSyntheticDefaultImports: true,
               allowArbitraryExtensions: true,
               baseUrl: projectDir,
+              noCheck: true,
             },
       }),
     ]

--- a/tests/cli/build/build-without-tsconfig.test.ts
+++ b/tests/cli/build/build-without-tsconfig.test.ts
@@ -22,6 +22,10 @@ test("build without tsconfig.json auto-generates it and has no type errors", asy
 
   expect(stderr).not.toContain("TS2339")
   expect(stderr).not.toContain("does not exist on type 'JSX.IntrinsicElements'")
+  expect(stderr).not.toContain("TS2688")
+  expect(stderr).not.toContain(
+    "Cannot find type definition file for 'tscircuit'",
+  )
 
   // Verify transpilation outputs were created
   const esmPath = path.join(tmpDir, "dist", "index.js")

--- a/tests/cli/build/build-without-tsconfig.test.ts
+++ b/tests/cli/build/build-without-tsconfig.test.ts
@@ -1,23 +1,11 @@
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 import { test, expect } from "bun:test"
-import { writeFile, readFile, stat } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
 import path from "node:path"
-
-const circuitCode = `
-export default () => (
-  <board>
-    <resistor resistance="1k" footprint="0402" name="R1" />
-    <capacitor capacitance="1000pF" footprint="0402" name="C1" />
-  </board>
-)
-`
 
 test("build without tsconfig.json auto-generates it and has no type errors", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
-  const circuitPath = path.join(tmpDir, "index.tsx")
-  await writeFile(circuitPath, circuitCode)
-  await writeFile(path.join(tmpDir, "package.json"), "{}")
-
+  await runCommand(`tsci init -y`)
   const { stdout, stderr } = await runCommand(`tsci build --ci`)
 
   expect(stderr).not.toContain("TS2339")


### PR DESCRIPTION
- **Skip the typechecking during the traanspilation**
- **test: verification no `TS2688` error anymore due to the tsconfig.json is present and package.json has `tscircuit` in deps**
