### PR TITLE
fix: type error in cloud about missing types for `tscircuit` when `alwaysUseLatestTscircuitOnCloud` is present in the config

### DIFF
--- a/tests/cli/build/build-ci-keep-tscircuit-types.test.ts
+++ b/tests/cli/build/build-ci-keep-tscircuit-types.test.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
-test("build --ci with alwaysUseLatestTscircuitOnCloud removes tscircuit from dependencies", async () => {
+test("build --ci keeps tscircuit in devDependencies", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   await writeFile(
@@ -17,11 +17,14 @@ test("build --ci with alwaysUseLatestTscircuitOnCloud removes tscircuit from dep
   await writeFile(
     path.join(tmpDir, "package.json"),
     JSON.stringify({
-      name: "test-skip-tscircuit",
+      name: "test-keep-tscircuit-types",
       version: "1.0.0",
       dependencies: {
         tscircuit: "^0.0.100",
         lodash: "^4.17.21",
+      },
+      devDependencies: {
+        tscircuit: "^0.0.101",
       },
     }),
   )
@@ -32,10 +35,11 @@ test("build --ci with alwaysUseLatestTscircuitOnCloud removes tscircuit from dep
     "\nSkipping tscircuit package installation from dependencies (using cloud container version).",
   )
 
-  // Verify package.json was modified to remove tscircuit
   const packageJson = JSON.parse(
     await readFile(path.join(tmpDir, "package.json"), "utf-8"),
   )
+
   expect(packageJson.dependencies.tscircuit).toBeUndefined()
   expect(packageJson.dependencies.lodash).toBe("^4.17.21")
+  expect(packageJson.devDependencies.tscircuit).toBe("^0.0.101")
 }, 60_000)


### PR DESCRIPTION
<img width="1572" height="670" alt="image" src="https://github.com/user-attachments/assets/024315c4-f98b-42f0-b49c-03fa9a013c3c" />

When `alwaysUseLatestTscircuitOnCloud` is present in the config file it used to remove `tscircuit` from `dependency` and `devDependency` package.json, while the tsconfig.json has the type array with `[tscircuit]` which is the reason for this issue