### PR TITLE
feat(build): support --inject-props and --inject-props-file in tsci build

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -23,6 +23,8 @@ export interface BuildCommandOptions {
   profile?: boolean
   useCdnJavascript?: boolean
   concurrency?: string
+  injectProps?: string
+  injectPropsFile?: string
 }
 
 const runCommand = (command: string, cwd: string) => {

--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -22,6 +22,7 @@ export const buildFile = async (
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
     platformConfig?: PlatformConfig
+    injectedProps?: Record<string, unknown>
   },
 ): Promise<BuildFileOutcome> => {
   try {
@@ -47,6 +48,7 @@ export const buildFile = async (
       const result = await generateCircuitJson({
         filePath: input,
         platformConfig: completePlatformConfig,
+        injectedProps: options?.injectedProps,
       })
       circuitJson = result.circuitJson
     }

--- a/cli/build/build-worker-entrypoint.ts
+++ b/cli/build/build-worker-entrypoint.ts
@@ -71,6 +71,7 @@ const handleBuildFile = async (
     ignoreWarnings?: boolean
     platformConfig?: unknown
     profile?: boolean
+    injectedProps?: Record<string, unknown>
   },
 ): Promise<BuildCompletedMessage> => {
   const errors: string[] = []
@@ -106,6 +107,7 @@ const handleBuildFile = async (
       : await generateCircuitJson({
           filePath,
           platformConfig: completePlatformConfig,
+          injectedProps: options?.injectedProps,
         })
 
     // Write circuit JSON to disk (not sent through IPC to avoid memory issues)

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -37,6 +37,50 @@ import runFrameStandaloneBundleContent from "@tscircuit/runframe/standalone" wit
 const normalizeRelativePath = (projectDir: string, targetPath: string) =>
   path.relative(projectDir, targetPath).split(path.sep).join("/")
 
+const parseInjectedProps = ({
+  injectProps,
+  injectPropsFile,
+  projectDir,
+}: {
+  injectProps?: string
+  injectPropsFile?: string
+  projectDir: string
+}): Record<string, unknown> | undefined => {
+  if (injectProps && injectPropsFile) {
+    throw new Error(
+      "Cannot use --inject-props and --inject-props-file together",
+    )
+  }
+
+  const rawProps = (() => {
+    if (injectPropsFile) {
+      const resolvedPropsPath = path.resolve(projectDir, injectPropsFile)
+      return fs.readFileSync(resolvedPropsPath, "utf-8")
+    }
+
+    return injectProps
+  })()
+
+  if (!rawProps) {
+    return undefined
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(rawProps)
+  } catch (error) {
+    throw new Error(
+      `Failed to parse injected props JSON: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Injected props must be a JSON object")
+  }
+
+  return parsed as Record<string, unknown>
+}
+
 const getOutputDirName = (relativePath: string) => {
   const normalizedRelativePath = relativePath
     .toLowerCase()
@@ -105,6 +149,14 @@ export const registerBuild = (program: Command) => {
       "--concurrency <number>",
       "Number of files to build in parallel (default: 1)",
       "1",
+    )
+    .option(
+      "--inject-props <json>",
+      "Inject JSON props into the built file's default export",
+    )
+    .option(
+      "--inject-props-file <path>",
+      "Inject JSON props from a file into the built file's default export",
     )
     .action(async (file?: string, options?: BuildCommandOptions) => {
       try {
@@ -224,12 +276,19 @@ export const registerBuild = (program: Command) => {
         const shouldGenerateKicadProject =
           resolvedOptions?.kicadProject || resolvedOptions?.kicadLibrary
 
+        const injectedProps = parseInjectedProps({
+          injectProps: resolvedOptions?.injectProps,
+          injectPropsFile: resolvedOptions?.injectPropsFile,
+          projectDir,
+        })
+
         // Prepare build options for reuse
         const buildOptions = {
           ignoreErrors: resolvedOptions?.ignoreErrors,
           ignoreWarnings: resolvedOptions?.ignoreWarnings,
           platformConfig,
           profile: resolvedOptions?.profile,
+          injectedProps,
         }
 
         // Helper function to process a single build result

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -22,6 +22,7 @@ export type BuildJob = {
     ignoreWarnings?: boolean
     platformConfig?: PlatformConfig
     profile?: boolean
+    injectedProps?: Record<string, unknown>
   }
 }
 
@@ -333,6 +334,7 @@ export async function buildFilesWithWorkerPool(options: {
     ignoreWarnings?: boolean
     platformConfig?: PlatformConfig
     profile?: boolean
+    injectedProps?: Record<string, unknown>
   }
   onLog?: (lines: string[]) => void
   onJobComplete?: (result: BuildJobResult) => void

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -13,6 +13,7 @@ export type BuildFileMessage = {
     ignoreWarnings?: boolean
     platformConfig?: PlatformConfig
     profile?: boolean
+    injectedProps?: Record<string, unknown>
   }
 }
 

--- a/lib/shared/generate-circuit-json.tsx
+++ b/lib/shared/generate-circuit-json.tsx
@@ -27,6 +27,7 @@ type GenerateCircuitJsonOptions = {
   outputFileName?: string
   saveToFile?: boolean
   platformConfig?: PlatformConfig
+  injectedProps?: Record<string, unknown>
 }
 
 /**
@@ -41,6 +42,7 @@ export async function generateCircuitJson({
   outputFileName,
   saveToFile = false,
   platformConfig,
+  injectedProps,
 }: GenerateCircuitJsonOptions) {
   debug(`Generating circuit JSON for ${filePath}`)
 
@@ -120,7 +122,7 @@ export async function generateCircuitJson({
     )
   }
 
-  runner.add(<Component />)
+  runner.add(<Component {...(injectedProps ?? {})} />)
 
   // Wait for the circuit to be fully rendered
   await runner.renderUntilSettled()

--- a/tests/cli/build/build-inject-props.test.ts
+++ b/tests/cli/build/build-inject-props.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { expect, test } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const componentFile = `
+export default ({
+  resistorName = "R1",
+}: {
+  resistorName?: string
+}) => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name={resistorName} schX={3} pcbX={3} />
+  </board>
+)
+`
+
+test("build --inject-props injects props into default export", async () => {
+  const { runCommand, tmpDir } = await getCliTestFixture()
+  const filePath = path.join(tmpDir, "with-props.circuit.tsx")
+
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(filePath, componentFile)
+
+  const { exitCode } = await runCommand(
+    'tsci build --inject-props {"resistorName":"R9"} with-props.circuit.tsx',
+  )
+
+  expect(exitCode).toBe(0)
+
+  const outputPath = path.join(tmpDir, "dist", "with-props", "circuit.json")
+  const circuitJson = JSON.parse(await readFile(outputPath, "utf-8"))
+  const sourceComponent = circuitJson.find(
+    (el: any) => el.type === "source_component",
+  )
+
+  expect(sourceComponent?.name).toBe("R9")
+}, 30_000)
+
+test("build --inject-props-file injects props from file", async () => {
+  const { runCommand, tmpDir } = await getCliTestFixture()
+  const filePath = path.join(tmpDir, "with-props-file.circuit.tsx")
+  const configDir = path.join(tmpDir, "config")
+
+  await mkdir(configDir, { recursive: true })
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(filePath, componentFile)
+  await writeFile(
+    path.join(configDir, "props.json"),
+    JSON.stringify({ resistorName: "R10" }),
+  )
+
+  const { exitCode } = await runCommand(
+    "tsci build --inject-props-file ./config/props.json with-props-file.circuit.tsx",
+  )
+
+  expect(exitCode).toBe(0)
+
+  const outputPath = path.join(
+    tmpDir,
+    "dist",
+    "with-props-file",
+    "circuit.json",
+  )
+  const circuitJson = JSON.parse(await readFile(outputPath, "utf-8"))
+  const sourceComponent = circuitJson.find(
+    (el: any) => el.type === "source_component",
+  )
+
+  expect(sourceComponent?.name).toBe("R10")
+}, 30_000)


### PR DESCRIPTION
### Motivation
- Enable callers of `tsci build` to inject a JSON props object into the default export of a component at build-time, a common need when adjusting behavior like autorouting without editing source files.

### Description
- Add CLI options `--inject-props <json>` and `--inject-props-file <path>` and parsing/validation logic that ensures the injected value is a JSON object and prevents using both flags together via `parseInjectedProps` in `cli/build/register.ts`.
- Thread the parsed `injectedProps` through build machinery (sequential and worker paths) by extending `BuildCommandOptions`, `BuildJob` options, worker message types, and the worker pool so both single-threaded and concurrent builds receive the props (`cli/build/build-ci.ts`, `cli/build/register.ts`, `cli/build/worker-types.ts`, `cli/build/worker-pool.ts`, `cli/build/build-worker-entrypoint.ts`).
- Apply injected props when rendering the component during circuit generation by passing `injectedProps` into `generateCircuitJson` and rendering as `<Component {...(injectedProps ?? {})} />` (`lib/shared/generate-circuit-json.tsx`), and ensure `buildFile` forwards the option (`cli/build/build-file.ts`).
- Add integration tests that exercise both inline JSON and file-based injection and assert the produced `circuit.json` reflects the injected props (`tests/cli/build/build-inject-props.test.ts`).

### Testing
- Ran `bun test tests/cli/build/build-inject-props.test.ts` and the two new tests passed (2 passed, 0 failed).
- Ran TypeScript checking with `bunx tsc --noEmit` which succeeded with no errors.
- Ran code formatting with `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a89be730dc832eb7fd1d958be05165)