### PR TITLE
Improve tsci init defaults and generated output paths

### DIFF
--- a/cli/init/register.ts
+++ b/cli/init/register.ts
@@ -40,6 +40,7 @@ export const registerInit = (program: Command) => {
             name: "continueInCurrentDirectory",
             message:
               "Do you want to initialize a new project in the current directory?",
+            initial: true,
           })
           if (!continueInCurrentDirectory) {
             const { desiredDirectory } = await prompts({

--- a/lib/shared/setup-tscircuit-skill.ts
+++ b/lib/shared/setup-tscircuit-skill.ts
@@ -12,7 +12,10 @@ interface GitHubContent {
 
 const SKILL_REPO_API_URL =
   "https://api.github.com/repos/tscircuit/skill/contents"
-const SKILL_DIR_NAME = ".claude/skills/tscircuit"
+const SKILL_INSTALL_PATHS = [
+  ".claude/skills/tscircuit",
+  ".codex/skills/tscircuit",
+]
 
 async function fetchGitHubContents(apiUrl: string): Promise<GitHubContent[]> {
   const response = await fetch(apiUrl)
@@ -75,10 +78,12 @@ export async function setupTscircuitSkill(
   projectDir: string,
   skipPrompt = false,
 ): Promise<boolean> {
-  const skillDir = path.join(projectDir, SKILL_DIR_NAME)
+  const missingSkillPaths = SKILL_INSTALL_PATHS.filter(
+    (skillPath) => !fs.existsSync(path.join(projectDir, skillPath, "SKILL.md")),
+  )
 
-  if (fs.existsSync(path.join(skillDir, "SKILL.md"))) {
-    console.log("Claude skill already exists, skipping...")
+  if (missingSkillPaths.length === 0) {
+    console.log("TSCircuit AI skills already exist, skipping...")
     return true
   }
 
@@ -87,7 +92,7 @@ export async function setupTscircuitSkill(
       type: "confirm",
       name: "setupSkill",
       message:
-        "Would you like to set up tscircuit AI skill for enhanced AI assistance?",
+        "Would you like to set up tscircuit AI skills for enhanced AI assistance?",
       initial: true,
     })
 
@@ -97,11 +102,14 @@ export async function setupTscircuitSkill(
     }
   }
 
-  console.info("Setting up tscircuit skill...")
+  console.info("Setting up tscircuit AI skills...")
 
   try {
-    await downloadSkillRepo(skillDir)
-    console.info(`tscircuit skill installed at ${SKILL_DIR_NAME}`)
+    for (const skillPath of missingSkillPaths) {
+      const targetDir = path.join(projectDir, skillPath)
+      await downloadSkillRepo(targetDir)
+      console.info(`tscircuit skill installed at ${skillPath}`)
+    }
     return true
   } catch (error) {
     const errorMessage =

--- a/lib/shared/write-file-if-not-exists.ts
+++ b/lib/shared/write-file-if-not-exists.ts
@@ -1,11 +1,16 @@
 import fs from "fs"
+import path from "node:path"
 import kleur from "kleur"
 
 export const writeFileIfNotExists = (filePath: string, content: string) => {
   if (!fs.existsSync(filePath)) {
     fs.writeFileSync(filePath, content.trimStart(), "utf-8")
-    console.info(kleur.dim(`Created: ${kleur.gray(filePath)}`))
+    const relativeFilePath = path.relative(process.cwd(), filePath) || filePath
+    console.info(kleur.dim(`Created: ${kleur.gray(relativeFilePath)}`))
   } else {
-    console.info(kleur.dim(`Skipped: ${kleur.gray(filePath)} already exists`))
+    const relativeFilePath = path.relative(process.cwd(), filePath) || filePath
+    console.info(
+      kleur.dim(`Skipped: ${kleur.gray(relativeFilePath)} already exists`),
+    )
   }
 }

--- a/tests/cli/init/init-no-install.test.ts
+++ b/tests/cli/init/init-no-install.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { join } from "node:path"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
 test("init --no-install creates project without installing dependencies", async () => {
@@ -7,7 +8,7 @@ test("init --no-install creates project without installing dependencies", async 
   const projectDir = "test-project"
   const { stdout } = await runCommand(`tsci init ${projectDir} -y --no-install`)
   expect(stdout).not.toContain("Installing dependencies")
-})
+}, 30_000)
 
 test("init --no-install creates project installing dependencies", async () => {
   const { runCommand } = await getCliTestFixture()
@@ -15,4 +16,31 @@ test("init --no-install creates project installing dependencies", async () => {
   const projectDir = "test-project"
   const { stdout } = await runCommand(`tsci init ${projectDir} -y`)
   expect(stdout).toContain("Installing dependencies")
-})
+}, 30_000)
+
+test("init output uses relative paths for created files", async () => {
+  const { runCommand } = await getCliTestFixture()
+
+  const projectDir = "relative-path-project"
+  const { stdout } = await runCommand(`tsci init ${projectDir} -y --no-install`)
+
+  expect(stdout).toContain(`Created: ${projectDir}/index.circuit.tsx`)
+  expect(stdout).toContain(`Created: ${projectDir}/package.json`)
+}, 30_000)
+
+test("init installs tscircuit skills for both Claude and Codex", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  const projectDir = "skills-project"
+  await runCommand(`tsci init ${projectDir} -y --no-install`)
+
+  const claudeSkillExists = await Bun.file(
+    join(tmpDir, projectDir, ".claude/skills/tscircuit/SKILL.md"),
+  ).exists()
+  const codexSkillExists = await Bun.file(
+    join(tmpDir, projectDir, ".codex/skills/tscircuit/SKILL.md"),
+  ).exists()
+
+  expect(claudeSkillExists).toBeTrue()
+  expect(codexSkillExists).toBeTrue()
+}, 30_000)


### PR DESCRIPTION
### Motivation

- Make project initialization less surprising by defaulting the current-directory confirmation to `Yes` and improve readability of created/skipped file messages by showing relative paths.
- Ensure AI skill setup covers both assistant ecosystems by installing the TSCircuit skill under both `.claude` and `.codex` so users get consistent AI assistance.

### Description

- Set the init prompt default to `true` for `continueInCurrentDirectory` in `cli/init/register.ts` so the confirmation now defaults to Yes.  
- Change `writeFileIfNotExists` in `lib/shared/write-file-if-not-exists.ts` to log created/skipped file paths relative to `process.cwd()` instead of absolute paths.  
- Expand `setupTscircuitSkill` in `lib/shared/setup-tscircuit-skill.ts` to install the skill into both `.claude/skills/tscircuit` and `.codex/skills/tscircuit`, only installing missing paths and updating messages to refer to plural "skills."  
- Add and update `tests/cli/init/init-no-install.test.ts` to assert relative path output, to verify both Claude and Codex skill installs, and increase timeouts on init tests to reduce flakiness.

### Testing

- Ran `bun test tests/cli/init` which completed with all tests passing.  
- Ran `bunx tsc --noEmit` for type-checking which completed successfully.  
- Ran `bun run format` which formatted files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa334e6aa8832ea7097caf3f505cfd)