### PR TITLE
feat: add findAvailablePort function and verbose logging support

### DIFF
--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander"
 import * as fs from "node:fs"
 import * as net from "node:net"
 import * as path from "node:path"
+import Debug from "debug"
 import { DevServer } from "./DevServer"
 import { resolveDevTarget } from "./resolve-dev-target"
 import kleur from "kleur"
@@ -16,6 +17,45 @@ const isPortAvailable = (port: number): Promise<boolean> => {
     })
     server.listen(port)
   })
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const findAvailablePort = async ({
+  preferredPort,
+  timeoutMs,
+  verbose,
+}: {
+  preferredPort: number
+  timeoutMs: number
+  verbose: boolean
+}): Promise<{ port: number; attempts: number }> => {
+  let port = preferredPort
+  const start = Date.now()
+  let attempts = 0
+
+  while (true) {
+    const available = await isPortAvailable(port)
+    if (available) return { port, attempts }
+
+    attempts += 1
+    if (verbose) {
+      console.log(
+        kleur.gray(
+          `Port ${port} is in use, trying port ${port + 1}... (attempt ${attempts})`,
+        ),
+      )
+    }
+
+    if (Date.now() - start >= timeoutMs) {
+      throw new Error(
+        `Unable to find an open port within ${timeoutMs}ms starting from ${preferredPort}. Last tried port ${port}. Try specifying a different --port or increasing --port-timeout.`,
+      )
+    }
+
+    port += 1
+    await sleep(150)
+  }
 }
 
 const warnIfTsconfigMissingTscircuitType = (projectDir: string) => {
@@ -39,24 +79,70 @@ const warnIfTsconfigMissingTscircuitType = (projectDir: string) => {
   }
 }
 
+const enableDevVerboseLogging = () => {
+  const namespace = "tscircuit:devserver"
+  const existingNamespaces = (process.env.DEBUG ?? "")
+    .split(/[\s,]+/)
+    .map((ns) => ns.trim())
+    .filter(Boolean)
+
+  if (!existingNamespaces.includes(namespace)) {
+    existingNamespaces.push(namespace)
+  }
+
+  const mergedNamespaces = existingNamespaces.join(",")
+
+  Debug.enable(mergedNamespaces || namespace)
+  process.env.DEBUG = mergedNamespaces || namespace
+
+  console.log(
+    kleur.gray(
+      `Verbose debug logging enabled (DEBUG=${mergedNamespaces || namespace})`,
+    ),
+  )
+}
+
+// Exported for testing to verify DEBUG namespace wiring
+export const enableDevVerboseLoggingForTest = enableDevVerboseLogging
+export const findAvailablePortForTest = findAvailablePort
+
 export const registerDev = (program: Command) => {
   program
     .command("dev")
     .description("Start development server for a package")
     .argument("[file]", "Path to the package file or directory")
     .option("-p, --port <number>", "Port to run server on", "3020")
+    .option(
+      "--port-timeout <ms>",
+      "Maximum time in ms to search for an open port",
+      "10000",
+    )
     .option("--kicad-pcm", "Enable KiCad PCM proxy server at /pcm/*")
+    .option("-v, --verbose", "Enable verbose debug logging")
     .action(
-      async (file: string, options: { port: string; kicadPcm?: boolean }) => {
+      async (
+        file: string,
+        options: {
+          port: string
+          portTimeout?: string
+          kicadPcm?: boolean
+          verbose?: boolean
+        },
+      ) => {
         let port = parseInt(options.port)
+        const portTimeout = parseInt(options.portTimeout ?? "10000")
         const startTime = Date.now()
 
-        while (!(await isPortAvailable(port))) {
-          console.log(
-            kleur.gray(`Port ${port} is in use, trying port ${port + 1}...`),
-          )
-          port += 1
+        if (options.verbose) {
+          enableDevVerboseLogging()
         }
+
+        const { port: resolvedPort } = await findAvailablePort({
+          preferredPort: port,
+          timeoutMs: portTimeout,
+          verbose: !!options.verbose,
+        })
+        port = resolvedPort
 
         const target = await resolveDevTarget(file)
         if (!target) return

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -21,13 +21,15 @@ const isPortAvailable = (port: number): Promise<boolean> => {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+const DEFAULT_PORT_TIMEOUT_MS = 10_000
+
 const findAvailablePort = async ({
   preferredPort,
-  timeoutMs,
+  timeoutMs = DEFAULT_PORT_TIMEOUT_MS,
   verbose,
 }: {
   preferredPort: number
-  timeoutMs: number
+  timeoutMs?: number
   verbose: boolean
 }): Promise<{ port: number; attempts: number }> => {
   let port = preferredPort
@@ -49,7 +51,7 @@ const findAvailablePort = async ({
 
     if (Date.now() - start >= timeoutMs) {
       throw new Error(
-        `Unable to find an open port within ${timeoutMs}ms starting from ${preferredPort}. Last tried port ${port}. Try specifying a different --port or increasing --port-timeout.`,
+        `Unable to find an open port within ${timeoutMs}ms starting from ${preferredPort}. Last tried port ${port}. Try specifying a different --port.`,
       )
     }
 
@@ -112,11 +114,6 @@ export const registerDev = (program: Command) => {
     .description("Start development server for a package")
     .argument("[file]", "Path to the package file or directory")
     .option("-p, --port <number>", "Port to run server on", "3020")
-    .option(
-      "--port-timeout <ms>",
-      "Maximum time in ms to search for an open port",
-      "10000",
-    )
     .option("--kicad-pcm", "Enable KiCad PCM proxy server at /pcm/*")
     .option("-v, --verbose", "Enable verbose debug logging")
     .action(
@@ -124,13 +121,11 @@ export const registerDev = (program: Command) => {
         file: string,
         options: {
           port: string
-          portTimeout?: string
           kicadPcm?: boolean
           verbose?: boolean
         },
       ) => {
         let port = parseInt(options.port)
-        const portTimeout = parseInt(options.portTimeout ?? "10000")
         const startTime = Date.now()
 
         if (options.verbose) {
@@ -139,7 +134,7 @@ export const registerDev = (program: Command) => {
 
         const { port: resolvedPort } = await findAvailablePort({
           preferredPort: port,
-          timeoutMs: portTimeout,
+          timeoutMs: DEFAULT_PORT_TIMEOUT_MS,
           verbose: !!options.verbose,
         })
         port = resolvedPort

--- a/tests/cli/dev/dev-port-timeout-success.test.ts
+++ b/tests/cli/dev/dev-port-timeout-success.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { findAvailablePortForTest } from "cli/dev/register"
+import getPort from "get-port"
+
+test("findAvailablePort resolves when a port is free", async () => {
+  const freePort = await getPort()
+  const { port, attempts } = await findAvailablePortForTest({
+    preferredPort: freePort,
+    timeoutMs: 2000,
+    verbose: false,
+  })
+
+  expect(port).toBe(freePort)
+  expect(attempts).toBe(0)
+})

--- a/tests/cli/dev/dev-port-timeout-timeout.test.ts
+++ b/tests/cli/dev/dev-port-timeout-timeout.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import net from "node:net"
+import { findAvailablePortForTest } from "cli/dev/register"
+import getPort from "get-port"
+
+const startServerOnPort = async (port: number) =>
+  new Promise<net.Server>((resolve, reject) => {
+    const server = net.createServer()
+    server.once("error", reject)
+    server.listen(port, () => resolve(server))
+  })
+
+test("findAvailablePort times out when no port becomes available", async () => {
+  const busyPort = await getPort()
+  const servers = [
+    await startServerOnPort(busyPort),
+    await startServerOnPort(busyPort + 1),
+    await startServerOnPort(busyPort + 2),
+  ]
+
+  try {
+    await expect(
+      findAvailablePortForTest({
+        preferredPort: busyPort,
+        timeoutMs: 200,
+        verbose: false,
+      }),
+    ).rejects.toThrow(/Unable to find an open port/)
+  } finally {
+    servers.forEach((s) => s.close())
+  }
+})

--- a/tests/cli/dev/dev-verbose-flag-append.test.ts
+++ b/tests/cli/dev/dev-verbose-flag-append.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import Debug from "debug"
+import { enableDevVerboseLoggingForTest } from "cli/dev/register"
+
+const getDebugNamespaces = () => (process.env.DEBUG ?? "")
+  .split(/[\s,]+/)
+  .map((ns) => ns.trim())
+  .filter(Boolean)
+
+test("verbose helper appends without duplicating existing namespaces", () => {
+  const originalEnv = process.env.DEBUG
+  Debug.disable()
+  process.env.DEBUG = "foo,bar"
+
+  try {
+    enableDevVerboseLoggingForTest()
+
+    const namespaces = getDebugNamespaces()
+    expect(namespaces).toEqual(expect.arrayContaining(["foo", "bar", "tscircuit:devserver"]))
+
+    const occurrences = namespaces.filter((ns) => ns === "tscircuit:devserver").length
+    expect(occurrences).toBe(1)
+  } finally {
+    process.env.DEBUG = originalEnv
+    Debug.disable()
+  }
+})

--- a/tests/cli/dev/dev-verbose-flag-append.test.ts
+++ b/tests/cli/dev/dev-verbose-flag-append.test.ts
@@ -2,10 +2,11 @@ import { expect, test } from "bun:test"
 import Debug from "debug"
 import { enableDevVerboseLoggingForTest } from "cli/dev/register"
 
-const getDebugNamespaces = () => (process.env.DEBUG ?? "")
-  .split(/[\s,]+/)
-  .map((ns) => ns.trim())
-  .filter(Boolean)
+const getDebugNamespaces = () =>
+  (process.env.DEBUG ?? "")
+    .split(/[\s,]+/)
+    .map((ns) => ns.trim())
+    .filter(Boolean)
 
 test("verbose helper appends without duplicating existing namespaces", () => {
   const originalEnv = process.env.DEBUG
@@ -16,9 +17,13 @@ test("verbose helper appends without duplicating existing namespaces", () => {
     enableDevVerboseLoggingForTest()
 
     const namespaces = getDebugNamespaces()
-    expect(namespaces).toEqual(expect.arrayContaining(["foo", "bar", "tscircuit:devserver"]))
+    expect(namespaces).toEqual(
+      expect.arrayContaining(["foo", "bar", "tscircuit:devserver"]),
+    )
 
-    const occurrences = namespaces.filter((ns) => ns === "tscircuit:devserver").length
+    const occurrences = namespaces.filter(
+      (ns) => ns === "tscircuit:devserver",
+    ).length
     expect(occurrences).toBe(1)
   } finally {
     process.env.DEBUG = originalEnv

--- a/tests/cli/dev/dev-verbose-flag-enable.test.ts
+++ b/tests/cli/dev/dev-verbose-flag-enable.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import Debug from "debug"
+import { enableDevVerboseLoggingForTest } from "cli/dev/register"
+
+const getDebugNamespaces = () => (process.env.DEBUG ?? "")
+  .split(/[\s,]+/)
+  .map((ns) => ns.trim())
+  .filter(Boolean)
+
+test("verbose helper enables tscircuit devserver namespace", () => {
+  const originalEnv = process.env.DEBUG
+  Debug.disable()
+  process.env.DEBUG = ""
+
+  try {
+    enableDevVerboseLoggingForTest()
+
+    const namespaces = getDebugNamespaces()
+    expect(namespaces).toContain("tscircuit:devserver")
+
+    const logger = Debug("tscircuit:devserver")
+    expect(logger.enabled).toBeTrue()
+  } finally {
+    process.env.DEBUG = originalEnv
+    Debug.disable()
+  }
+})

--- a/tests/cli/dev/dev-verbose-flag-enable.test.ts
+++ b/tests/cli/dev/dev-verbose-flag-enable.test.ts
@@ -2,10 +2,11 @@ import { expect, test } from "bun:test"
 import Debug from "debug"
 import { enableDevVerboseLoggingForTest } from "cli/dev/register"
 
-const getDebugNamespaces = () => (process.env.DEBUG ?? "")
-  .split(/[\s,]+/)
-  .map((ns) => ns.trim())
-  .filter(Boolean)
+const getDebugNamespaces = () =>
+  (process.env.DEBUG ?? "")
+    .split(/[\s,]+/)
+    .map((ns) => ns.trim())
+    .filter(Boolean)
 
 test("verbose helper enables tscircuit devserver namespace", () => {
   const originalEnv = process.env.DEBUG


### PR DESCRIPTION
This pull request enhances the development server CLI by improving port selection logic, adding a verbose logging option, and introducing comprehensive tests for these new features. The main improvements are the implementation of a robust port-finding mechanism with timeout and verbose feedback, and the ability to enable detailed debug logging via a command-line flag.

https://linear.app/tscircuit/issue/TSC-403/add-verbose-debug-logging-and-timeoutretry-for-port-acquisition-for

**Development server improvements:**

* Added a new `findAvailablePort` function to automatically search for an open port starting from a preferred value, with a configurable timeout and optional verbose output. This prevents startup failures when the default port is occupied and provides user feedback during the search.
* Introduced a `--verbose` (`-v`) flag to the `dev` command, which enables detailed debug logging for the development server using the `debug` package.
* Implemented the `enableDevVerboseLogging` helper to manage the debug namespace, ensuring it is appended without duplication and properly set in the environment.

**Testing enhancements:**

* Added tests for the port-finding logic, including successful port resolution and timeout scenarios, to ensure reliability and correct error handling. (`tests/cli/dev/dev-port-timeout-success.test.ts`, `tests/cli/dev/dev-port-timeout-timeout.test.ts`) [[1]](diffhunk://#diff-3e7a6306776e481d00b9f583cd02ce52b4a9387956789e72f73b0c585e220fd1R1-R15) [[2]](diffhunk://#diff-ea637c9592bd3ce72216d3428d8c8087f3fc2f29e679dfd492dce89d9d4cea70R1-R32)
* Added tests for the verbose logging helper to verify that the debug namespace is enabled and appended correctly without duplicates. (`tests/cli/dev/dev-verbose-flag-enable.test.ts`, `tests/cli/dev/dev-verbose-flag-append.test.ts`) [[1]](diffhunk://#diff-1b9b796783e3e92de905845f266314b58fd6a831c499b1329d8cc9e77ed3c9bdR1-R27) [[2]](diffhunk://#diff-28957bd99c7f5f09b60c9d74b710fa998c3adec9c2ad86882e3281317817f0eeR1-R27)