### PR TITLE
Add kicadProject option to the build section

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -14,7 +14,7 @@ export interface BuildCommandOptions {
   transpile?: boolean
   previewImages?: boolean
   allImages?: boolean
-  kicad?: boolean
+  kicadProject?: boolean
   kicadLibrary?: boolean
   kicadPcm?: boolean
   previewGltf?: boolean

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -58,7 +58,7 @@ export const registerBuild = (program: Command) => {
       "Generate preview images for every successful build output",
     )
     .option(
-      "--kicad",
+      "--kicad-project",
       "Generate KiCad project directories for each successful build output",
     )
     .option("--kicad-library", "Generate KiCad library in dist/kicad-library")
@@ -125,15 +125,15 @@ export const registerBuild = (program: Command) => {
           return
         }
 
-        // When --kicad is used without a file argument and kicadLibraryEntrypointPath is set,
+        // When --kicad-project is used without a file argument and kicadProjectEntrypointPath is set,
         // use that as the file to build
         let fileOrDirForBuild = file
         if (
           !file &&
-          resolvedOptions?.kicad &&
-          projectConfig?.kicadLibraryEntrypointPath
+          resolvedOptions?.kicadProject &&
+          projectConfig?.kicadProjectEntrypointPath
         ) {
-          fileOrDirForBuild = projectConfig.kicadLibraryEntrypointPath
+          fileOrDirForBuild = projectConfig.kicadProjectEntrypointPath
         }
 
         const {
@@ -192,8 +192,8 @@ export const registerBuild = (program: Command) => {
           GeneratedKicadProject & { sourcePath: string }
         > = []
 
-        const shouldGenerateKicad =
-          resolvedOptions?.kicad || resolvedOptions?.kicadLibrary
+        const shouldGenerateKicadProject =
+          resolvedOptions?.kicadProject || resolvedOptions?.kicadLibrary
 
         // Prepare build options for reuse
         const buildOptions = {
@@ -246,7 +246,7 @@ export const registerBuild = (program: Command) => {
             })
           }
 
-          if (buildOutcome.ok && shouldGenerateKicad) {
+          if (buildOutcome.ok && shouldGenerateKicadProject) {
             // Read circuit JSON from file if not provided (worker mode doesn't pass it through IPC)
             let circuitJson = buildOutcome.circuitJson
             if (!circuitJson && fs.existsSync(outputPath)) {
@@ -264,7 +264,7 @@ export const registerBuild = (program: Command) => {
                 circuitJson,
                 outputDir: projectOutputDir,
                 projectName,
-                writeFiles: Boolean(resolvedOptions?.kicad),
+                writeFiles: Boolean(resolvedOptions?.kicadProject),
               })
               kicadProjects.push({
                 ...project,
@@ -536,7 +536,7 @@ export const registerBuild = (program: Command) => {
           resolvedOptions?.previewImages && "preview-images",
           resolvedOptions?.allImages && "all-images",
           resolvedOptions?.glbs && "glbs",
-          resolvedOptions?.kicad && "kicad",
+          resolvedOptions?.kicadProject && "kicad-project",
           resolvedOptions?.kicadLibrary && "kicad-library",
           resolvedOptions?.kicadPcm && "kicad-pcm",
           resolvedOptions?.previewGltf && "preview-gltf",

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -125,13 +125,24 @@ export const registerBuild = (program: Command) => {
           return
         }
 
+        // When --kicad is used without a file argument and kicadLibraryEntrypointPath is set,
+        // use that as the file to build
+        let fileOrDirForBuild = file
+        if (
+          !file &&
+          resolvedOptions?.kicad &&
+          projectConfig?.kicadLibraryEntrypointPath
+        ) {
+          fileOrDirForBuild = projectConfig.kicadLibraryEntrypointPath
+        }
+
         const {
           circuitFiles,
           mainEntrypoint,
           previewComponentPath,
           siteDefaultComponentPath,
         } = await getBuildEntrypoints({
-          fileOrDir: file,
+          fileOrDir: fileOrDirForBuild,
         })
 
         const platformConfig: PlatformConfig | undefined = (() => {

--- a/cli/build/resolve-build-options.ts
+++ b/cli/build/resolve-build-options.ts
@@ -21,7 +21,10 @@ export const resolveBuildOptions = ({
 
   const configAppliedOpts: string[] = []
 
-  if (!cliOptions?.kicad && configBuild?.kicadLibrary) {
+  if (
+    !cliOptions?.kicad &&
+    (configBuild?.kicadProject || configBuild?.kicadLibrary)
+  ) {
     configAppliedOpts.push("kicad")
   }
   if (!cliOptions?.kicadLibrary && configBuild?.kicadLibrary) {
@@ -42,7 +45,10 @@ export const resolveBuildOptions = ({
 
   const options: BuildCommandOptions = {
     ...cliOptions,
-    kicad: cliOptions?.kicad ?? configBuild?.kicadLibrary,
+    kicad:
+      cliOptions?.kicad ??
+      configBuild?.kicadProject ??
+      configBuild?.kicadLibrary,
     kicadLibrary: cliOptions?.kicadLibrary ?? configBuild?.kicadLibrary,
     kicadPcm: cliOptions?.kicadPcm ?? configBuild?.kicadPcm,
     previewImages: cliOptions?.previewImages ?? configBuild?.previewImages,

--- a/cli/build/resolve-build-options.ts
+++ b/cli/build/resolve-build-options.ts
@@ -21,11 +21,8 @@ export const resolveBuildOptions = ({
 
   const configAppliedOpts: string[] = []
 
-  if (
-    !cliOptions?.kicad &&
-    (configBuild?.kicadProject || configBuild?.kicadLibrary)
-  ) {
-    configAppliedOpts.push("kicad")
+  if (!cliOptions?.kicadProject && configBuild?.kicadProject) {
+    configAppliedOpts.push("kicad-project")
   }
   if (!cliOptions?.kicadLibrary && configBuild?.kicadLibrary) {
     configAppliedOpts.push("kicad-library")
@@ -45,10 +42,7 @@ export const resolveBuildOptions = ({
 
   const options: BuildCommandOptions = {
     ...cliOptions,
-    kicad:
-      cliOptions?.kicad ??
-      configBuild?.kicadProject ??
-      configBuild?.kicadLibrary,
+    kicadProject: cliOptions?.kicadProject ?? configBuild?.kicadProject,
     kicadLibrary: cliOptions?.kicadLibrary ?? configBuild?.kicadLibrary,
     kicadPcm: cliOptions?.kicadPcm ?? configBuild?.kicadPcm,
     previewImages: cliOptions?.previewImages ?? configBuild?.previewImages,

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -15,6 +15,7 @@ export const projectConfigSchema = z.object({
   build: z
     .object({
       circuitJson: z.boolean().optional(),
+      kicadProject: z.boolean().optional(),
       kicadLibrary: z.boolean().optional(),
       kicadPcm: z.boolean().optional(),
       previewImages: z.boolean().optional(),

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -9,6 +9,7 @@ export const projectConfigSchema = z.object({
   snapshotsDir: z.string().optional(),
   prebuildCommand: z.string().optional(),
   buildCommand: z.string().optional(),
+  kicadProjectEntrypointPath: z.string().optional(),
   kicadLibraryEntrypointPath: z.string().optional(),
   kicadLibraryName: z.string().optional(),
   alwaysUseLatestTscircuitOnCloud: z.boolean().optional(),

--- a/tests/cli/build/build-config-options.test.ts
+++ b/tests/cli/build/build-config-options.test.ts
@@ -207,15 +207,15 @@ test("build with multiple config build options", async () => {
     JSON.stringify({
       mainEntrypoint: "./lib/index.tsx",
       build: {
-        kicadLibrary: true,
+        kicadProject: true,
         previewImages: true,
       },
     }),
   )
 
   await runCommand(`tsci build ${circuitPath} --ignore-errors`)
-  const kicadLibDir = path.join(tmpDir, "dist", "multi", "kicad")
-  expect((await stat(kicadLibDir)).isDirectory()).toBe(true)
+  const kicadDir = path.join(tmpDir, "dist", "multi", "kicad")
+  expect((await stat(kicadDir)).isDirectory()).toBe(true)
 
   const schematicSvgExists = await stat(
     path.join(tmpDir, "dist", "schematic.svg"),
@@ -271,7 +271,7 @@ test("build uses config build.kicadProject setting", async () => {
 
   const { stderr, stdout } = await runCommand(`tsci build`)
   expect(stderr).toBe("")
-  expect(stdout).toContain("kicad")
+  expect(stdout).toContain("kicad-project")
 
   const kicadDir = path.join(tmpDir, "dist", "my-board", "kicad")
   expect((await stat(kicadDir)).isDirectory()).toBe(true)
@@ -282,7 +282,7 @@ test("build uses config build.kicadProject setting", async () => {
   expect(files.some((f) => f.endsWith(".kicad_pcb"))).toBe(true)
 }, 60_000)
 
-test("build uses kicadLibraryEntrypointPath for --kicad when no file specified", async () => {
+test("build uses kicadProjectEntrypointPath for --kicad-project when no file specified", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   await mkdir(path.join(tmpDir, "lib"), { recursive: true })
@@ -291,7 +291,7 @@ test("build uses kicadLibraryEntrypointPath for --kicad when no file specified",
   await writeFile(
     path.join(tmpDir, "tscircuit.config.json"),
     JSON.stringify({
-      kicadLibraryEntrypointPath: "lib/my-library.tsx",
+      kicadProjectEntrypointPath: "lib/my-library.tsx",
       build: {
         kicadProject: true,
       },
@@ -300,9 +300,9 @@ test("build uses kicadLibraryEntrypointPath for --kicad when no file specified",
 
   const { stderr, stdout } = await runCommand(`tsci build`)
   expect(stderr).toBe("")
-  expect(stdout).toContain("kicad")
+  expect(stdout).toContain("kicad-project")
 
-  // Should build the file from kicadLibraryEntrypointPath
+  // Should build the file from kicadProjectEntrypointPath
   const kicadDir = path.join(tmpDir, "dist", "lib", "my-library", "kicad")
   expect((await stat(kicadDir)).isDirectory()).toBe(true)
 

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -245,13 +245,15 @@ test("build with --all-images generates preview assets for each build", async ()
   await readImageSet("second")
 }, 60_000)
 
-test("build with --kicad generates KiCad project files", async () => {
+test("build with --kicad-project generates KiCad project files", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "kicad-board.tsx")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
-  const { stderr } = await runCommand(`tsci build --kicad ${circuitPath}`)
+  const { stderr } = await runCommand(
+    `tsci build --kicad-project ${circuitPath}`,
+  )
   expect(stderr).toBe("")
 
   const projectDir = path.join(tmpDir, "dist", "kicad-board", "kicad")

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -68,6 +68,10 @@
           "type": "boolean",
           "description": "Enable circuit JSON output in build."
         },
+        "kicadProject": {
+          "type": "boolean",
+          "description": "Enable KiCad project output (.kicad_pro, .kicad_sch, .kicad_pcb) in build."
+        },
         "kicadLibrary": {
           "type": "boolean",
           "description": "Enable KiCad library output in build."

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -48,6 +48,10 @@
       "type": "string",
       "description": "Override command used for cloud builds."
     },
+    "kicadProjectEntrypointPath": {
+      "type": "string",
+      "description": "Entry file for KiCad project generation (.kicad_pro, .kicad_sch, .kicad_pcb)."
+    },
     "kicadLibraryEntrypointPath": {
       "type": "string",
       "description": "Entry file for KiCad footprint library generation."


### PR DESCRIPTION
@seveibar the flag is ```tsci build --kicad```, is it ok to take the entrypoint from ```kicadLibraryEntrypoint``` or we should add a new entrypoint option?