### PR TITLE
gate diff artifact generation behind --ci/--test

### DIFF
--- a/cli/snapshot/register.ts
+++ b/cli/snapshot/register.ts
@@ -17,6 +17,8 @@ export const registerSnapshot = (program: Command) => {
     .option("--pcb-only", "Generate only PCB snapshots")
     .option("--schematic-only", "Generate only schematic snapshots")
     .option("--disable-parts-engine", "Disable the parts engine")
+    .option("--ci", "Enable CI mode with snapshot diff artifacts")
+    .option("--test", "Enable test mode with snapshot diff artifacts")
     .action(
       async (
         target: string | undefined,
@@ -27,6 +29,8 @@ export const registerSnapshot = (program: Command) => {
           schematicOnly?: boolean
           forceUpdate?: boolean
           disablePartsEngine?: boolean
+          ci?: boolean
+          test?: boolean
         },
       ) => {
         await snapshotProject({
@@ -39,6 +43,7 @@ export const registerSnapshot = (program: Command) => {
           platformConfig: options.disablePartsEngine
             ? { partsEngineDisabled: true }
             : undefined,
+          createDiff: (options.ci ?? false) || (options.test ?? false),
           onExit: (code) => process.exit(code),
           onError: (msg) => console.error(msg),
           onSuccess: (msg) => console.log(msg),

--- a/lib/shared/compare-images.ts
+++ b/lib/shared/compare-images.ts
@@ -5,13 +5,14 @@ export const compareAndCreateDiff = async (
   buffer1: Buffer,
   buffer2: Buffer,
   diffPath: string,
+  createDiff = true,
 ): Promise<{ equal: boolean }> => {
   const { equal } = await looksSame(buffer1, buffer2, {
     strict: false,
     tolerance: 2,
   })
 
-  if (!equal) {
+  if (!equal && createDiff) {
     if (diffPath.endsWith(".png")) {
       await looksSame.createDiff({
         reference: buffer1,

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -39,6 +39,8 @@ type SnapshotOptions = {
   forceUpdate?: boolean
   /** Optional platform configuration overrides */
   platformConfig?: PlatformConfig
+  /** Create visual diff artifacts when snapshots mismatch */
+  createDiff?: boolean
   onExit?: (code: number) => void
   onError?: (message: string) => void
   onSuccess?: (message: string) => void
@@ -56,6 +58,7 @@ export const snapshotProject = async ({
   onError = (msg) => console.error(msg),
   onSuccess = (msg) => console.log(msg),
   platformConfig,
+  createDiff = false,
 }: SnapshotOptions = {}) => {
   const projectDir = process.cwd()
   const ignore = [
@@ -280,6 +283,7 @@ export const snapshotProject = async ({
         oldContentBuffer,
         newContentBuffer,
         diffPath,
+        createDiff,
       )
 
       if (update) {
@@ -291,7 +295,9 @@ export const snapshotProject = async ({
           didUpdate = true
         }
       } else if (!equal) {
-        mismatches.push(`${snapPath} (diff: ${diffPath})`)
+        mismatches.push(
+          createDiff ? `${snapPath} (diff: ${diffPath})` : snapPath,
+        )
       } else {
         console.log("✅", kleur.gray(path.relative(projectDir, snapPath)))
       }

--- a/tests/cli/snapshot/looks-same-visual-diff.test.ts
+++ b/tests/cli/snapshot/looks-same-visual-diff.test.ts
@@ -37,7 +37,7 @@ test("CLI detects visual change when another chip is added", async () => {
   fs.writeFileSync(snapPath, mutatedSvg)
 
   // Run snapshot again, expect visual diff detected
-  const { stdout, stderr } = await runCommand("tsci snapshot")
+  const { stdout, stderr } = await runCommand("tsci snapshot --test")
   expect(stdout).not.toContain("All snapshots match")
   expect(stderr).toContain(".diff.svg")
 

--- a/tests/cli/snapshot/snapshot-diff.test.ts
+++ b/tests/cli/snapshot/snapshot-diff.test.ts
@@ -31,7 +31,7 @@ test("snapshot command creates diff images for pcb, schematic and 3d when visual
   `,
   )
 
-  const { stderr } = await runCommand("tsci snapshot --3d")
+  const { stderr } = await runCommand("tsci snapshot --3d --ci")
   expect(stderr).toContain("Snapshot mismatch")
 
   const snapDir = join(tmpDir, "__snapshots__")
@@ -48,4 +48,4 @@ test("snapshot command creates diff images for pcb, schematic and 3d when visual
   expect(pcbDiff).toBe(true)
   expect(schDiff).toBe(true)
   expect(threeDDiff).toBe(true)
-}, 30_000)
+}, 45_000)

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -420,6 +420,49 @@ test("visual comparison works for pcb and schematic snapshots", async () => {
   expect(schAfter).toBe(schBefore)
 }, 30_000)
 
+test("snapshot command does not create diff files by default when visuals change", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "mismatch-no-diff.board.tsx"),
+    `
+    export const MismatchNoDiff = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  await runCommand("tsci snapshot --update")
+
+  await Bun.write(
+    join(tmpDir, "mismatch-no-diff.board.tsx"),
+    `
+    export const MismatchNoDiff = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+        <chip name="U2" footprint="soic8" schX={-3} pcbX={-3} />
+      </board>
+    )
+  `,
+  )
+
+  const { stderr } = await runCommand("tsci snapshot")
+  expect(stderr).toContain("Snapshot mismatch")
+  expect(stderr).not.toContain(".diff")
+
+  const snapDir = join(tmpDir, "__snapshots__")
+  const pcbDiff = await Bun.file(
+    join(snapDir, "mismatch-no-diff.board-pcb.diff.svg"),
+  ).exists()
+  const schDiff = await Bun.file(
+    join(snapDir, "mismatch-no-diff.board-schematic.diff.svg"),
+  ).exists()
+
+  expect(pcbDiff).toBe(false)
+  expect(schDiff).toBe(false)
+}, 30_000)
 test("snapshot command creates diff files when visuals change", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
@@ -448,7 +491,7 @@ test("snapshot command creates diff files when visuals change", async () => {
   `,
   )
 
-  const { stderr } = await runCommand("tsci snapshot")
+  const { stderr } = await runCommand("tsci snapshot --test")
   expect(stderr).toContain("Snapshot mismatch")
 
   const snapDir = join(tmpDir, "__snapshots__")


### PR DESCRIPTION
### Motivation

- Avoid writing `.diff.*` snapshot artifacts during normal developer runs and only produce them in CI/test flows to reduce noise and disk churn.

### Description

- Added `--ci` and `--test` options to the `tsci snapshot` command and wired them to a new `createDiff` boolean. (`cli/snapshot/register.ts`)
- Introduced `createDiff?: boolean` in `snapshotProject` and forwarded it into the comparison step so diffs are only written when enabled. (`lib/shared/snapshot-project.ts`)
- Updated the low-level image comparison `compareAndCreateDiff` to accept `createDiff` and skip writing `.diff.*` files when `createDiff` is `false`. (`lib/shared/compare-images.ts`)
- Updated tests to assert the new behavior: tests that expect diff files now run with `--ci`/`--test`, and a new test verifies that default snapshot runs report mismatches but do not create `.diff.*` files. (tests under `tests/cli/snapshot/`)

### Testing

- Ran targeted snapshot tests with `bun test`:
  - `bun test tests/cli/snapshot/snapshot-diff.test.ts` — passed.
  - `bun test tests/cli/snapshot/snapshot.test.ts -t "does not create diff files by default"` — passed.
  - `bun test tests/cli/snapshot/snapshot.test.ts tests/cli/snapshot/snapshot-diff.test.ts tests/cli/snapshot/looks-same-visual-diff.test.ts` — initial run hit a timeout in the 3D diff test, then re-run with an increased timeout and the failing case passed.
- Typecheck performed with `bunx tsc --noEmit` — passed.
- Code formatted with `bun run format` — ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5d0716ff8832eb0d079740de00dd5)