### PR TITLE
feat(build): add --profile timing output for per-circuit builds

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -20,6 +20,7 @@ export interface BuildCommandOptions {
   kicadPcm?: boolean
   previewGltf?: boolean
   glbs?: boolean
+  profile?: boolean
   useCdnJavascript?: boolean
   concurrency?: string
 }

--- a/cli/build/build-worker-entrypoint.ts
+++ b/cli/build/build-worker-entrypoint.ts
@@ -39,10 +39,12 @@ const handleBuildFile = async (
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
     platformConfig?: unknown
+    profile?: boolean
   },
 ): Promise<BuildCompletedMessage> => {
   const errors: string[] = []
   const warnings: string[] = []
+  const startedAt = options?.profile ? performance.now() : 0
 
   try {
     // Change to project directory for proper module resolution
@@ -100,6 +102,7 @@ const handleBuildFile = async (
       ok: !hasErrors,
       errors,
       warnings,
+      durationMs: options?.profile ? performance.now() - startedAt : undefined,
     }
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err)
@@ -119,6 +122,7 @@ const handleBuildFile = async (
       },
       errors,
       warnings,
+      durationMs: options?.profile ? performance.now() - startedAt : undefined,
     }
   }
 }

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -303,9 +303,7 @@ export const registerBuild = (program: Command) => {
             if (resolvedOptions?.profile) {
               const durationMs = performance.now() - startedAt
               console.log(
-                kleur.cyan(
-                  `[profile] ${relative}: ${durationMs.toFixed(1)}ms`,
-                ),
+                kleur.cyan(`[profile] ${relative}: ${durationMs.toFixed(1)}ms`),
               )
             }
             await processBuildResult(filePath, outputPath, buildOutcome)
@@ -345,7 +343,10 @@ export const registerBuild = (program: Command) => {
                 }
               }
 
-              if (resolvedOptions?.profile && typeof result.durationMs === "number") {
+              if (
+                resolvedOptions?.profile &&
+                typeof result.durationMs === "number"
+              ) {
                 console.log(
                   kleur.cyan(
                     `[profile] ${relative}: ${result.durationMs.toFixed(1)}ms`,

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -199,6 +199,8 @@ export const registerBuild = (program: Command) => {
         const kicadProjects: Array<
           GeneratedKicadProject & { sourcePath: string }
         > = []
+        const profileEntries: Array<{ filePath: string; durationMs: number }> =
+          []
 
         const shouldGenerateKicadProject =
           resolvedOptions?.kicadProject || resolvedOptions?.kicadLibrary
@@ -302,6 +304,7 @@ export const registerBuild = (program: Command) => {
             )
             if (resolvedOptions?.profile) {
               const durationMs = performance.now() - startedAt
+              profileEntries.push({ filePath: relative, durationMs })
               console.log(
                 kleur.cyan(`[profile] ${relative}: ${durationMs.toFixed(1)}ms`),
               )
@@ -347,6 +350,10 @@ export const registerBuild = (program: Command) => {
                 resolvedOptions?.profile &&
                 typeof result.durationMs === "number"
               ) {
+                profileEntries.push({
+                  filePath: relative,
+                  durationMs: result.durationMs,
+                })
                 console.log(
                   kleur.cyan(
                     `[profile] ${relative}: ${result.durationMs.toFixed(1)}ms`,
@@ -572,6 +579,19 @@ export const registerBuild = (program: Command) => {
           resolvedOptions?.previewGltf && "preview-gltf",
           resolvedOptions?.profile && "profile",
         ].filter(Boolean) as string[]
+
+        if (resolvedOptions?.profile && profileEntries.length > 0) {
+          console.log("")
+          console.log(kleur.bold("Profile Summary (slowest first)"))
+          const sortedProfileEntries = [...profileEntries].sort(
+            (a, b) => b.durationMs - a.durationMs,
+          )
+          for (const profileEntry of sortedProfileEntries) {
+            console.log(
+              `  ${kleur.cyan(profileEntry.durationMs.toFixed(1) + "ms")} ${profileEntry.filePath}`,
+            )
+          }
+        }
 
         console.log("")
         console.log(kleur.bold("Build complete"))

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -18,6 +18,7 @@ export type BuildJob = {
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
     platformConfig?: PlatformConfig
+    profile?: boolean
   }
 }
 
@@ -108,6 +109,7 @@ export class WorkerPool {
             isFatalError: completedMsg.isFatalError,
             errors: completedMsg.errors,
             warnings: completedMsg.warnings,
+            durationMs: completedMsg.durationMs,
           })
           threadWorker.currentJob = null
           threadWorker.busy = false
@@ -220,6 +222,7 @@ export async function buildFilesWithWorkerPool(options: {
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
     platformConfig?: PlatformConfig
+    profile?: boolean
   }
   onLog?: (lines: string[]) => void
   onJobComplete?: (result: BuildJobResult) => void

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -12,6 +12,7 @@ export type BuildFileMessage = {
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
     platformConfig?: PlatformConfig
+    profile?: boolean
   }
 }
 
@@ -28,6 +29,7 @@ export type BuildCompletedMessage = {
   isFatalError?: { errorType: string; message: string }
   errors: string[]
   warnings: string[]
+  durationMs?: number
 }
 
 /**
@@ -59,4 +61,5 @@ export type BuildJobResult = {
   isFatalError?: { errorType: string; message: string }
   errors: string[]
   warnings: string[]
+  durationMs?: number
 }

--- a/tests/cli/build/build-profile.test.ts
+++ b/tests/cli/build/build-profile.test.ts
@@ -22,4 +22,20 @@ test("build with --profile logs per-circuit circuit.json generation time", async
   expect(exitCode).toBe(0)
   expect(stdout).toContain("[profile] first.circuit.tsx:")
   expect(stdout).toContain("[profile] second.circuit.tsx:")
+  expect(stdout).toContain("Profile Summary (slowest first)")
+
+  const profileSummaryLines = stdout
+    .split("\n")
+    .filter((line) => line.trim().match(/^[0-9]+\.[0-9]ms\s+/))
+
+  expect(profileSummaryLines.length).toBeGreaterThanOrEqual(2)
+
+  const durations = profileSummaryLines.map((line) => {
+    const match = line.trim().match(/^([0-9]+\.[0-9])ms\s+/)
+    return match ? Number.parseFloat(match[1]) : Number.NaN
+  })
+
+  for (let i = 1; i < durations.length; i++) {
+    expect(durations[i - 1] >= durations[i]).toBe(true)
+  }
 }, 30_000)

--- a/tests/cli/build/build-profile.test.ts
+++ b/tests/cli/build/build-profile.test.ts
@@ -1,0 +1,25 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+
+const circuitCode = (name: string) => `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="${name}" schX={3} pcbX={3} />
+  </board>
+)`
+
+test("build with --profile logs per-circuit circuit.json generation time", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await writeFile(path.join(tmpDir, "first.circuit.tsx"), circuitCode("R1"))
+  await writeFile(path.join(tmpDir, "second.circuit.tsx"), circuitCode("R2"))
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { stdout, exitCode } = await runCommand("tsci build --profile")
+
+  expect(exitCode).toBe(0)
+  expect(stdout).toContain("[profile] first.circuit.tsx:")
+  expect(stdout).toContain("[profile] second.circuit.tsx:")
+}, 30_000)


### PR DESCRIPTION
### Motivation

- Provide an opt-in way to measure and log how long each circuit's `circuit.json` generation takes so users can profile slow builds across many circuits.

### Description

- Add a `--profile` CLI option to `tsci build` and expose `profile?: boolean` on `BuildCommandOptions` so the flag flows through build option resolution (`cli/build/register.ts`, `cli/build/build-ci.ts`).
- Record per-file durations for sequential builds using `performance.now()` around `buildFile` and log `[profile] <relative-path>: <ms>` when enabled (`cli/build/register.ts`).
- Propagate `profile` to worker threads and capture timing inside the worker, returning `durationMs` in the `BuildCompletedMessage` and `BuildJobResult` so concurrent builds also report per-file timings (`cli/build/build-worker-entrypoint.ts`, `cli/build/worker-types.ts`, `cli/build/worker-pool.ts`).
- Surface `profile` in the final enabled-options summary and add an automated test that asserts profile lines are printed for multiple circuits (`tests/cli/build/build-profile.test.ts`).

### Testing

- Ran `bun test tests/cli/build/build-profile.test.ts`, which passed and showed per-circuit `[profile]` log lines for the two test circuits. 
- Ran `bun test tests/cli/build/build.test.ts -t "build with file only outputs that file"`, which passed and confirmed no regressions in single-file build behavior.

<img width="615" height="508" alt="image" src="https://github.com/user-attachments/assets/a68f9597-9bd2-4ac5-8ba4-0466be37c8fa" />


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699c171a61b48327acce67a42dbc1ae4)