### PR TITLE
Detect non-interactive CLI mode via tty/flag/env and auto-confirm prompts

### DIFF
--- a/lib/utils/prompts.ts
+++ b/lib/utils/prompts.ts
@@ -11,7 +11,7 @@ export const prompts = (...args: Parameters<typeof ogPrompts>) => {
     const result: any = {}
     promptArray.forEach((prompt) => {
       if (prompt.type === "confirm") {
-        result[(prompt as any).name] = prompt.initial ?? true
+        result[(prompt as any).name] = true
         return
       } else if (prompt.initial) {
         result[(prompt as any).name] = prompt.initial

--- a/lib/utils/should-be-interactive.ts
+++ b/lib/utils/should-be-interactive.ts
@@ -3,5 +3,11 @@ export const shouldBeInteractive = () => {
   if (process.env.NODE_ENV === "ci") return false
   if (process.env.CI) return false
   if (process.env.TSCI_TEST_MODE) return false
+
+  if (process.argv.includes("--non-interactive")) return false
+  if (process.env.TSCIRCUIT_NON_INTERACTIVE === "1") return false
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false
+
   return true
 }

--- a/tests/lib/prompts-non-interactive.test.ts
+++ b/tests/lib/prompts-non-interactive.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, expect, test } from "bun:test"
+import { prompts } from "lib/utils/prompts"
+
+const originalNodeEnv = process.env.NODE_ENV
+const originalCi = process.env.CI
+const originalTestMode = process.env.TSCI_TEST_MODE
+const originalNonInteractiveEnv = process.env.TSCIRCUIT_NON_INTERACTIVE
+const originalArgv = [...process.argv]
+const originalStdinIsTTY = process.stdin.isTTY
+const originalStdoutIsTTY = process.stdout.isTTY
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv
+  process.env.CI = originalCi
+  process.env.TSCI_TEST_MODE = originalTestMode
+  process.env.TSCIRCUIT_NON_INTERACTIVE = originalNonInteractiveEnv
+  process.argv = [...originalArgv]
+
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: originalStdinIsTTY,
+    configurable: true,
+  })
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: originalStdoutIsTTY,
+    configurable: true,
+  })
+})
+
+test("confirm prompts auto-resolve to yes when --non-interactive flag is passed", async () => {
+  process.argv = [...originalArgv, "--non-interactive"]
+
+  const result = await prompts({
+    name: "shouldContinue",
+    type: "confirm",
+    initial: false,
+    message: "continue?",
+  })
+
+  expect(result).toEqual({ shouldContinue: true })
+})
+
+test("confirm prompts auto-resolve to yes when TSCIRCUIT_NON_INTERACTIVE=1", async () => {
+  process.env.TSCIRCUIT_NON_INTERACTIVE = "1"
+
+  const result = await prompts({
+    name: "shouldContinue",
+    type: "confirm",
+    initial: false,
+    message: "continue?",
+  })
+
+  expect(result).toEqual({ shouldContinue: true })
+})
+
+test("confirm prompts auto-resolve to yes when stdin is not a tty", async () => {
+  process.env.NODE_ENV = "production"
+  process.env.CI = ""
+  process.env.TSCI_TEST_MODE = ""
+  process.env.TSCIRCUIT_NON_INTERACTIVE = ""
+  process.argv = originalArgv.filter((arg) => arg !== "--non-interactive")
+
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: false,
+    configurable: true,
+  })
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: true,
+    configurable: true,
+  })
+
+  const result = await prompts({
+    name: "shouldContinue",
+    type: "confirm",
+    initial: false,
+    message: "continue?",
+  })
+
+  expect(result).toEqual({ shouldContinue: true })
+})

--- a/tests/lib/should-be-interactive.test.ts
+++ b/tests/lib/should-be-interactive.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, expect, test } from "bun:test"
+import { shouldBeInteractive } from "lib/utils/should-be-interactive"
+
+const originalNodeEnv = process.env.NODE_ENV
+const originalCi = process.env.CI
+const originalTestMode = process.env.TSCI_TEST_MODE
+const originalNonInteractiveEnv = process.env.TSCIRCUIT_NON_INTERACTIVE
+const originalArgv = [...process.argv]
+const originalStdinIsTTY = process.stdin.isTTY
+const originalStdoutIsTTY = process.stdout.isTTY
+
+afterEach(() => {
+  process.env.NODE_ENV = originalNodeEnv
+  process.env.CI = originalCi
+  process.env.TSCI_TEST_MODE = originalTestMode
+  process.env.TSCIRCUIT_NON_INTERACTIVE = originalNonInteractiveEnv
+  process.argv = [...originalArgv]
+
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: originalStdinIsTTY,
+    configurable: true,
+  })
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: originalStdoutIsTTY,
+    configurable: true,
+  })
+})
+
+test("returns false when --non-interactive is provided", () => {
+  process.argv = [...originalArgv, "--non-interactive"]
+
+  expect(shouldBeInteractive()).toBe(false)
+})
+
+test("returns false when TSCIRCUIT_NON_INTERACTIVE is 1", () => {
+  process.env.TSCIRCUIT_NON_INTERACTIVE = "1"
+
+  expect(shouldBeInteractive()).toBe(false)
+})
+
+test("returns false when stdin is not a tty", () => {
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: false,
+    configurable: true,
+  })
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: true,
+    configurable: true,
+  })
+
+  expect(shouldBeInteractive()).toBe(false)
+})
+
+test("returns true when tty is available and no non-interactive flags are set", () => {
+  process.env.NODE_ENV = "production"
+  process.env.CI = ""
+  process.env.TSCI_TEST_MODE = ""
+  process.env.TSCIRCUIT_NON_INTERACTIVE = ""
+  process.argv = originalArgv.filter((arg) => arg !== "--non-interactive")
+
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: true,
+    configurable: true,
+  })
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: true,
+    configurable: true,
+  })
+
+  expect(shouldBeInteractive()).toBe(true)
+})


### PR DESCRIPTION
### Motivation

- Ensure the CLI can detect non-interactive environments (CI, piped input, or explicit flags/env) and behave deterministically without waiting for user input. 
- Automatically accept confirmation prompts when running non-interactively so headless workflows and scripts do not hang or fail. 

### Description

- Updated `shouldBeInteractive` in `lib/utils/should-be-interactive.ts` to treat the following as non-interactive: `--non-interactive` CLI flag, `TSCIRCUIT_NON_INTERACTIVE=1` environment variable, or when `process.stdin` or `process.stdout` are not TTYs. 
- Modified `prompts` in `lib/utils/prompts.ts` so that when `shouldBeInteractive()` is false, `confirm` prompts are automatically resolved to `true` (yes) instead of relying on `initial` values. 
- Added focused unit tests: `tests/lib/should-be-interactive.test.ts` to exercise CLI detection paths and `tests/lib/prompts-non-interactive.test.ts` to verify `confirm` prompts auto-resolve to yes in non-interactive situations. 

### Testing

- Ran `bun test tests/lib/should-be-interactive.test.ts` and all tests passed (4 passed). 
- Ran `bun test tests/lib/prompts-non-interactive.test.ts` and all tests passed (3 passed). 
- Type-checked the project with `bunx tsc --noEmit`, which succeeded. 
- Ran code formatting with `bun run format` to ensure consistent formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699bbafe8bf0832ead4ec1351f088be7)