### PR TITLE
test: add CI includeBoardFiles edge-case reproduction for site builds

### DIFF
--- a/tests/cli/build/build-ci-site-include-board-edge-case.test.ts
+++ b/tests/cli/build/build-ci-site-include-board-edge-case.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const mainEntrypointCode = `
+export const marker = "library-entrypoint"
+`
+
+test("build --ci --concurrency with includeBoardFiles can produce an empty static site when no files match", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({
+      name: "test-ci-site-include-board-edge-case",
+      version: "1.0.0",
+      dependencies: {
+        tscircuit: "latest",
+      },
+    }),
+  )
+
+  await mkdir(path.join(tmpDir, "lib"), { recursive: true })
+  await writeFile(path.join(tmpDir, "lib", "index.ts"), mainEntrypointCode)
+
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({
+      mainEntrypoint: "lib/index.ts",
+      previewComponentPath: "generated/example.tsx",
+      siteDefaultComponentPath: "generated/example.tsx",
+      includeBoardFiles: ["generated/*.tsx"],
+      alwaysUseLatestTscircuitOnCloud: true,
+      prebuildCommand: 'node -e "process.exit(0)"',
+    }),
+  )
+
+  const { stdout, exitCode } = await runCommand(
+    "tsci build --ci --concurrency 4",
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stdout).toContain("Building 0 file(s) with concurrency 4...")
+
+  await expect(
+    stat(path.join(tmpDir, "dist", "index.html")),
+  ).resolves.toBeTruthy()
+  await expect(
+    stat(path.join(tmpDir, "dist", "index.js")),
+  ).resolves.toBeTruthy()
+  await expect(
+    stat(path.join(tmpDir, "dist", "lib", "index", "circuit.json")),
+  ).rejects.toBeTruthy()
+
+  const indexHtml = await readFile(
+    path.join(tmpDir, "dist", "index.html"),
+    "utf-8",
+  )
+  expect(indexHtml).toContain(
+    "window.TSCIRCUIT_RUNFRAME_STATIC_FILE_LIST = [];",
+  )
+}, 60_000)


### PR DESCRIPTION
### Motivation
- Reproduce an edge case where `includeBoardFiles` is configured but matches no files, causing `tsci build --ci --concurrency 4` to produce a site shell and transpiled library output but no built `circuit.json` artifacts (an “empty” site). 

### Description
- Add a focused test `tests/cli/build/build-ci-site-include-board-edge-case.test.ts` that writes a minimal project config with `mainEntrypoint`, `previewComponentPath`, `siteDefaultComponentPath`, `includeBoardFiles`, `alwaysUseLatestTscircuitOnCloud`, and `prebuildCommand`, runs `tsci build --ci --concurrency 4`, and asserts the site + transpile outputs exist while no `circuit.json` files are produced and the static file list in `index.html` is empty. 

### Testing
- Ran the new test with `bun test tests/cli/build/build-ci-site-include-board-edge-case.test.ts` and it passed. 
- Ran typecheck with `bunx tsc --noEmit` which succeeded. 
- Ran formatter with `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f6a4ef388832eb1106e74c47b8e88)