### PR TITLE
Implement `tsci check netlist` with readable netlist output

### DIFF
--- a/cli/check/netlist/register.ts
+++ b/cli/check/netlist/register.ts
@@ -1,12 +1,73 @@
+import { convertCircuitJsonToReadableNetlist } from "circuit-json-to-readable-netlist"
+import type { PlatformConfig } from "@tscircuit/props"
+import type { AnyCircuitElement } from "circuit-json"
 import type { Command } from "commander"
+import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getCompletePlatformConfig } from "lib/shared/get-complete-platform-config"
+import { getEntrypoint } from "lib/shared/get-entrypoint"
+import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
+import path from "node:path"
+
+const resolveInputFilePath = async (file?: string) => {
+  if (file) {
+    return path.isAbsolute(file) ? file : path.resolve(process.cwd(), file)
+  }
+
+  const entrypoint = await getEntrypoint({
+    projectDir: process.cwd(),
+  })
+
+  if (!entrypoint) {
+    throw new Error("No input file provided and no entrypoint found")
+  }
+
+  return entrypoint
+}
+
+export const checkNetlist = async (file?: string) => {
+  const resolvedInputFilePath = await resolveInputFilePath(file)
+
+  const completePlatformConfig = getCompletePlatformConfig({
+    routingDrcChecksDisabled: true,
+    placementDrcChecksDisabled: true,
+  } satisfies PlatformConfig)
+
+  const { circuitJson } = await generateCircuitJson({
+    filePath: resolvedInputFilePath,
+    platformConfig: completePlatformConfig,
+  })
+
+  const typedCircuitJson = circuitJson as AnyCircuitElement[]
+  const diagnostics = analyzeCircuitJson(typedCircuitJson)
+  const readableNetlist = convertCircuitJsonToReadableNetlist(typedCircuitJson)
+
+  const diagnosticsLines = [
+    `Errors: ${diagnostics.errors.length}`,
+    `Warnings: ${diagnostics.warnings.length}`,
+  ]
+
+  if (diagnostics.errors.length > 0) {
+    diagnosticsLines.push(
+      ...diagnostics.errors.map((err) => `- ${err.type}: ${err.message ?? ""}`),
+    )
+  }
+
+  return `${diagnosticsLines.join("\n")}\n\nReadable Netlist:\n${readableNetlist}`
+}
 
 export const registerCheckNetlist = (program: Command) => {
   program.commands
     .find((c) => c.name() === "check")!
     .command("netlist")
     .description("Partially build and validate the netlist")
-    .argument("[refdeses]", "Optional refdeses to scope the check")
-    .action(() => {
-      throw new Error("Not implemented")
+    .argument("[file]", "Path to the entry file")
+    .action(async (file?: string) => {
+      try {
+        const output = await checkNetlist(file)
+        console.log(output)
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exit(1)
+      }
     })
 }

--- a/tests/cli/check/check-netlist.test.ts
+++ b/tests/cli/check/check-netlist.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import { writeFile } from "node:fs/promises"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const circuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor
+      resistance="1k"
+      footprint="0402"
+      name="R1"
+      schX={3}
+      pcbX={3}
+    />
+    <capacitor
+      capacitance="1000pF"
+      footprint="0402"
+      name="C1"
+      schX={-3}
+      pcbX={-3}
+    />
+    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+  </board>
+)
+`
+
+test("check netlist includes readable netlist output", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "test-circuit.tsx")
+
+  await writeFile(circuitPath, circuitCode)
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci check netlist ${circuitPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("Errors: 0")
+  expect(stdout).toMatch(/Warnings: \d+/)
+  expect(stdout).toContain("Readable Netlist:")
+  expect(stdout).toContain("COMPONENTS:")
+  expect(stdout).toContain("R1")
+  expect(stdout).toContain("C1")
+  expect(stdout).toContain("NET: C1_pos")
+}, 20_000)


### PR DESCRIPTION
### Motivation
- Provide a `tsci check netlist` command that produces a human-readable netlist alongside basic diagnostics for quicker verification of generated circuits.
- Ensure DRC checks from autorouter/placement are disabled during this partial build so netlist extraction is not blocked by routing/placement DRCs.

### Description
- Implemented the `checkNetlist` flow in `cli/check/netlist/register.ts` which resolves an input file (or falls back to the project entrypoint) and generates circuit JSON via `generateCircuitJson`.
- Disable DRC checks by passing `routingDrcChecksDisabled: true` and `placementDrcChecksDisabled: true` into `getCompletePlatformConfig` when generating the circuit JSON.
- Convert the generated circuit JSON to a readable netlist using `convertCircuitJsonToReadableNetlist` and include a diagnostics summary (`Errors:` / `Warnings:`) in the command output.
- Added an integration test `tests/cli/check/check-netlist.test.ts` that actually runs the CLI (`tsci check netlist <file>`) and asserts the diagnostics and readable netlist content appear in `stdout`.

### Testing
- Ran the new integration test with `bun test tests/cli/check/check-netlist.test.ts`, which passed.
- Type-checked the project with `bunx tsc --noEmit`, which succeeded.
- Formatted the repository with `bun run format` after changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab58585e00832e8e8caa506bbff7d5)