### PR TITLE
feat(push): add archive upload path for faster tsci push

### DIFF
--- a/tests/cli/push/push14-upload-archive.test.ts
+++ b/tests/cli/push/push14-upload-archive.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+test("should attempt archive upload when TSCI_PUSH_ARCHIVE is enabled", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture({ loggedIn: true })
+  const snippetFilePath = path.resolve(tmpDir, "snippet.tsx")
+
+  fs.writeFileSync(snippetFilePath, "// Snippet content")
+  fs.writeFileSync(
+    path.resolve(tmpDir, "package.json"),
+    JSON.stringify({ name: "@tsci/test-user.test-package", version: "1.0.0" }),
+  )
+
+  const previousArchiveFlag = process.env.TSCI_PUSH_ARCHIVE
+  process.env.TSCI_PUSH_ARCHIVE = "1"
+
+  let stdout = ""
+  let stderr = ""
+  try {
+    const result = await runCommand(`tsci push ${snippetFilePath}`)
+    stdout = result.stdout
+    stderr = result.stderr
+  } finally {
+    process.env.TSCI_PUSH_ARCHIVE = previousArchiveFlag
+  }
+
+  expect(stderr).toBe("")
+  expect(stdout).toContain("Uploading package archive...")
+  expect(stdout).toContain(
+    "Archive upload failed, falling back to file-by-file upload",
+  )
+  expect(stdout).toContain("⬆︎ package.json")
+  expect(stdout).toContain("⬆︎ snippet.tsx")
+  expect(stdout).toContain('"@tsci/test-user.test-package@1.0.0" published!')
+}, 30_000)


### PR DESCRIPTION
### Motivation
- Reduce latency of `tsci push` by supporting an archive-based upload path when `TSCI_PUSH_ARCHIVE` is enabled.

### Description
- Add `JSZip` and a `getArchivePayload` helper to build a compressed zip and encode it as `archive_base64` for upload.
- When `TSCI_PUSH_ARCHIVE=1`, attempt a single `POST` to `package_files/upload_archive` with `{ package_name_with_version, archive_base64, archive_format }`.
- If the archive upload fails, fall back to the existing file-by-file uploads and preserve existing binary/text handling (`content_base64` / `content_text`) and logging.
- Add a focused test `tests/cli/push/push14-upload-archive.test.ts` that enables the env var, asserts the archive attempt and validates fallback behavior and successful publish.

### Testing
- Ran `bun test tests/cli/push/push6-upload-files.test.ts tests/cli/push/push14-upload-archive.test.ts` and both tests passed (2 pass, 0 fail).
- Ran typecheck with `bunx tsc --noEmit` which completed successfully.
- Ran formatting with `bun run format` which completed and updated formatting where needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699b97b207ac832e9f0a3636df035463)