### PR TITLE
cli(search): add --json output to search command and test unified results

### DIFF
--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -14,6 +14,7 @@ export const registerSearch = (program: Command) => {
     .option("--jlcpcb", "Search JLCPCB components")
     .option("--lcsc", "Alias for --jlcpcb")
     .option("--tscircuit", "Search tscircuit registry packages")
+    .option("--json", "Output search results as JSON")
     .action(
       async (
         query: string,
@@ -22,6 +23,7 @@ export const registerSearch = (program: Command) => {
           jlcpcb?: boolean
           lcsc?: boolean
           tscircuit?: boolean
+          json?: boolean
         },
       ) => {
         const hasFilters =
@@ -84,6 +86,35 @@ export const registerSearch = (program: Command) => {
             error instanceof Error ? error.message : error,
           )
           process.exit(1)
+        }
+
+        if (opts.json) {
+          const unifiedResults = [
+            ...kicadResults.map((path) => ({
+              source: "kicad" as const,
+              path,
+            })),
+            ...results.packages.map((pkg) => ({
+              source: "tscircuit" as const,
+              ...pkg,
+            })),
+            ...jlcResults.map((comp) => ({
+              source: "jlcpcb" as const,
+              ...comp,
+            })),
+          ]
+
+          console.log(
+            JSON.stringify(
+              {
+                query,
+                results: unifiedResults,
+              },
+              null,
+              2,
+            ),
+          )
+          return
         }
 
         if (

--- a/tests/cli/search/search-json.test.ts
+++ b/tests/cli/search/search-json.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("search --json outputs valid json with unified result list", async () => {
+  const { runCommand } = await getCliTestFixture()
+  const { stdout, stderr, exitCode } = await runCommand(
+    "tsci search --tscircuit --json 555",
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+
+  const parsed = JSON.parse(stdout)
+  expect(parsed.query).toBe("555")
+  expect(Array.isArray(parsed.results)).toBe(true)
+  expect(parsed.results.length).toBeGreaterThan(0)
+  expect(parsed.results[0].source).toBe("tscircuit")
+  expect(parsed.results[0].name).toBeString()
+  expect(parsed.results[0].result).toBeUndefined()
+})


### PR DESCRIPTION
### Motivation

- Provide a machine-readable output for the `search` CLI so callers can consume unified results programmatically.
- Allow combining results from KiCad, JLCPCB, and tscircuit registry into a single structured response.

### Description

- Add a `--json` option to the `search` command in `cli/search/register.ts` and include `json?: boolean` in the action options.
- When `--json` is passed the command builds a unified `results` array that tags entries with `source` and includes KiCad paths, tscircuit packages, and JLCPCB components, then prints a JSON object with `query` and `results` and exits early.
- Preserve existing human-readable output when `--json` is not provided and keep existing search behavior and error handling intact.
- Add a new automated test `tests/cli/search/search-json.test.ts` that exercises the `--json` output using the CLI test fixture.

### Testing

- Ran the new test `tests/cli/search/search-json.test.ts` with `bun test` which verifies the CLI returns exit code `0`, produces valid JSON, includes the `query` and a non-empty `results` array, and asserts the first result is from `tscircuit`, and the test passed.
- No other tests were modified or added in this PR and existing behavior was left unchanged when `--json` is not used.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab726cc690832ea67bac7bf2d118cd)