### PR TITLE
Fix CI concurrent build exiting before static site generation

### DIFF
--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -368,10 +368,6 @@ export const registerBuild = (program: Command) => {
                 ok: result.ok,
                 isFatalError: result.isFatalError,
               })
-
-              if (result.isFatalError) {
-                process.exit(1)
-              }
             },
           })
         }
@@ -380,12 +376,6 @@ export const registerBuild = (program: Command) => {
           await buildWithWorkers()
         } else {
           await buildSequentially()
-        }
-
-        // Fatal errors (e.g., circuit generation exceptions) always cause exit code 1
-        // Non-fatal errors can be suppressed with --ignore-errors
-        if (hasFatalErrors || (hasErrors && !resolvedOptions?.ignoreErrors)) {
-          process.exit(1)
         }
 
         const shouldGeneratePreviewImages =
@@ -646,7 +636,11 @@ export const registerBuild = (program: Command) => {
             ? kleur.yellow("\n⚠ Build completed with errors")
             : kleur.green("\n✓ Done"),
         )
-        process.exit(0)
+        const exitCode =
+          hasFatalErrors || (hasErrors && !resolvedOptions?.ignoreErrors)
+            ? 1
+            : 0
+        process.exit(exitCode)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         console.error(message)

--- a/tests/cli/build/build-ci-concurrency-site-fatal.test.ts
+++ b/tests/cli/build/build-ci-concurrency-site-fatal.test.ts
@@ -1,0 +1,83 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readFile, stat } from "node:fs/promises"
+import path from "node:path"
+
+const validCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)`
+
+test("build --ci --concurrency still generates site output when a parallel build fatally fails", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  const generatorScript = `
+const fs = require("node:fs")
+const path = require("node:path")
+
+const generatedDir = path.join("lib", "scaffolds", "Demo", "generated")
+fs.mkdirSync(generatedDir, { recursive: true })
+
+fs.writeFileSync(
+  path.join(generatedDir, "Scaffold_Demo_8x8.tsx"),
+  ${JSON.stringify(validCircuitCode)},
+)
+
+fs.writeFileSync(
+  path.join(generatedDir, "Scaffold_Demo_Fail.tsx"),
+  'export default () => { throw new Error("intentional fatal error") }',
+)
+`
+
+  await writeFile(path.join(tmpDir, "generate.js"), generatorScript)
+
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({
+      mainEntrypoint: "lib/index.ts",
+      previewComponentPath:
+        "lib/scaffolds/Demo/generated/Scaffold_Demo_8x8.tsx",
+      siteDefaultComponentPath:
+        "lib/scaffolds/Demo/generated/Scaffold_Demo_8x8.tsx",
+      includeBoardFiles: ["lib/scaffolds/**/generated/*.tsx"],
+      alwaysUseLatestTscircuitOnCloud: true,
+      prebuildCommand: "node generate.js",
+    }),
+  )
+
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({
+      name: "test-build-ci-concurrency-site-fatal",
+      version: "1.0.0",
+      dependencies: {
+        react: "*",
+      },
+    }),
+  )
+
+  const { stderr } = await runCommand("tsci build --ci --concurrency 4")
+
+  expect(stderr).toContain("circuit_generation_failed")
+
+  const indexHtml = await readFile(
+    path.join(tmpDir, "dist", "index.html"),
+    "utf-8",
+  )
+  expect(indexHtml).toContain("Scaffold_Demo_8x8")
+
+  const successfulOutputExists = await stat(
+    path.join(
+      tmpDir,
+      "dist",
+      "lib/scaffolds/Demo/generated/Scaffold_Demo_8x8",
+      "circuit.json",
+    ),
+  )
+    .then(() => true)
+    .catch(() => false)
+
+  expect(successfulOutputExists).toBe(true)
+}, 60_000)


### PR DESCRIPTION
### Motivation
- Concurrent builds could call `process.exit(1)` from a worker `onJobComplete` when a fatal error occurred, which could terminate the process before post-build steps like `--site` completed.
- This caused an edge case where a config that uses `prebuildCommand` to generate board files (with `includeBoardFiles` globs and `previewComponentPath`/`siteDefaultComponentPath` set) would not produce `dist/index.html` or other outputs if any parallel build fatally failed.

### Description
- Removed the immediate `process.exit(1)` inside the worker `onJobComplete` handler and no longer exit from inside the parallel job callback.
- Defer final exit handling until after all post-build tasks run and compute the exit code from `hasFatalErrors` and `hasErrors` vs `ignoreErrors`.
- Added a regression test `tests/cli/build/build-ci-concurrency-site-fatal.test.ts` that reproduces the scenario using a `prebuildCommand` that generates one successful and one fatally failing board file, and runs `tsci build --ci --concurrency 4` to verify site output is still generated from successful builds.
- Changes are in `cli/build/register.ts` and the new test file under `tests/cli/build/`.

### Testing
- Ran `bun test tests/cli/build/build-ci-concurrency-site-fatal.test.ts` and the test passed.
- Ran `bunx tsc --noEmit` for typechecking and it completed with no errors.
- Ran `bun run format` to format changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f726ea254832e90a55c4d89b27d74)