### PR TITLE
Worker threads should not render the circuit.json (prebuilt files)

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs"
 import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
+import type { AnyCircuitElement } from "circuit-json"
 import kleur from "kleur"
 import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { getCompletePlatformConfig } from "lib/shared/get-complete-platform-config"
-import type { AnyCircuitElement } from "circuit-json"
 
 export type BuildFileOutcome = {
   ok: boolean
@@ -27,7 +27,10 @@ export const buildFile = async (
   try {
     console.log("Generating circuit JSON...")
 
-    const isPrebuiltCircuitJson = input.toLowerCase().endsWith(".circuit.json")
+    const normalizedInputPath = input.toLowerCase().replaceAll("\\", "/")
+    const isPrebuiltCircuitJson =
+      normalizedInputPath.endsWith(".circuit.json") ||
+      normalizedInputPath.endsWith("/circuit.json")
     let circuitJson: AnyCircuitElement[] = []
 
     if (isPrebuiltCircuitJson) {

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -20,12 +20,12 @@ import { buildKicadPcm } from "./build-kicad-pcm"
 import { buildPreviewGltf } from "./build-preview-gltf"
 import type { BuildFileResult } from "./build-preview-images"
 import { buildPreviewImages } from "./build-preview-images"
-import { exitBuild } from "./utils/exit-build"
 import { generateKicadProject } from "./generate-kicad-project"
 import type { GeneratedKicadProject } from "./generate-kicad-project"
 import { getBuildEntrypoints } from "./get-build-entrypoints"
 import { resolveBuildOptions } from "./resolve-build-options"
 import { transpileFile } from "./transpile"
+import { exitBuild } from "./utils/exit-build"
 import { buildFilesWithWorkerPool } from "./worker-pool"
 import type { BuildJobResult } from "./worker-types"
 
@@ -37,10 +37,22 @@ import runFrameStandaloneBundleContent from "@tscircuit/runframe/standalone" wit
 const normalizeRelativePath = (projectDir: string, targetPath: string) =>
   path.relative(projectDir, targetPath).split(path.sep).join("/")
 
-const getOutputDirName = (relativePath: string) =>
-  relativePath
+const getOutputDirName = (relativePath: string) => {
+  const normalizedRelativePath = relativePath
+    .toLowerCase()
+    .replaceAll("\\", "/")
+
+  if (
+    normalizedRelativePath === "circuit.json" ||
+    normalizedRelativePath.endsWith("/circuit.json")
+  ) {
+    return path.dirname(relativePath)
+  }
+
+  return relativePath
     .replace(/(\.board|\.circuit)?\.tsx$/, "")
     .replace(/\.circuit\.json$/, "")
+}
 
 export const registerBuild = (program: Command) => {
   program


### PR DESCRIPTION
- File with path `*.circuit.json` and `circuit.json` are treated as prebuilt files