### PR TITLE
fix placement check

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/cli",
@@ -12,7 +11,7 @@
         "@tscircuit/fake-snippets": "^0.0.182",
         "@tscircuit/file-server": "^0.0.32",
         "@tscircuit/math-utils": "0.0.29",
-        "@tscircuit/props": "^0.0.474",
+        "@tscircuit/props": "^0.0.487",
         "@tscircuit/runframe": "^0.0.1677",
         "@tscircuit/schematic-match-adapt": "^0.0.22",
         "@types/bun": "^1.2.2",
@@ -320,7 +319,7 @@
 
     "@tscircuit/ngspice-spice-engine": ["@tscircuit/ngspice-spice-engine@0.0.8", "", { "dependencies": { "eecircuit-engine": "^1.5.6" }, "peerDependencies": { "@tscircuit/props": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-jubJ8Kgpm9FPRdHBiRBYkf5+B37bqkjDRKpCXOMqS08UZnbS+iCv2k4ACMW+s1zbK0Xa5v+9yjuoHlfKFW1v/Q=="],
 
-    "@tscircuit/props": ["@tscircuit/props@0.0.474", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-lC4gEYngU0d8+olcxR930k6Hb0ru2WkblM3JVnA+JZ2x7xA6YW35GfAhYWiiLz+okl9eboPbKXTc481mosw8fA=="],
+    "@tscircuit/props": ["@tscircuit/props@0.0.487", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-NCxrc+IbXWcTsKz0bqa0Rak3XbR+HKeZ9eBNES0YGdfQTHRVwicPLha4AyYA4WgWGg7Yzq1hYtPFtyMyrOoRwg=="],
 
     "@tscircuit/runframe": ["@tscircuit/runframe@0.0.1677", "", { "dependencies": { "@tscircuit/solver-utils": "^0.0.7" } }, "sha512-ZZP18ZMjLHeRfuGuhVbrIQiuI1QKOkiATzn0IB9NGFMxmSHxNNUYDR+j/Z4g4YapFpEt9aNI21OW594x6yAKTg=="],
 
@@ -332,7 +331,7 @@
 
     "@tscircuit/simple-3d-svg": ["@tscircuit/simple-3d-svg@0.0.41", "", { "dependencies": { "fast-xml-parser": "^5.2.5", "fflate": "^0.8.2" } }, "sha512-2iwhHhMLElq5t0fcC0Gr7cCpZhEOAKh+6NN0NIJ9YWUCcsB7UN8uYko7jqNTxDlYOe6E0ZYaDZWsQ3amOZ3dlw=="],
 
-    "@tscircuit/solver-utils": ["@tscircuit/solver-utils@0.0.7", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-SB5+A92BMsozxOWfi6iXrcVv1UAFfbBAbKlWHG9TXWquEvAVPSukeCZJ08Yhq0b22T4qkMNy5bZWshXwlO+BuQ=="],
+    "@tscircuit/solver-utils": ["@tscircuit/solver-utils@0.0.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-NMzqn7NM0SpeHnoWwewcnitxSNczaFsm/WENmBy8dxnFbUkGBdmSY5Gbky8C9e7q8+SzRcwj7GqXE7EWAHTirw=="],
 
     "@tscircuit/soup-util": ["@tscircuit/soup-util@0.0.41", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "*" } }, "sha512-47JKWBUKkRVHhad0HhBbdOJxB6v/eiac46beiKRBMlJqiZ1gPGI276v9iZfpF7c4hXR69cURcgiwuA5vowrFEg=="],
 
@@ -870,7 +869,7 @@
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 
-    "picocolors": ["picocolors@1.0.0", "", {}, "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="],
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
@@ -1114,8 +1113,6 @@
 
     "zustand-hoist": ["zustand-hoist@2.0.1", "", { "peerDependencies": { "zustand": ">=4.0.0" } }, "sha512-Lhvv3RlLQx1NSUtuhk8jegXe1Wyav9RAOnLd4CRs1SbB5qcFoarAGQTE43vIxXizrm1UQJl1q5uRbOZuXGXGpQ=="],
 
-    "@babel/code-frame/picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
-
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
@@ -1123,6 +1120,8 @@
     "@tscircuit/capacity-autorouter/bun-match-svg": ["bun-match-svg@0.0.14", "", { "dependencies": { "looks-same": "^9.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "bun-match-svg": "cli.ts" } }, "sha512-6tiAOY70cwf0aptY/0etMa3/8W1JggJBk3odwPhLhcUABoS3gaEbfYe8hE2z3o/tcbZ/imcmKz94c3T/ht7M+Q=="],
 
     "@tscircuit/circuit-json-flex/@tscircuit/miniflex": ["@tscircuit/miniflex@0.0.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-oRC0up2psp8dJD1CzXyUiFuhQZUWLdZNl9EAqOf/hHqXDhPKMU6wM79S+XQuaB0gdWNRnwcURHPPaKLw/ka3DQ=="],
+
+    "@tscircuit/runframe/@tscircuit/solver-utils": ["@tscircuit/solver-utils@0.0.7", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-SB5+A92BMsozxOWfi6iXrcVv1UAFfbBAbKlWHG9TXWquEvAVPSukeCZJ08Yhq0b22T4qkMNy5bZWshXwlO+BuQ=="],
 
     "@types/prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
@@ -1153,6 +1152,8 @@
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 
     "dot-prop/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "edge-runtime/picocolors": ["picocolors@1.0.0", "", {}, "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="],
 
     "editorconfig/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
@@ -1205,8 +1206,6 @@
     "tscircuit/@tscircuit/runframe": ["@tscircuit/runframe@0.0.1638", "", { "dependencies": { "@tscircuit/solver-utils": "^0.0.7" } }, "sha512-m0ZIUjLJM0EZ2n/w8ghxcWLwgLD/1oPtcnmvmBVjByMWuImVwim8vGn7zwqjoqAPM2DnW9VmKUuYwnPCOIfLlg=="],
 
     "tscircuit/@tscircuit/schematic-match-adapt": ["@tscircuit/schematic-match-adapt@0.0.16", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-85e6Pq58zrhZqivyW4bPVZfGfg8xLBCj3yjHl5LZslwfsDRgtWVob4bjJMhCfNL/mLsPUQKnpiDNnFKl9ugUZw=="],
-
-    "tscircuit/@tscircuit/solver-utils": ["@tscircuit/solver-utils@0.0.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-NMzqn7NM0SpeHnoWwewcnitxSNczaFsm/WENmBy8dxnFbUkGBdmSY5Gbky8C9e7q8+SzRcwj7GqXE7EWAHTirw=="],
 
     "tscircuit/circuit-json-to-spice": ["circuit-json-to-spice@0.0.34", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-59XyRHATq455875XlEiAfycIvxkOjaKnX4nzzlvY88UJyFcjkHSQCB9HCnbHJGsRxVBEmrTcELLyVIFmB+c4LA=="],
 

--- a/cli/check/placement/register.ts
+++ b/cli/check/placement/register.ts
@@ -44,7 +44,8 @@ const getCircuitJsonForPlacementCheck = async (filePath: string) => {
   }
 
   const completePlatformConfig = getCompletePlatformConfig({
-    pcbDisabled: true,
+    pcbDisabled: false,
+    routingDisabled: true,
   } satisfies PlatformConfig)
 
   const { circuitJson } = await generateCircuitJson({

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@tscircuit/fake-snippets": "^0.0.182",
     "@tscircuit/file-server": "^0.0.32",
     "@tscircuit/math-utils": "0.0.29",
-    "@tscircuit/props": "^0.0.474",
+    "@tscircuit/props": "^0.0.487",
     "@tscircuit/runframe": "^0.0.1677",
     "@tscircuit/schematic-match-adapt": "^0.0.22",
     "@types/bun": "^1.2.2",

--- a/tests/cli/check/check-placement.test.ts
+++ b/tests/cli/check/check-placement.test.ts
@@ -5,7 +5,7 @@ import { checkPlacement } from "../../../cli/check/placement/register"
 
 const circuitCode = `
 export default () => (
-  <board width="10mm" height="10mm">
+  <board width="10mm" height="10mm" routingDisabled>
     <resistor resistance="1k" footprint="0402" name="R1" pcbX={3} pcbY={2} />
     <capacitor capacitance="1000pF" footprint="0402" name="C1" pcbX={-3} pcbY={-2} />
   </board>
@@ -27,10 +27,12 @@ test("check placement analyzes the provided refdes", async () => {
   try {
     const output = await checkPlacement(circuitPath, "R1")
     expect(output).toContain("R1")
+    expect(output).toContain("R1.center=(3mm, 2mm)")
+    expect(output).toContain("R1.size=(width=")
   } finally {
     await unlink(circuitPath)
   }
-})
+}, 20_000)
 
 test("check placement analyzes all placements when refdes is missing", async () => {
   const circuitPath = await makeCircuitFile()
@@ -39,7 +41,9 @@ test("check placement analyzes all placements when refdes is missing", async () 
     const output = await checkPlacement(circuitPath)
     expect(output).toContain("R1")
     expect(output).toContain("C1")
+    expect(output).toContain("R1.center=(3mm, 2mm)")
+    expect(output).toContain("C1.center=(-3mm, -2mm)")
   } finally {
     await unlink(circuitPath)
   }
-})
+}, 20_000)


### PR DESCRIPTION
### Motivation
- Restore the placement-check behavior from the referenced PR while avoiding an upgrade of the top-level `tscircuit` dependency. 
- Ensure placement analysis runs with PCB generation enabled but routing disabled to match the intended checks. 
- Improve test coverage to assert component center/size details and to stabilize test timing.

### Description
- Enable PCB generation and disable routing for placement checks by setting `pcbDisabled: false` and `routingDisabled: true` in `getCompletePlatformConfig` in `cli/check/placement/register.ts`.
- Strengthen `tests/cli/check/check-placement.test.ts` to mark the fixture board `routingDisabled`, assert `R1.center`/`R1.size` and `C1.center` output strings, and add `20_000` ms timeouts to each test.
- Bump `@tscircuit/props` to `^0.0.487` and refresh lockfile entries accordingly, while intentionally leaving `tscircuit` pinned (no `tscircuit` version bump).
- Commit and format changes; updated `bun.lock` reflects the `props` update and related lock adjustments only.

### Testing
- Ran `bun update --latest @tscircuit/props` which completed successfully.
- Ran `bun test tests/cli/check/check-placement.test.ts` and both tests passed (2 passed, 0 failed).
- Ran `bunx tsc --noEmit` which completed with no type errors.
- Ran `bun run format` to apply formatting fixes with no remaining issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a780c8c5fc832ebe8021df9d28ec86)