### PR TITLE
refactor: explicitly type circuitJson with `AnyCircuitElement[]` for improved type safety in snapshot and KiCad project generation.

### DIFF
--- a/cli/build/generate-kicad-project.ts
+++ b/cli/build/generate-kicad-project.ts
@@ -4,6 +4,7 @@ import {
   CircuitJsonToKicadPcbConverter,
   CircuitJsonToKicadSchConverter,
 } from "circuit-json-to-kicad"
+import type { AnyCircuitElement } from "circuit-json"
 
 type GenerateKicadProjectOptions = {
   circuitJson: unknown[]
@@ -54,13 +55,13 @@ export const generateKicadProject = async ({
   writeFiles,
 }: GenerateKicadProjectOptions): Promise<GeneratedKicadProject> => {
   const schConverter = new CircuitJsonToKicadSchConverter(
-    circuitJson as unknown as any[],
+    circuitJson as AnyCircuitElement[],
   )
   schConverter.runUntilFinished()
   const schContent = schConverter.getOutputString()
 
   const pcbConverter = new CircuitJsonToKicadPcbConverter(
-    circuitJson as unknown as any[],
+    circuitJson as AnyCircuitElement[],
   )
   pcbConverter.runUntilFinished()
   const pcbContent = pcbConverter.getOutputString()

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -1,3 +1,4 @@
+import type { AnyCircuitElement } from "circuit-json"
 import fs from "node:fs"
 import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
@@ -83,7 +84,7 @@ export const snapshotProject = async ({
   for (const file of boardFiles) {
     const relativeFilePath = path.relative(projectDir, file)
 
-    let circuitJson: any
+    let circuitJson: AnyCircuitElement[]
     let pcbSvg: string
     let schSvg: string
 
@@ -172,17 +173,17 @@ export const snapshotProject = async ({
               kleur.red(
                 `\n❌ Failed to generate 3D snapshot for ${relativeFilePath}:\n`,
               ) +
-                kleur.red(`   No pcb_board found in circuit JSON\n`) +
-                kleur.red(
-                  `   Existing snapshot: ${path.relative(projectDir, snap3dPath)}\n`,
-                ),
+              kleur.red(`   No pcb_board found in circuit JSON\n`) +
+              kleur.red(
+                `   Existing snapshot: ${path.relative(projectDir, snap3dPath)}\n`,
+              ),
             )
             return onExit(1)
           } else {
             // Skip with warning if no existing snapshot
             console.log(
               kleur.red(`⚠️  Skipping 3D snapshot for ${relativeFilePath}:`) +
-                kleur.red(` No pcb_board found in circuit JSON`),
+              kleur.red(` No pcb_board found in circuit JSON`),
             )
             png3d = null
           }
@@ -201,13 +202,13 @@ export const snapshotProject = async ({
     // Determine snapshot directory based on whether snapshotsDir is configured
     const snapDir = snapshotsDirName
       ? // If snapshotsDir is provided, everything goes in the snapshots directory
-        path.join(
-          projectDir,
-          snapshotsDirName,
-          path.relative(projectDir, path.dirname(file)),
-        )
+      path.join(
+        projectDir,
+        snapshotsDirName,
+        path.relative(projectDir, path.dirname(file)),
+      )
       : // If snapshotsDir isn't provided, we create a `__snapshots__` directory next to the file like jest
-        path.join(path.dirname(file), "__snapshots__")
+      path.join(path.dirname(file), "__snapshots__")
 
     fs.mkdirSync(snapDir, { recursive: true })
 

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -173,17 +173,17 @@ export const snapshotProject = async ({
               kleur.red(
                 `\n❌ Failed to generate 3D snapshot for ${relativeFilePath}:\n`,
               ) +
-              kleur.red(`   No pcb_board found in circuit JSON\n`) +
-              kleur.red(
-                `   Existing snapshot: ${path.relative(projectDir, snap3dPath)}\n`,
-              ),
+                kleur.red(`   No pcb_board found in circuit JSON\n`) +
+                kleur.red(
+                  `   Existing snapshot: ${path.relative(projectDir, snap3dPath)}\n`,
+                ),
             )
             return onExit(1)
           } else {
             // Skip with warning if no existing snapshot
             console.log(
               kleur.red(`⚠️  Skipping 3D snapshot for ${relativeFilePath}:`) +
-              kleur.red(` No pcb_board found in circuit JSON`),
+                kleur.red(` No pcb_board found in circuit JSON`),
             )
             png3d = null
           }
@@ -202,13 +202,13 @@ export const snapshotProject = async ({
     // Determine snapshot directory based on whether snapshotsDir is configured
     const snapDir = snapshotsDirName
       ? // If snapshotsDir is provided, everything goes in the snapshots directory
-      path.join(
-        projectDir,
-        snapshotsDirName,
-        path.relative(projectDir, path.dirname(file)),
-      )
+        path.join(
+          projectDir,
+          snapshotsDirName,
+          path.relative(projectDir, path.dirname(file)),
+        )
       : // If snapshotsDir isn't provided, we create a `__snapshots__` directory next to the file like jest
-      path.join(path.dirname(file), "__snapshots__")
+        path.join(path.dirname(file), "__snapshots__")
 
     fs.mkdirSync(snapDir, { recursive: true })
 


### PR DESCRIPTION
This pull request improves type safety in the handling of circuit data throughout the codebase by replacing generic or unknown types with the more specific `AnyCircuitElement` type from the `circuit-json` library. This change ensures that circuit data is processed with the correct structure, reducing the risk of runtime errors and making the code easier to maintain.

**Type safety improvements:**

* Updated imports to include the `AnyCircuitElement` type from `circuit-json` in both `cli/build/generate-kicad-project.ts` and `lib/shared/snapshot-project.ts`, enabling more precise type annotations. [[1]](diffhunk://#diff-dda13f4985e16211ed95eb758bba20f4f927f5d97da15fd249a34c7b0ebf5c3aR7) [[2]](diffhunk://#diff-2092324af8269cfb0e148140806e9cd2bdaa13d8e031df470ee0204bc17b26b9R1)
* Changed the type of `circuitJson` from `unknown[]`/`any` to `AnyCircuitElement[]` in both the `generateKicadProject` function and the `snapshotProject` function, ensuring that circuit data is typed accurately throughout the conversion and snapshot processes. [[1]](diffhunk://#diff-dda13f4985e16211ed95eb758bba20f4f927f5d97da15fd249a34c7b0ebf5c3aL57-R64) [[2]](diffhunk://#diff-2092324af8269cfb0e148140806e9cd2bdaa13d8e031df470ee0204bc17b26b9L86-R87)