### PR TITLE
Add `.stp` support to static asset and binary file lists

### DIFF
--- a/cli/build/transpile/static-asset-plugin.ts
+++ b/cli/build/transpile/static-asset-plugin.ts
@@ -22,6 +22,7 @@ export const STATIC_ASSET_EXTENSIONS = new Set([
   ".gif",
   ".bmp",
   ".step",
+  ".stp",
   ".kicad_mod",
   ".kicad_pcb",
   ".kicad_pro",

--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -29,6 +29,7 @@ const BINARY_FILE_EXTENSIONS = new Set([
   ".jpeg",
   ".jpg",
   ".step",
+  ".stp",
 ])
 
 type FileUploadPayload = Pick<

--- a/lib/shared/is-binary-file.ts
+++ b/lib/shared/is-binary-file.ts
@@ -11,6 +11,7 @@ export const BINARY_FILE_EXTENSIONS = new Set([
   ".obj",
   ".stl",
   ".step",
+  ".stp",
   // Image formats
   ".png",
   ".jpg",

--- a/lib/shared/register-static-asset-loaders.ts
+++ b/lib/shared/register-static-asset-loaders.ts
@@ -5,6 +5,7 @@ const STATIC_ASSET_EXTENSIONS = [
   ".glb",
   ".gltf",
   ".step",
+  ".stp",
   ".kicad_mod",
   ".kicad_pcb",
   ".kicad_pro",

--- a/types/static-assets/index.d.ts
+++ b/types/static-assets/index.d.ts
@@ -48,6 +48,11 @@ declare module "*.step" {
   export default src
 }
 
+declare module "*.stp" {
+  const src: string
+  export default src
+}
+
 declare module "*.kicad_mod" {
   const src: string
   export default src


### PR DESCRIPTION
### Motivation
- `.stp` is a common alternate extension for STEP 3D models and should be handled the same as `.step` across the build, dev, and type-system paths. 
- Ensure runtime loaders, the dev file-sync/upload paths, and tooling treat `.stp` assets consistently to avoid import/ upload/ type errors.

### Description
- Added `".stp"` to the transpiler static asset set in `cli/build/transpile/static-asset-plugin.ts` so `.stp` imports are resolved and copied during bundling.  
- Added `".stp"` to the dev server binary extensions in `cli/dev/DevServer.ts` so `.stp` files are treated as binary during sync/upload.  
- Added `".stp"` to the shared static asset loader list in `lib/shared/register-static-asset-loaders.ts` so Bun loader handling matches other codepaths.  
- Added `".stp"` to the binary file detection set in `lib/shared/is-binary-file.ts` and a TypeScript module declaration `declare module "*.stp"` in `types/static-assets/index.d.ts` to support typed imports.

### Testing
- Ran `bun test tests/cli/build/build-step-assets-from-dependency.test.ts` which passed (1 test, 1 pass).  
- Ran `bunx tsc --noEmit` for type checking which completed with no errors.  
- Ran `bun run format` to apply formatting; formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698fb744d7ac832e9166729eb69f146c)