### PR TITLE
Add libraryEntrypoint support to tscircuit config

### DIFF
--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 
 export const projectConfigSchema = z.object({
   mainEntrypoint: z.string().optional(),
+  libraryEntrypoint: z.string().optional(),
   previewComponentPath: z.string().optional(),
   siteDefaultComponentPath: z.string().optional(),
   ignoredFiles: z.array(z.string()).optional(),

--- a/lib/shared/get-entrypoint.ts
+++ b/lib/shared/get-entrypoint.ts
@@ -127,12 +127,11 @@ export const getEntrypoint = async ({
     }
 
     const projectConfig = loadProjectConfig(validatedProjectDir)
-    if (
-      projectConfig?.mainEntrypoint &&
-      typeof projectConfig.mainEntrypoint === "string"
-    ) {
+    const configEntrypoint =
+      projectConfig?.mainEntrypoint ?? projectConfig?.libraryEntrypoint
+    if (configEntrypoint && typeof configEntrypoint === "string") {
       const validatedConfigPath = validateFilePath(
-        projectConfig.mainEntrypoint,
+        configEntrypoint,
         validatedProjectDir,
       )
       if (validatedConfigPath) {

--- a/tests/get-entrypoint.test.ts
+++ b/tests/get-entrypoint.test.ts
@@ -50,6 +50,54 @@ test("getEntrypoint detects entrypoint from config", async () => {
   expect(entrypoint).toBe(path.join(tmpDir, "src", "main.circuit.tsx"))
 })
 
+test("getEntrypoint detects entrypoint from libraryEntrypoint config alias", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  await fs.mkdir(path.join(tmpDir, "src"))
+  await fs.writeFile(
+    path.join(tmpDir, "src", "library.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ libraryEntrypoint: "src/library.tsx" }),
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "src", "library.tsx"))
+})
+
+test("getEntrypoint prioritizes mainEntrypoint over libraryEntrypoint", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  await fs.mkdir(path.join(tmpDir, "src"))
+  await fs.writeFile(
+    path.join(tmpDir, "src", "main.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "src", "library.tsx"),
+    'export default () => <board width="11mm" height="11mm"></board>',
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({
+      mainEntrypoint: "src/main.tsx",
+      libraryEntrypoint: "src/library.tsx",
+    }),
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "src", "main.tsx"))
+})
 test("getEntrypoint detects entrypoint in common locations", async () => {
   const { tmpDir } = await getCliTestFixture()
 

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -14,6 +14,10 @@
       "type": "string",
       "description": "Entry file for the circuit project."
     },
+    "libraryEntrypoint": {
+      "type": "string",
+      "description": "Alias for mainEntrypoint used as the TypeScript library entry file."
+    },
     "previewComponentPath": {
       "type": "string",
       "description": "Optional component path used for previews."


### PR DESCRIPTION
### Motivation
- Provide a dedicated `libraryEntrypoint` configuration key so projects can specify a TypeScript library entry file as an alias for `mainEntrypoint`.
- Preserve existing behavior and precedence so `mainEntrypoint` continues to take priority when both are present.

### Description
- Add `libraryEntrypoint` to the runtime Zod project config schema in `lib/project-config/project-config-schema.ts` as an optional `string` field.
- Add `libraryEntrypoint` to the published JSON schema `types/tscircuit.config.schema.json` with a brief description for editor/schema validation.
- Update entrypoint resolution in `lib/shared/get-entrypoint.ts` to use `projectConfig?.mainEntrypoint ?? projectConfig?.libraryEntrypoint` as the configured entrypoint fallback.
- Add tests in `tests/get-entrypoint.test.ts` to assert resolution from `libraryEntrypoint` and that `mainEntrypoint` is preferred when both are defined.

### Testing
- Ran `bun test tests/get-entrypoint.test.ts` and all tests passed (21 pass, 0 fail).
- Ran a typecheck with `bunx tsc --noEmit` which completed successfully with no errors.
- Ran `bun run format` to apply formatting, which updated files as needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9cfe79048832ea368f6cc1c2a5a22)