### PR TITLE
feat: upload binary files via multipart/form-data in local sync pipeline

### DIFF
--- a/cli/dev/DevServer.ts
+++ b/cli/dev/DevServer.ts
@@ -1,40 +1,37 @@
-import ky, { TimeoutError } from "ky"
-import type { FileServerRoutes } from "lib/file-server/FileServerRoutes"
-import { createHttpServer } from "lib/server/createHttpServer"
-import { EventsWatcher } from "lib/server/EventsWatcher"
-import type http from "node:http"
-import type { TypedKyInstance } from "typed-ky"
-import path from "node:path"
 import fs from "node:fs"
-import type {
-  FileUpdatedEvent,
-  FileDeletedEvent,
-} from "../../lib/file-server/FileServerEvent"
+import type http from "node:http"
+import path from "node:path"
 import * as chokidar from "chokidar"
-import { pushSnippet } from "lib/shared/push-snippet"
-import { getPackageFilePaths } from "./get-package-file-paths"
-import { addPackage } from "lib/shared/add-package"
 import Debug from "debug"
 import kleur from "kleur"
-import { loadProjectConfig } from "lib/project-config"
-import { shouldIgnorePath } from "lib/shared/should-ignore-path"
-import { getAllNodeModuleFilePaths } from "lib/dependency-analysis/getNodeModuleDependencies"
+import ky, { TimeoutError } from "ky"
 import { setSessionToken } from "lib/cli-config"
+import { getAllNodeModuleFilePaths } from "lib/dependency-analysis/getNodeModuleDependencies"
+import type { FileServerRoutes } from "lib/file-server/FileServerRoutes"
+import { loadProjectConfig } from "lib/project-config"
+import { EventsWatcher } from "lib/server/EventsWatcher"
+import { createHttpServer } from "lib/server/createHttpServer"
+import { addPackage } from "lib/shared/add-package"
+import { pushSnippet } from "lib/shared/push-snippet"
+import { shouldIgnorePath } from "lib/shared/should-ignore-path"
+import type { TypedKyInstance } from "typed-ky"
+import type {
+  FileDeletedEvent,
+  FileUpdatedEvent,
+} from "../../lib/file-server/FileServerEvent"
+import { getPackageFilePaths } from "./get-package-file-paths"
 
 const debug = Debug("tscircuit:devserver")
 
-const BINARY_FILE_EXTENSIONS = new Set([
-  ".glb",
-  ".png",
-  ".jpeg",
-  ".jpg",
-  ".step",
-])
+const BINARY_FILE_EXTENSIONS = new Set([".glb", ".png", ".jpeg", ".jpg"])
 
-type FileUploadPayload = Pick<
-  FileServerRoutes["api/files/upsert"]["POST"]["requestJson"],
-  "text_content" | "binary_content_b64"
->
+type FileUploadPayload =
+  | {
+      text_content: string
+    }
+  | {
+      binary_content: Buffer
+    }
 
 export class DevServer {
   port: number
@@ -429,6 +426,15 @@ export class DevServer {
     filePayload: FileUploadPayload
   }) {
     try {
+      if ("binary_content" in filePayload) {
+        await this.postBinaryFileUpsertMultipart({
+          filePath,
+          initiator,
+          binaryContent: filePayload.binary_content,
+        })
+        return
+      }
+
       await this.fsKy.post("api/files/upsert", {
         json: {
           file_path: filePath,
@@ -442,6 +448,41 @@ export class DevServer {
     }
   }
 
+  private async postBinaryFileUpsertMultipart({
+    filePath,
+    initiator,
+    binaryContent,
+  }: {
+    filePath: string
+    initiator: "filesystem_change"
+    binaryContent: Buffer
+  }) {
+    const formData = new FormData()
+    formData.set("file_path", filePath)
+    formData.set("initiator", initiator)
+    const binaryBytes = Uint8Array.from(binaryContent)
+    formData.set(
+      "binary_file",
+      new Blob([binaryBytes]),
+      path.basename(filePath),
+    )
+
+    const response = await fetch(
+      `http://localhost:${this.port}/api/files/upsert-multipart`,
+      {
+        method: "POST",
+        body: formData,
+      },
+    )
+
+    if (!response.ok) {
+      const errorBody = await response.text()
+      throw new Error(
+        `Multipart upload failed for ${filePath}: ${response.status} ${response.statusText}${errorBody ? ` - ${errorBody}` : ""}`,
+      )
+    }
+  }
+
   private logFileUpsertTimeout(error: unknown, filePath: string) {
     if (!(error instanceof TimeoutError)) return
 
@@ -452,8 +493,7 @@ export class DevServer {
     )
     console.error(
       kleur.yellow(
-        `Additional info: the file server at http://localhost:${this.port}/api/files/upsert did not respond in time. ` +
-          "Make sure the dev server started successfully, the port is not blocked, and try again.",
+        `Additional info: the file server at http://localhost:${this.port}/api/files/upsert did not respond in time. Make sure the dev server started successfully, the port is not blocked, and try again.`,
       ),
     )
   }
@@ -495,7 +535,7 @@ export class DevServer {
 
     if (BINARY_FILE_EXTENSIONS.has(ext)) {
       const fileBuffer = fs.readFileSync(absoluteFilePath)
-      return { binary_content_b64: fileBuffer.toString("base64") }
+      return { binary_content: fileBuffer }
     }
 
     return { text_content: fs.readFileSync(absoluteFilePath, "utf-8") }

--- a/lib/server/createHttpServer.ts
+++ b/lib/server/createHttpServer.ts
@@ -1,11 +1,11 @@
-import * as http from "node:http"
 import * as fs from "node:fs"
-import { getNodeHandler } from "winterspec/adapters/node"
-import pkg from "../../package.json"
+import * as http from "node:http"
 // @ts-ignore
 import runFrameStandaloneBundleContent from "@tscircuit/runframe/standalone" with {
   type: "text",
 }
+import { getNodeHandler } from "winterspec/adapters/node"
+import pkg from "../../package.json"
 
 // @ts-ignore
 import winterspecBundle from "@tscircuit/file-server/dist/bundle.js"
@@ -34,7 +34,77 @@ export const createHttpServer = async ({
       : null
 
   const server = http.createServer(async (req, res) => {
-    const url = new URL(req.url!, `http://${req.headers.host}`)
+    const requestHost = req.headers.host ?? `localhost:${port}`
+    const url = new URL(req.url!, `http://${requestHost}`)
+
+    if (
+      url.pathname === "/api/files/upsert-multipart" &&
+      req.method === "POST"
+    ) {
+      try {
+        const request = new Request(url.toString(), {
+          method: req.method,
+          headers: req.headers as HeadersInit,
+          body: req as unknown as BodyInit,
+          duplex: "half",
+        } as RequestInit)
+
+        const formData = await request.formData()
+        const filePath = formData.get("file_path")?.toString()
+        const initiator = formData.get("initiator")?.toString()
+        const binaryFile = formData.get("binary_file")
+
+        if (!filePath || !(binaryFile instanceof Blob)) {
+          res.writeHead(400, { "Content-Type": "application/json" })
+          res.end(
+            JSON.stringify({
+              error:
+                "Missing required multipart fields: file_path, binary_file",
+            }),
+          )
+          return
+        }
+
+        const binaryContentB64 = Buffer.from(
+          await binaryFile.arrayBuffer(),
+        ).toString("base64")
+
+        const upstreamResponse = await fetch(
+          `http://${requestHost}/api/files/upsert`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              file_path: filePath,
+              initiator,
+              binary_content_b64: binaryContentB64,
+            }),
+          },
+        )
+
+        const responseText = await upstreamResponse.text()
+        res.writeHead(upstreamResponse.status, {
+          "Content-Type":
+            upstreamResponse.headers.get("content-type") ?? "application/json",
+        })
+        res.end(responseText)
+        return
+      } catch (error) {
+        res.writeHead(500, { "Content-Type": "application/json" })
+        res.end(
+          JSON.stringify({
+            error_code: "MULTIPART_UPLOAD_FAILED",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to process multipart upload",
+          }),
+        )
+        return
+      }
+    }
 
     if (url.pathname === "/standalone.min.js") {
       const standaloneFilePath = process.env.RUNFRAME_STANDALONE_FILE_PATH

--- a/tests/cli/dev/multipart-binary-upload.test.ts
+++ b/tests/cli/dev/multipart-binary-upload.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { join } from "node:path"
+import { DevServer } from "cli/dev/DevServer"
+import getPort from "get-port"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("multipart endpoint upserts binary files", async () => {
+  const fixture = await getCliTestFixture()
+  const devServerPort = await getPort()
+
+  const mainFilePath = join(fixture.tmpDir, "main.tsx")
+  await Bun.write(
+    mainFilePath,
+    `export default () => <board width=\"10mm\" height=\"10mm\" />`,
+  )
+
+  const devServer = new DevServer({
+    port: devServerPort,
+    componentFilePath: mainFilePath,
+  })
+
+  try {
+    await devServer.start()
+
+    const binaryContent = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d])
+    const formData = new FormData()
+    formData.set("file_path", "uploaded.png")
+    formData.set("binary_file", new Blob([binaryContent]), "uploaded.png")
+
+    const response = await fetch(
+      `http://localhost:${devServerPort}/api/files/upsert-multipart`,
+      {
+        method: "POST",
+        body: formData,
+      },
+    )
+
+    expect(response.ok).toBe(true)
+
+    const { file } = await devServer.fsKy
+      .get("api/files/get", {
+        searchParams: { file_path: "uploaded.png" },
+      })
+      .json()
+
+    expect(file.binary_content_b64).toBe(
+      Buffer.from(binaryContent).toString("base64"),
+    )
+    expect(file.text_content).toBeUndefined()
+  } finally {
+    await devServer.stop()
+  }
+})


### PR DESCRIPTION
- No more encoding of binary files to base64 on the file-watcher client side

## Tested with actual circuit
<img width="1742" height="1602" alt="image" src="https://github.com/user-attachments/assets/e4188c29-4e11-4726-868c-eb591fa3f6df" />
