### PR TITLE
Add --ignore-drc option to suppress PCB DRC issues and report ignored counts

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -6,6 +6,7 @@ import { installProjectDependencies } from "lib/shared/install-project-dependenc
 export interface BuildCommandOptions {
   ignoreErrors?: boolean
   ignoreWarnings?: boolean
+  ignoreDrc?: boolean
   disablePcb?: boolean
   disablePartsEngine?: boolean
   ignoreConfig?: boolean

--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -4,6 +4,7 @@ import type { PlatformConfig } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import kleur from "kleur"
 import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
+import { isDrcIssue } from "lib/shared/drc-diagnostics"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { getCompletePlatformConfig } from "lib/shared/get-complete-platform-config"
 
@@ -11,6 +12,8 @@ export type BuildFileOutcome = {
   ok: boolean
   circuitJson?: AnyCircuitElement[]
   hasErrors?: boolean
+  ignoredDrcErrors?: number
+  ignoredDrcWarnings?: number
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
 }
@@ -22,6 +25,7 @@ export const buildFile = async (
   options?: {
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
+    ignoreDrc?: boolean
     platformConfig?: PlatformConfig
     injectedProps?: Record<string, unknown>
   },
@@ -59,16 +63,22 @@ export const buildFile = async (
     console.log(`Circuit JSON written to ${path.relative(projectDir, output)}`)
 
     const { errors, warnings } = analyzeCircuitJson(circuitJson)
+    const filteredErrors = options?.ignoreDrc
+      ? errors.filter((issue) => !isDrcIssue(issue))
+      : errors
+    const filteredWarnings = options?.ignoreDrc
+      ? warnings.filter((issue) => !isDrcIssue(issue))
+      : warnings
 
     if (!options?.ignoreWarnings) {
-      for (const warn of warnings) {
+      for (const warn of filteredWarnings) {
         const msg = warn.message || JSON.stringify(warn)
         console.log(kleur.yellow(msg))
       }
     }
 
     if (!options?.ignoreErrors) {
-      for (const err of errors) {
+      for (const err of filteredErrors) {
         const msg = err.message || JSON.stringify(err)
         console.error(kleur.red(msg))
         if (err.stack) {
@@ -80,7 +90,9 @@ export const buildFile = async (
     return {
       ok: true,
       circuitJson,
-      hasErrors: errors.length > 0 && !options?.ignoreErrors,
+      hasErrors: filteredErrors.length > 0 && !options?.ignoreErrors,
+      ignoredDrcErrors: errors.length - filteredErrors.length,
+      ignoredDrcWarnings: warnings.length - filteredWarnings.length,
     }
   } catch (err) {
     console.error(err)

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -109,6 +109,7 @@ export const registerBuild = (program: Command) => {
     )
     .option("--ignore-errors", "Do not exit with code 1 on errors")
     .option("--ignore-warnings", "Do not log warnings")
+    .option("--ignore-drc", "Ignore DRC check errors and warnings")
     .option("--ignore-config", "Ignore options from tscircuit.config.json")
     .option("--disable-pcb", "Disable PCB outputs")
     .option("--disable-parts-engine", "Disable the parts engine")
@@ -227,7 +228,8 @@ export const registerBuild = (program: Command) => {
         const platformConfig: PlatformConfig | undefined = (() => {
           if (
             !resolvedOptions?.disablePcb &&
-            !resolvedOptions?.disablePartsEngine
+            !resolvedOptions?.disablePartsEngine &&
+            !resolvedOptions?.ignoreDrc
           ) {
             return
           }
@@ -240,6 +242,12 @@ export const registerBuild = (program: Command) => {
 
           if (resolvedOptions?.disablePartsEngine) {
             config.partsEngineDisabled = true
+          }
+
+          if (resolvedOptions?.ignoreDrc) {
+            config.netlistDrcChecksDisabled = true
+            config.routingDrcChecksDisabled = true
+            config.placementDrcChecksDisabled = true
           }
 
           return config
@@ -264,6 +272,8 @@ export const registerBuild = (program: Command) => {
 
         let hasErrors = false
         let hasFatalErrors = false
+        let ignoredDrcErrorCount = 0
+        let ignoredDrcWarningCount = 0
         const staticFileReferences: StaticBuildFileReference[] = []
 
         const builtFiles: BuildFileResult[] = []
@@ -286,6 +296,7 @@ export const registerBuild = (program: Command) => {
         const buildOptions = {
           ignoreErrors: resolvedOptions?.ignoreErrors,
           ignoreWarnings: resolvedOptions?.ignoreWarnings,
+          ignoreDrc: resolvedOptions?.ignoreDrc,
           platformConfig,
           profile: resolvedOptions?.profile,
           injectedProps,
@@ -319,6 +330,8 @@ export const registerBuild = (program: Command) => {
             circuitJson?: unknown[]
             hasErrors?: boolean
             isFatalError?: { errorType: string; message: string }
+            ignoredDrcErrors?: number
+            ignoredDrcWarnings?: number
           },
         ) => {
           const relative = path.relative(projectDir, filePath)
@@ -329,6 +342,9 @@ export const registerBuild = (program: Command) => {
             outputPath,
             ok: buildOutcome.ok,
           })
+
+          ignoredDrcErrorCount += buildOutcome.ignoredDrcErrors ?? 0
+          ignoredDrcWarningCount += buildOutcome.ignoredDrcWarnings ?? 0
 
           if (buildOutcome.hasErrors) {
             hasErrors = true
@@ -507,6 +523,8 @@ export const registerBuild = (program: Command) => {
                 ok: result.ok,
                 hasErrors: result.hasErrors,
                 isFatalError: result.isFatalError,
+                ignoredDrcErrors: result.ignoredDrcErrors,
+                ignoredDrcWarnings: result.ignoredDrcWarnings,
               })
 
               if (resolvedOptions?.glbs && result.ok) {
@@ -794,6 +812,17 @@ export const registerBuild = (program: Command) => {
         console.log(
           `  Output    ${kleur.dim(path.relative(process.cwd(), distDir) || "dist")}`,
         )
+
+        if (
+          resolvedOptions?.ignoreDrc &&
+          (ignoredDrcErrorCount > 1 || ignoredDrcWarningCount > 1)
+        ) {
+          console.log(
+            kleur.gray(
+              `> Ignored ${ignoredDrcErrorCount} DRC check errors and ${ignoredDrcWarningCount} warnings`,
+            ),
+          )
+        }
         console.log(
           hasErrors
             ? kleur.yellow("\n⚠ Build completed with errors")

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import { analyzeCircuitJson } from "../../lib/shared/circuit-json-diagnostics"
+import { isDrcIssue } from "../../lib/shared/drc-diagnostics"
 import { generateCircuitJson } from "../../lib/shared/generate-circuit-json"
 import { getCompletePlatformConfig } from "../../lib/shared/get-complete-platform-config"
 import { registerStaticAssetLoaders } from "../../lib/shared/register-static-asset-loaders"
@@ -70,9 +71,15 @@ export const handleBuildFile = async (
     )
 
     const diagnostics = analyzeCircuitJson(circuitJson)
+    const filteredErrors = options?.ignoreDrc
+      ? diagnostics.errors.filter((issue) => !isDrcIssue(issue))
+      : diagnostics.errors
+    const filteredWarnings = options?.ignoreDrc
+      ? diagnostics.warnings.filter((issue) => !isDrcIssue(issue))
+      : diagnostics.warnings
 
     if (!options?.ignoreWarnings) {
-      for (const warn of diagnostics.warnings) {
+      for (const warn of filteredWarnings) {
         const msg = warn.message || JSON.stringify(warn)
         warnings.push(msg)
         workerLog(`Warning: ${msg}`)
@@ -80,14 +87,14 @@ export const handleBuildFile = async (
     }
 
     if (!options?.ignoreErrors) {
-      for (const err of diagnostics.errors) {
+      for (const err of filteredErrors) {
         const msg = err.message || JSON.stringify(err)
         errors.push(msg)
         workerLog(`Error: ${msg}`)
       }
     }
 
-    const hasErrors = diagnostics.errors.length > 0 && !options?.ignoreErrors
+    const hasErrors = filteredErrors.length > 0 && !options?.ignoreErrors
     let glbOk: boolean | undefined
     let glbError: string | undefined
     let previewOk: boolean | undefined
@@ -139,6 +146,8 @@ export const handleBuildFile = async (
       preview_error: previewError,
       ok: true,
       hasErrors,
+      ignoredDrcErrors: diagnostics.errors.length - filteredErrors.length,
+      ignoredDrcWarnings: diagnostics.warnings.length - filteredWarnings.length,
       errors,
       warnings,
       durationMs: options?.profile ? performance.now() - startedAt : undefined,

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -18,6 +18,7 @@ type BuildJob = {
   options?: {
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
+    ignoreDrc?: boolean
     platformConfig?: PlatformConfig
     profile?: boolean
     injectedProps?: Record<string, unknown>
@@ -58,6 +59,7 @@ export async function buildFilesWithWorkerPool(options: {
   buildOptions?: {
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
+    ignoreDrc?: boolean
     platformConfig?: PlatformConfig
     profile?: boolean
     injectedProps?: Record<string, unknown>
@@ -108,6 +110,8 @@ export async function buildFilesWithWorkerPool(options: {
         previewError: completedMessage.preview_error,
         ok: completedMessage.ok,
         hasErrors: completedMessage.hasErrors,
+        ignoredDrcErrors: completedMessage.ignoredDrcErrors,
+        ignoredDrcWarnings: completedMessage.ignoredDrcWarnings,
         isFatalError: completedMessage.isFatalError,
         errors: completedMessage.errors,
         warnings: completedMessage.warnings,

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -13,6 +13,7 @@ export type BuildFileMessage = {
   options?: {
     ignoreErrors?: boolean
     ignoreWarnings?: boolean
+    ignoreDrc?: boolean
     platformConfig?: PlatformConfig
     profile?: boolean
     injectedProps?: Record<string, unknown>
@@ -36,6 +37,8 @@ export type BuildCompletedMessage = {
   preview_error?: string
   ok: boolean
   hasErrors?: boolean
+  ignoredDrcErrors?: number
+  ignoredDrcWarnings?: number
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
   errors: string[]
@@ -75,6 +78,8 @@ export type BuildJobResult = {
   previewError?: string
   ok: boolean
   hasErrors?: boolean
+  ignoredDrcErrors?: number
+  ignoredDrcWarnings?: number
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
   errors: string[]

--- a/lib/shared/circuit-json-diagnostics.ts
+++ b/lib/shared/circuit-json-diagnostics.ts
@@ -14,12 +14,17 @@ export function analyzeCircuitJson(circuitJson: any[]): {
     if (!item || typeof item !== "object") continue
 
     const t = item.type
-    if (typeof t === "string") {
-      if (t.endsWith("_error")) errors.push(item)
-      else if (t.endsWith("_warning")) warnings.push(item)
+    const hasErrorByType = typeof t === "string" && t.endsWith("_error")
+    const hasErrorByKey = "error_type" in item
+    if (hasErrorByType || hasErrorByKey) {
+      errors.push(item)
     }
-    if ("error_type" in item) errors.push(item)
-    if ("warning_type" in item) warnings.push(item as CircuitJsonIssue)
+
+    const hasWarningByType = typeof t === "string" && t.endsWith("_warning")
+    const hasWarningByKey = "warning_type" in item
+    if (hasWarningByType || hasWarningByKey) {
+      warnings.push(item as CircuitJsonIssue)
+    }
   }
 
   return { errors, warnings }

--- a/lib/shared/drc-diagnostics.ts
+++ b/lib/shared/drc-diagnostics.ts
@@ -1,0 +1,29 @@
+import type { CircuitJsonIssue } from "./circuit-json-diagnostics"
+
+const DRC_SUFFIX_REGEX = /_(error|warning)$/
+
+const isDrcKey = (value: unknown): boolean => {
+  if (typeof value !== "string") {
+    return false
+  }
+
+  const normalizedValue = value.toLowerCase()
+
+  if (normalizedValue.includes("drc")) {
+    return true
+  }
+
+  if (
+    normalizedValue.startsWith("pcb_") &&
+    DRC_SUFFIX_REGEX.test(normalizedValue)
+  ) {
+    return true
+  }
+
+  return false
+}
+
+export const isDrcIssue = (issue: CircuitJsonIssue): boolean =>
+  isDrcKey(issue.type) ||
+  isDrcKey((issue as { error_type?: unknown }).error_type) ||
+  isDrcKey((issue as { warning_type?: unknown }).warning_type)

--- a/tests/cli/build/build-with-drc-error.test.ts
+++ b/tests/cli/build/build-with-drc-error.test.ts
@@ -10,6 +10,14 @@ export default () => (
   </board>
 )`
 
+const multiDrcErrorCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={8} />
+    <resistor resistance="2k" footprint="0402" name="R2" schX={4} pcbX={8} />
+  </board>
+)`
+
 test("build succeeds when circuit JSON is generated with DRC errors", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
@@ -30,4 +38,23 @@ test("build succeeds when circuit JSON is generated with DRC errors", async () =
 
   expect(exitCode).toBe(0)
   expect(stdout).toContain("Build completed with errors")
+}, 30_000)
+
+test("build --ignore-drc suppresses DRC errors and reports ignored counts", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await writeFile(
+    path.join(tmpDir, "test.circuit.tsx"),
+    multiDrcErrorCircuitCode,
+  )
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout, stderr } = await runCommand(
+    "tsci build --ignore-drc",
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stdout).toMatch(/> Ignored \d+ DRC check errors and \d+ warnings/)
+  expect(stdout).toContain("✓ Done")
+  expect(stderr).not.toContain("Component R1 extends outside board boundaries")
 }, 30_000)

--- a/tests/drc-diagnostics.test.ts
+++ b/tests/drc-diagnostics.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { isDrcIssue } from "lib/shared/drc-diagnostics"
+
+test("isDrcIssue detects pcb DRC errors and warnings", () => {
+  expect(
+    isDrcIssue({
+      type: "pcb_component_outside_board_error",
+      message: "outside board",
+    }),
+  ).toBe(true)
+
+  expect(
+    isDrcIssue({
+      type: "pcb_trace_too_close_warning",
+      message: "too close",
+    }),
+  ).toBe(true)
+})
+
+test("isDrcIssue ignores non-DRC issues", () => {
+  expect(
+    isDrcIssue({
+      type: "source_component_not_found_error",
+      message: "missing",
+    }),
+  ).toBe(false)
+})


### PR DESCRIPTION
### Motivation
- Provide a way to ignore PCB DRC (Design Rule Check) errors/warnings during builds so DRC issues do not fail or clutter builds when explicitly requested.
- Surface a summary count of ignored DRC items to inform users when DRC has been intentionally suppressed.

### Description
- Added a new CLI option `--ignore-drc` to the `build` command and threaded it through build options to workers via `BuildFileMessage` and `BuildJobResult` fields.
- Introduced `lib/shared/drc-diagnostics.ts` with `isDrcIssue` to detect DRC-related issues by `type`, `error_type`, or `warning_type` keys.
- Updated `analyzeCircuitJson` to also detect errors/warnings by `error_type`/`warning_type` keys in addition to `_error`/`_warning` suffixes.
- Filtered build diagnostics when `ignoreDrc` is enabled so DRC issues are not logged or counted as errors, and added `ignoredDrcErrors` / `ignoredDrcWarnings` counts to build results and worker messages.
- When `--ignore-drc` is used, the platform config injection disables netlist/routing/placement DRC checks via `PlatformConfig` flags, and the CLI prints a gray summary line reporting the number of ignored DRC errors and warnings.

### Testing
- Ran the new unit tests with `bun:test`: `tests/drc-diagnostics.test.ts` passed verifying `isDrcIssue` behavior.
- Ran the CLI integration tests with `bun:test`: `tests/cli/build/build-with-drc-error.test.ts` passed, including the new `build --ignore-drc` scenario which asserts suppressed DRC messages and the ignored-count summary.
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab72e38f7c832ebe63763407eaa458)