### PR TITLE
docs: clarify local development section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The `build` command also accepts the following options:
 - `--ignore-errors` - continue build even if circuit JSON contains errors
 - `--ignore-warnings` - suppress warning output
 
-## Development
+## Local development
 
-This command will open the `index.tsx` file for editing.
+This command starts local development and watches for changes.
 
 ```bash
 bun run dev
@@ -87,7 +87,7 @@ bun run dev
 When you run `tsci dev`, we start a local
 server that uses the [@tscircuit/file-server](https://github.com/tscircuit/file-server) and [@tscircuit/runframe](https://github.com/tscircuit/runframe) (on the browser)
 
-We use commanderjs to define the CLI commands inside
+We use Commander.js to define the CLI commands inside
 of `cli/main.ts`
 
 Utility functions are defined in `lib/*`


### PR DESCRIPTION
## What I noticed
The README had two `Development` headings and the first one said the command "will open `index.tsx`", which is misleading for a CLI repo.

## What I changed
- renamed the first heading to `Local development`
- updated wording to describe what `bun run dev` actually does (starts local dev + watch mode)
- changed `commanderjs` to `Commander.js` for consistency with package naming

## Why this is worth fixing
This removes ambiguity for new contributors trying to run the repo locally and makes docs terminology more precise.
