### PR TITLE
chore: add .tscircuit to .gitignore

### DIFF
--- a/examples/scaffold/.gitignore
+++ b/examples/scaffold/.gitignore
@@ -15,6 +15,7 @@ build/
 .idea/
 *.swp
 *.swo
+.tscircuit
 
 # OS files
 .DS_Store


### PR DESCRIPTION
This pull request makes a minor update to the `.gitignore` file in the `examples/scaffold` project to exclude `.tscircuit` files from version control. This helps keep the repository clean by preventing build artifacts or temporary files from being committed.