### PR TITLE
Support `tsci snapshot` for direct `circuit.json` files

### DIFF
--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -81,6 +81,14 @@ export const snapshotProject = async ({
   const mismatches: string[] = []
   let didUpdate = false
 
+  const isCircuitJsonFile = (filePath: string) => {
+    const normalizedPath = filePath.toLowerCase().replaceAll("\\", "/")
+    return (
+      normalizedPath.endsWith(".circuit.json") ||
+      normalizedPath.endsWith("/circuit.json")
+    )
+  }
+
   for (const file of boardFiles) {
     const relativeFilePath = path.relative(projectDir, file)
 
@@ -89,14 +97,19 @@ export const snapshotProject = async ({
     let schSvg: string
 
     try {
-      // Get complete platform config with kicad_mod support
-      const completePlatformConfig = getCompletePlatformConfig(platformConfig)
+      if (isCircuitJsonFile(file)) {
+        const parsed = JSON.parse(fs.readFileSync(file, "utf-8"))
+        circuitJson = Array.isArray(parsed) ? parsed : []
+      } else {
+        // Get complete platform config with kicad_mod support
+        const completePlatformConfig = getCompletePlatformConfig(platformConfig)
 
-      const result = await generateCircuitJson({
-        filePath: file,
-        platformConfig: completePlatformConfig,
-      })
-      circuitJson = result.circuitJson
+        const result = await generateCircuitJson({
+          filePath: file,
+          platformConfig: completePlatformConfig,
+        })
+        circuitJson = result.circuitJson
+      }
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error)
@@ -163,7 +176,7 @@ export const snapshotProject = async ({
           const snapDir = snapshotsDirName
             ? path.join(projectDir, snapshotsDirName, relativeDir)
             : path.join(fileDir, "__snapshots__")
-          const base = path.basename(file).replace(/\.tsx$/, "")
+          const base = path.basename(file).replace(/\.[^.]+$/, "")
           const snap3dPath = path.join(snapDir, `${base}-3d.snap.png`)
           const existing3dSnapshot = fs.existsSync(snap3dPath)
 
@@ -212,7 +225,7 @@ export const snapshotProject = async ({
 
     fs.mkdirSync(snapDir, { recursive: true })
 
-    const base = path.basename(file).replace(/\.tsx$/, "")
+    const base = path.basename(file).replace(/\.[^.]+$/, "")
     const snapshots: Array<
       | { type: "pcb" | "schematic"; content: string; isBinary: false }
       | { type: "3d"; content: Buffer; isBinary: true }

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -125,6 +125,41 @@ test("snapshot command snapshots circuit files", async () => {
   expect(extraSch).toBe(true)
 }, 30_000)
 
+test("snapshot command supports direct circuit.json files", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "circuit.json"),
+    JSON.stringify([
+      {
+        type: "pcb_board",
+        center: { x: 0, y: 0 },
+        width: 10,
+        height: 10,
+        thickness: 1.6,
+        num_layers: 2,
+      },
+    ]),
+  )
+
+  const { stdout } = await runCommand("tsci snapshot circuit.json --update")
+  expect(stdout).toContain("Created snapshots")
+  expect(stdout).toContain(
+    `✅ ${join("__snapshots__", "circuit-pcb.snap.svg")}`,
+  )
+  expect(stdout).toContain(
+    `✅ ${join("__snapshots__", "circuit-schematic.snap.svg")}`,
+  )
+
+  const snapDir = join(tmpDir, "__snapshots__")
+  expect(await Bun.file(join(snapDir, "circuit-pcb.snap.svg")).exists()).toBe(
+    true,
+  )
+  expect(
+    await Bun.file(join(snapDir, "circuit-schematic.snap.svg")).exists(),
+  ).toBe(true)
+}, 30_000)
+
 test("snapshot respects includeBoardFiles config", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 


### PR DESCRIPTION
### Motivation

- Make the `tsci snapshot` command accept prebuilt circuit JSON files (e.g. `circuit.json` or `*.circuit.json`) so users can run `tsci snapshot path/to/circuit.json` without requiring a TSX build step.
- Ensure snapshot file naming works for non-TSX inputs so generated snapshot filenames are correct for JSON inputs.

### Description

- Added an `isCircuitJsonFile` helper and updated `snapshotProject` to `JSON.parse` inputs when the path looks like a circuit JSON file instead of invoking `generateCircuitJson` (preserving the existing TSX flow for other inputs). (`lib/shared/snapshot-project.ts`)
- Normalized snapshot base name handling by replacing the previous `.tsx`-specific replacement with a generic `replace(/\.[^.]+$/, "")` so filenames are correct for `.json` and other extensions. (`lib/shared/snapshot-project.ts`)
- Added an integration test that writes a `circuit.json` fixture and asserts `tsci snapshot circuit.json --update` creates the PCB and schematic snapshots in `__snapshots__`. (`tests/cli/snapshot/snapshot.test.ts`)

### Testing

- Ran `bun test tests/cli/snapshot/snapshot.test.ts` which passed all tests in that file (14 passed, 0 failed).
- Ran TypeScript check with `bunx tsc --noEmit` which succeeded.
- Ran formatter with `bun run format` (formatted files) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a52de1e278832e81dbbc3211fce257)