### PR TITLE
Support kicad metadata prop introspection for kicad-project

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "@types/semver": "^7.5.8",
         "bun-match-svg": "^0.0.12",
         "chokidar": "4.0.1",
-        "circuit-json-to-kicad": "^0.0.71",
+        "circuit-json-to-kicad": "^0.0.74",
         "circuit-json-to-readable-netlist": "^0.0.13",
         "circuit-json-to-spice": "^0.0.10",
         "circuit-json-to-tscircuit": "^0.0.9",
@@ -451,7 +451,7 @@
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.68", "", { "dependencies": { "@jscad/modeling": "^2.12.6", "jscad-electronics": "^0.0.120", "jscad-to-gltf": "^0.0.5", "occt-import-js": "^0.0.23" }, "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-js", "@resvg/resvg-wasm"] }, "sha512-DlZSJtfFPkzZ3Gp/bi8Y2ExsSS4UHbC5Pwy7TCf4T3jAgN0Rov5NlztZX9MSn5pXWEZgZwChrrLJfn5kG9zAnw=="],
 
-    "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.71", "", { "dependencies": { "@tscircuit/props": "^0.0.470", "circuit-json": "^0.0.378" }, "peerDependencies": { "typescript": "^5" } }, "sha512-WpA+MCibBatvM/l3EVRfGjiLjqoBCDRyZ0oHilXyP0GvdNbBS9T53EiOJpCAqFMzThgmlR93N3oXbvuX8mKowQ=="],
+    "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.74", "", { "dependencies": { "@tscircuit/props": "^0.0.470", "circuit-json": "^0.0.378" }, "peerDependencies": { "typescript": "^5" } }, "sha512-yCib9M0Wm/vJWedE0yrboMTiWeATb43YFFFshZn1F9s5FY2I/hO7tLy3MR3cbgkJoUfsOyf39sITiHjEyFi1gQ=="],
 
     "circuit-json-to-readable-netlist": ["circuit-json-to-readable-netlist@0.0.13", "", { "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.0.0" } }, "sha512-Wwk/PdEuqKTQM8HRNVzohgcVpicSRkfcUW+eeycb4ZUaJNunGFEEpBkGHPguIcuG9RJBQrGp3XfBVoBUXeBmWQ=="],
 

--- a/cli/build/generate-kicad-project.ts
+++ b/cli/build/generate-kicad-project.ts
@@ -10,6 +10,7 @@ import type {
 } from "@tscircuit/props"
 import { extractKicadMetadataForKicadProject } from "lib/shared/extract-kicad-metadata-for-kicad-project"
 import { registerStaticAssetLoaders } from "lib/shared/register-static-asset-loaders"
+import { pathToFileURL } from "node:url"
 
 type GenerateKicadProjectOptions = {
   circuitJson: unknown[]
@@ -69,7 +70,6 @@ export const generateKicadProject = async ({
   if (filePath) {
     try {
       registerStaticAssetLoaders()
-      const { pathToFileURL } = await import("node:url")
       const module = await import(pathToFileURL(filePath).href)
       const Component = module.default || Object.values(module)[0]
       if (Component && typeof Component === "function") {

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -260,11 +260,13 @@ export const registerBuild = (program: Command) => {
                 "kicad",
               )
               const projectName = path.basename(outputDirName)
+
               const project = await generateKicadProject({
                 circuitJson,
                 outputDir: projectOutputDir,
                 projectName,
                 writeFiles: Boolean(resolvedOptions?.kicadProject),
+                filePath,
               })
               kicadProjects.push({
                 ...project,

--- a/lib/shared/extract-kicad-metadata-for-kicad-project.ts
+++ b/lib/shared/extract-kicad-metadata-for-kicad-project.ts
@@ -1,0 +1,202 @@
+import type {
+  KicadFootprintMetadata,
+  KicadSymbolMetadata,
+} from "@tscircuit/props"
+
+interface ReactElement {
+  type: string | Function
+  props?: {
+    kicadFootprintMetadata?: KicadFootprintMetadata
+    kicadSymbolMetadata?: KicadSymbolMetadata
+    children?: ReactElement | ReactElement[]
+    [key: string]: unknown
+  }
+}
+
+interface ExtractKicadMetadataForKicadProjectOptions {
+  maxIterations?: number
+  debug?: boolean
+}
+
+interface ExtractKicadMetadataForKicadProjectResult {
+  footprintMetadataMap: Map<string, KicadFootprintMetadata>
+  symbolMetadataMap: Map<string, KicadSymbolMetadata>
+}
+
+/**
+ * Extracts RefDes prefix (letters only) from a name like "MC1", "MP_Med2", etc.
+ */
+function extractRefDesPrefix(name: string): string {
+  // Extract leading letters, handling underscores (e.g., "MC_Med1" -> "MC")
+  const match = name.match(/^([A-Za-z]+)/)
+  return match ? match[1] : ""
+}
+
+/**
+ * Extracts RefDes prefix from metadata's properties.Reference.value
+ */
+function getRefDesPrefixFromMetadata(
+  metadata: KicadFootprintMetadata | KicadSymbolMetadata,
+): string | null {
+  if (metadata && typeof metadata === "object" && "properties" in metadata) {
+    const props = metadata.properties as Record<string, unknown>
+    if (
+      props?.Reference &&
+      typeof props.Reference === "object" &&
+      props.Reference !== null
+    ) {
+      const ref = props.Reference as { value?: string }
+      if (ref.value && typeof ref.value === "string") {
+        // Remove trailing asterisks like "MP**" -> "MP"
+        const cleaned = ref.value.replace(/\*+$/, "")
+        // Extract just the letters prefix (e.g., "MC1" -> "MC", "MC_Med1" -> "MC")
+        return extractRefDesPrefix(cleaned)
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Extracts all kicadFootprintMetadata and kicadSymbolMetadata from a board/circuit component
+ * for use in KiCad project generation. Returns maps keyed by RefDes prefix.
+ *
+ * This function performs BFS traversal and props introspection without rendering
+ * the component through @tscircuit/core. It handles:
+ * - Nested functional components (calls them to get their children)
+ * - Multi-level component hierarchies
+ * - Array and single children
+ * - Components that fail to render (gracefully skipped)
+ *
+ * @param Component - The board/circuit component function to introspect
+ * @param options - Configuration options
+ * @returns Maps of RefDes prefix to metadata for use by circuit-json-to-kicad
+ */
+export function extractKicadMetadataForKicadProject(
+  Component: (props?: any) => ReactElement,
+  options: ExtractKicadMetadataForKicadProjectOptions = {},
+): ExtractKicadMetadataForKicadProjectResult {
+  const { maxIterations = 1000, debug = false } = options
+
+  const footprintMetadataMap = new Map<string, KicadFootprintMetadata>()
+  const symbolMetadataMap = new Map<string, KicadSymbolMetadata>()
+
+  let reactElm: ReactElement
+  try {
+    reactElm = Component({})
+  } catch (e) {
+    if (debug) {
+      console.log(
+        `[extractKicadMetadataForKicadProject] Failed to call root component:`,
+        e,
+      )
+    }
+    return { footprintMetadataMap, symbolMetadataMap }
+  }
+
+  if (!reactElm) {
+    return { footprintMetadataMap, symbolMetadataMap }
+  }
+
+  const queue: ReactElement[] = [reactElm]
+  let iterations = 0
+
+  while (queue.length > 0) {
+    iterations++
+    if (iterations > maxIterations) {
+      if (debug) {
+        console.log(
+          `[extractKicadMetadataForKicadProject] Max iterations (${maxIterations}) reached`,
+        )
+      }
+      break
+    }
+
+    const elm = queue.shift()
+    if (!elm) continue
+
+    // Handle nested functional components - call them to get their element tree
+    if (typeof elm.type === "function") {
+      try {
+        let childElm: ReactElement | null = null
+        try {
+          childElm = (elm.type as Function)(elm.props || {})
+        } catch {
+          childElm = (elm.type as Function)()
+        }
+        if (childElm) {
+          queue.push(childElm)
+        }
+      } catch (e) {
+        if (debug) {
+          console.log(
+            `[extractKicadMetadataForKicadProject] Failed to call functional component:`,
+            e,
+          )
+        }
+      }
+    }
+
+    // Check for kicadFootprintMetadata in this element's props
+    if (elm?.props?.kicadFootprintMetadata) {
+      const metadata = elm.props.kicadFootprintMetadata
+      const prefix = getRefDesPrefixFromMetadata(metadata)
+      if (prefix && !footprintMetadataMap.has(prefix)) {
+        footprintMetadataMap.set(prefix, metadata)
+        if (debug) {
+          console.log(
+            `[extractKicadMetadataForKicadProject] Found footprint metadata for prefix: ${prefix}`,
+          )
+        }
+      }
+    }
+
+    // Check for kicadSymbolMetadata in this element's props
+    if (elm?.props?.kicadSymbolMetadata) {
+      const metadata = elm.props.kicadSymbolMetadata
+      const prefix = getRefDesPrefixFromMetadata(metadata)
+      if (prefix && !symbolMetadataMap.has(prefix)) {
+        symbolMetadataMap.set(prefix, metadata)
+        if (debug) {
+          console.log(
+            `[extractKicadMetadataForKicadProject] Found symbol metadata for prefix: ${prefix}`,
+          )
+        }
+      }
+    }
+
+    // Process children - add them to the queue
+    if (elm?.props) {
+      const children = elm.props.children
+      if (Array.isArray(children)) {
+        for (const child of children) {
+          if (child && typeof child === "object") {
+            queue.push(child as ReactElement)
+          }
+        }
+      } else if (children && typeof children === "object") {
+        queue.push(children as ReactElement)
+      }
+
+      // Also check other props that might contain React elements
+      for (const [key, value] of Object.entries(elm.props)) {
+        if (
+          key !== "children" &&
+          key !== "kicadFootprintMetadata" &&
+          key !== "kicadSymbolMetadata" &&
+          value &&
+          typeof value === "object" &&
+          "type" in (value as object) &&
+          "props" in (value as object)
+        ) {
+          queue.push(value as ReactElement)
+        }
+      }
+    }
+  }
+
+  return {
+    footprintMetadataMap,
+    symbolMetadataMap,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/semver": "^7.5.8",
     "bun-match-svg": "^0.0.12",
     "chokidar": "4.0.1",
-    "circuit-json-to-kicad": "^0.0.71",
+    "circuit-json-to-kicad": "^0.0.74",
     "circuit-json-to-readable-netlist": "^0.0.13",
     "circuit-json-to-spice": "^0.0.10",
     "circuit-json-to-tscircuit": "^0.0.9",

--- a/tests/cli/build/build-kicad-project-with-metadata.test.ts
+++ b/tests/cli/build/build-kicad-project-with-metadata.test.ts
@@ -1,0 +1,80 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readdir, readFile } from "node:fs/promises"
+import path from "node:path"
+
+test("build --kicad-project extracts and applies footprint metadata", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  const componentCode = `
+const CustomChip = (props: { name: string }) => (
+  <chip
+    name={props.name}
+    footprint="soic8"
+    kicadFootprintMetadata={{
+      footprintName: "CustomSOIC8",
+      properties: {
+        Reference: {
+          value: "U",
+          at: { x: 0, y: -4 },
+          layer: "F.SilkS",
+          effects: {
+            font: { size: { x: 0.8, y: 0.8 }, thickness: 0.12 },
+          },
+        },
+      },
+      model: {
+        path: "\${KIPRJMOD}/3dmodels/chip.step",
+        offset: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+        rotate: { x: 0, y: 0, z: 0 },
+      },
+    }}
+  />
+)
+
+export default () => (
+  <board width="20mm" height="20mm">
+    <CustomChip name="U1" />
+    <CustomChip name="U2" />
+  </board>
+)
+`
+
+  await writeFile(path.join(tmpDir, "board.tsx"), componentCode)
+
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({
+      name: "test-kicad-metadata",
+      version: "1.0.0",
+      type: "module",
+      dependencies: {
+        react: "^19.1.0",
+      },
+    }),
+  )
+
+  await runCommand("tsci install")
+
+  const { stdout } = await runCommand("tsci build board.tsx --kicad-project")
+
+  // Should log that metadata was found
+  expect(stdout).toContain("Found 1 footprint metadata")
+
+  // Check the generated kicad_pcb file
+  const kicadDir = path.join(tmpDir, "dist", "board", "kicad")
+  const files = await readdir(kicadDir)
+  const pcbFile = files.find((f) => f.endsWith(".kicad_pcb"))!
+  const pcbContent = await readFile(path.join(kicadDir, pcbFile), "utf-8")
+
+  // Verify footprintName from metadata is applied
+  expect(pcbContent).toContain("CustomSOIC8")
+
+  // Verify model path from metadata is applied
+  expect(pcbContent).toContain("${KIPRJMOD}/3dmodels/chip.step")
+
+  // Verify both U1 and U2 components exist with correct RefDes from circuit-json
+  expect(pcbContent).toMatch(/Reference.*U1/s)
+  expect(pcbContent).toMatch(/Reference.*U2/s)
+}, 120_000)

--- a/tests/shared/extract-kicad-metadata-for-kicad-project-multiple-types.test.tsx
+++ b/tests/shared/extract-kicad-metadata-for-kicad-project-multiple-types.test.tsx
@@ -1,0 +1,90 @@
+import { test, expect } from "bun:test"
+import { extractKicadMetadataForKicadProject } from "lib/shared/extract-kicad-metadata-for-kicad-project"
+
+test("extracts footprint metadata for multiple component types keyed by prefix", () => {
+  const Board = () => (
+    <board>
+      <chip
+        name="U1"
+        kicadFootprintMetadata={{
+          footprintName: "SOIC8",
+          properties: {
+            Reference: { value: "U" },
+          },
+          attributes: {
+            smd: true,
+          },
+        }}
+      />
+      <chip
+        name="U2"
+        kicadFootprintMetadata={{
+          footprintName: "SOIC8_DIFFERENT",
+          properties: {
+            Reference: { value: "U" },
+          },
+        }}
+      />
+      <chip
+        name="J1"
+        kicadFootprintMetadata={{
+          footprintName: "Connector_USB",
+          properties: {
+            Reference: { value: "J" },
+            Datasheet: { value: "https://example.com/usb.pdf" },
+          },
+          attributes: {
+            through_hole: true,
+          },
+        }}
+      />
+      <resistor
+        name="R1"
+        resistance="10k"
+        kicadFootprintMetadata={{
+          footprintName: "R_0402",
+          properties: {
+            Reference: { value: "R" },
+          },
+        }}
+      />
+    </board>
+  )
+
+  const { footprintMetadataMap } = extractKicadMetadataForKicadProject(Board)
+
+  // Should have 3 unique prefixes (U, J, R) - U2's metadata is ignored since U1 comes first
+  expect(footprintMetadataMap.size).toBe(3)
+  expect(Array.from(footprintMetadataMap.keys()).sort()).toMatchInlineSnapshot(`
+    [
+      "J",
+      "R",
+      "U",
+    ]
+  `)
+
+  // U should use FIRST occurrence's metadata (U1, not U2)
+  expect(footprintMetadataMap.get("U")?.footprintName).toBe("SOIC8")
+  expect(footprintMetadataMap.get("U")?.attributes?.smd).toBe(true)
+
+  // J should have its own metadata
+  expect(footprintMetadataMap.get("J")).toMatchInlineSnapshot(`
+    {
+      "attributes": {
+        "through_hole": true,
+      },
+      "footprintName": "Connector_USB",
+      "properties": {
+        "Datasheet": {
+          "value": "https://example.com/usb.pdf",
+        },
+        "Reference": {
+          "value": "J",
+        },
+      },
+    }
+  `)
+
+  // R should have its metadata
+  expect(footprintMetadataMap.get("R")?.footprintName).toBe("R_0402")
+})

--- a/tests/shared/extract-kicad-metadata-for-kicad-project-nested-components.test.tsx
+++ b/tests/shared/extract-kicad-metadata-for-kicad-project-nested-components.test.tsx
@@ -1,0 +1,87 @@
+import { test, expect } from "bun:test"
+import { extractKicadMetadataForKicadProject } from "lib/shared/extract-kicad-metadata-for-kicad-project"
+
+test("extracts metadata from nested functional components", () => {
+  // Inner component that defines metadata
+  const CustomSensor = (props: { name: string }) => (
+    <chip
+      name={props.name}
+      kicadFootprintMetadata={{
+        footprintName: "LGA14",
+        properties: {
+          Reference: { value: "U" },
+          Value: { value: "BME280" },
+          Description: { value: "Environmental sensor" },
+        },
+        attributes: {
+          smd: true,
+          exclude_from_bom: false,
+        },
+      }}
+      kicadSymbolMetadata={{
+        symbolName: "BME280",
+        properties: {
+          Reference: { value: "U" },
+          Value: { value: "BME280" },
+        },
+      }}
+    />
+  )
+
+  // Wrapper component
+  const SensorModule = () => (
+    <group>
+      <CustomSensor name="U1" />
+      <resistor name="R1" resistance="10k" />
+    </group>
+  )
+
+  // Top-level board
+  const Board = () => (
+    <board>
+      <SensorModule />
+    </board>
+  )
+
+  const { footprintMetadataMap, symbolMetadataMap } =
+    extractKicadMetadataForKicadProject(Board)
+
+  // Should find the metadata from deeply nested CustomSensor
+  expect(footprintMetadataMap.size).toBe(1)
+  expect(symbolMetadataMap.size).toBe(1)
+
+  expect(footprintMetadataMap.get("U")).toMatchInlineSnapshot(`
+    {
+      "attributes": {
+        "exclude_from_bom": false,
+        "smd": true,
+      },
+      "footprintName": "LGA14",
+      "properties": {
+        "Description": {
+          "value": "Environmental sensor",
+        },
+        "Reference": {
+          "value": "U",
+        },
+        "Value": {
+          "value": "BME280",
+        },
+      },
+    }
+  `)
+
+  expect(symbolMetadataMap.get("U")).toMatchInlineSnapshot(`
+    {
+      "properties": {
+        "Reference": {
+          "value": "U",
+        },
+        "Value": {
+          "value": "BME280",
+        },
+      },
+      "symbolName": "BME280",
+    }
+  `)
+})

--- a/tests/shared/extract-kicad-metadata-for-kicad-project-single-component.test.tsx
+++ b/tests/shared/extract-kicad-metadata-for-kicad-project-single-component.test.tsx
@@ -1,0 +1,82 @@
+import { test, expect } from "bun:test"
+import { extractKicadMetadataForKicadProject } from "lib/shared/extract-kicad-metadata-for-kicad-project"
+
+test("extracts footprint metadata from board with single component", () => {
+  const Board = () => (
+    <board>
+      <chip
+        name="U1"
+        kicadFootprintMetadata={{
+          footprintName: "SOIC8",
+          properties: {
+            Reference: {
+              value: "U",
+              at: { x: 0, y: -3 },
+              layer: "F.SilkS",
+            },
+            Value: {
+              value: "ATmega328",
+              at: { x: 0, y: 3 },
+              layer: "F.Fab",
+            },
+          },
+          model: {
+            path: "${KIPRJMOD}/3dmodels/SOIC8.step",
+            offset: { x: 0, y: 0, z: 0 },
+            scale: { x: 1, y: 1, z: 1 },
+            rotate: { x: 0, y: 0, z: 0 },
+          },
+        }}
+      />
+    </board>
+  )
+
+  const { footprintMetadataMap, symbolMetadataMap } =
+    extractKicadMetadataForKicadProject(Board)
+
+  expect(footprintMetadataMap.size).toBe(1)
+  expect(symbolMetadataMap.size).toBe(0)
+
+  const metadata = footprintMetadataMap.get("U")
+  expect(metadata).toMatchInlineSnapshot(`
+    {
+      "footprintName": "SOIC8",
+      "model": {
+        "offset": {
+          "x": 0,
+          "y": 0,
+          "z": 0,
+        },
+        "path": "\${KIPRJMOD}/3dmodels/SOIC8.step",
+        "rotate": {
+          "x": 0,
+          "y": 0,
+          "z": 0,
+        },
+        "scale": {
+          "x": 1,
+          "y": 1,
+          "z": 1,
+        },
+      },
+      "properties": {
+        "Reference": {
+          "at": {
+            "x": 0,
+            "y": -3,
+          },
+          "layer": "F.SilkS",
+          "value": "U",
+        },
+        "Value": {
+          "at": {
+            "x": 0,
+            "y": 3,
+          },
+          "layer": "F.Fab",
+          "value": "ATmega328",
+        },
+      },
+    }
+  `)
+})


### PR DESCRIPTION
Existing extractors (extract-kicad-footprint-metadata.ts, extract-kicad-symbol-metadata.ts):                   
- Return first metadata found (for kicad-library: one component → one footprint file)                                           

New extractor (extract-kicad-metadata-for-kicad-project.ts):
- Returns all metadata as Maps keyed by RefDes prefix (for kicad-project: board has MC1, MC2, MP1, R1... needs metadata for each type)

kicad-library:  MachinePin component → single .kicad_mod file
kicad-project:  Board with MC1, MC2, MP1, MP2, R1 → needs Map<"MC" → metadata, "MP" → metadata, "R" → metadata>