### PR TITLE
feat: distinguish exit codes for build errors vs warnings

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -11,6 +11,7 @@ export type BuildFileOutcome = {
   ok: boolean
   circuitJson?: AnyCircuitElement[]
   hasErrors?: boolean
+  hasWarnings?: boolean
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
 }
@@ -81,6 +82,7 @@ export const buildFile = async (
       ok: true,
       circuitJson,
       hasErrors: errors.length > 0 && !options?.ignoreErrors,
+      hasWarnings: warnings.length > 0 && !options?.ignoreWarnings,
     }
   } catch (err) {
     console.error(err)

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -263,6 +263,7 @@ export const registerBuild = (program: Command) => {
         }
 
         let hasErrors = false
+        let hasWarnings = false
         let hasFatalErrors = false
         const staticFileReferences: StaticBuildFileReference[] = []
 
@@ -318,6 +319,7 @@ export const registerBuild = (program: Command) => {
             ok: boolean
             circuitJson?: unknown[]
             hasErrors?: boolean
+            hasWarnings?: boolean
             isFatalError?: { errorType: string; message: string }
           },
         ) => {
@@ -332,6 +334,9 @@ export const registerBuild = (program: Command) => {
 
           if (buildOutcome.hasErrors) {
             hasErrors = true
+          }
+          if (buildOutcome.hasWarnings) {
+            hasWarnings = true
           }
 
           if (!buildOutcome.ok) {
@@ -506,6 +511,7 @@ export const registerBuild = (program: Command) => {
               await processBuildResult(result.filePath, result.outputPath, {
                 ok: result.ok,
                 hasErrors: result.hasErrors,
+                hasWarnings: result.hasWarnings,
                 isFatalError: result.isFatalError,
               })
 
@@ -797,10 +803,18 @@ export const registerBuild = (program: Command) => {
         console.log(
           hasErrors
             ? kleur.yellow("\n⚠ Build completed with errors")
-            : kleur.green("\n✓ Done"),
+            : hasWarnings
+              ? kleur.yellow("\n⚠ Build completed with warnings")
+              : kleur.green("\n✓ Done"),
         )
         if (shouldExitNonZero) {
           exitBuild(1, "fatal circuit build errors occurred")
+        }
+        if (hasErrors) {
+          exitBuild(1, "circuit build errors occurred")
+        }
+        if (hasWarnings) {
+          exitBuild(2, "circuit build warnings occurred")
         }
 
         exitBuild(0, "build finished successfully")

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -88,6 +88,8 @@ export const handleBuildFile = async (
     }
 
     const hasErrors = diagnostics.errors.length > 0 && !options?.ignoreErrors
+    const hasWarnings =
+      diagnostics.warnings.length > 0 && !options?.ignoreWarnings
     let glbOk: boolean | undefined
     let glbError: string | undefined
     let previewOk: boolean | undefined
@@ -139,6 +141,7 @@ export const handleBuildFile = async (
       preview_error: previewError,
       ok: true,
       hasErrors,
+      hasWarnings,
       errors,
       warnings,
       durationMs: options?.profile ? performance.now() - startedAt : undefined,

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -108,6 +108,7 @@ export async function buildFilesWithWorkerPool(options: {
         previewError: completedMessage.preview_error,
         ok: completedMessage.ok,
         hasErrors: completedMessage.hasErrors,
+        hasWarnings: completedMessage.hasWarnings,
         isFatalError: completedMessage.isFatalError,
         errors: completedMessage.errors,
         warnings: completedMessage.warnings,

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -36,6 +36,7 @@ export type BuildCompletedMessage = {
   preview_error?: string
   ok: boolean
   hasErrors?: boolean
+  hasWarnings?: boolean
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
   errors: string[]
@@ -75,6 +76,7 @@ export type BuildJobResult = {
   previewError?: string
   ok: boolean
   hasErrors?: boolean
+  hasWarnings?: boolean
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
   errors: string[]

--- a/tests/cli/build/build-exit-code-clean.test.ts
+++ b/tests/cli/build/build-exit-code-clean.test.ts
@@ -1,0 +1,29 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, mkdir } from "node:fs/promises"
+import path from "node:path"
+
+test("build exits with code 0 when circuit JSON has no errors or warnings", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  // Create a prebuilt circuit.json with no issues
+  const circuitDir = path.join(tmpDir, "examples")
+  await mkdir(circuitDir, { recursive: true })
+  const circuitJsonPath = path.join(circuitDir, "circuit.json")
+
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "R1",
+      ftype: "simple_resistor",
+    },
+  ]
+
+  await writeFile(circuitJsonPath, JSON.stringify(circuitJson, null, 2))
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout } = await runCommand(`tsci build ${circuitJsonPath}`)
+  expect(exitCode).toBe(0)
+  expect(stdout).toContain("Done")
+}, 30_000)

--- a/tests/cli/build/build-exit-code-errors.test.ts
+++ b/tests/cli/build/build-exit-code-errors.test.ts
@@ -1,0 +1,34 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, mkdir } from "node:fs/promises"
+import path from "node:path"
+
+test("build exits with code 1 when circuit JSON contains errors", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  // Create a prebuilt circuit.json with an error element
+  const circuitDir = path.join(tmpDir, "examples")
+  await mkdir(circuitDir, { recursive: true })
+  const circuitJsonPath = path.join(circuitDir, "circuit.json")
+
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "R1",
+      ftype: "simple_resistor",
+    },
+    {
+      type: "pcb_component_outside_board_error",
+      message: "Component R1 is outside board boundary",
+      error_type: "pcb_error",
+    },
+  ]
+
+  await writeFile(circuitJsonPath, JSON.stringify(circuitJson, null, 2))
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout } = await runCommand(`tsci build ${circuitJsonPath}`)
+  expect(exitCode).toBe(1)
+  expect(stdout).toContain("errors")
+}, 30_000)

--- a/tests/cli/build/build-exit-code-warnings.test.ts
+++ b/tests/cli/build/build-exit-code-warnings.test.ts
@@ -1,0 +1,34 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, mkdir } from "node:fs/promises"
+import path from "node:path"
+
+test("build exits with code 2 when circuit JSON contains warnings but no errors", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  // Create a prebuilt circuit.json with a warning element
+  const circuitDir = path.join(tmpDir, "examples")
+  await mkdir(circuitDir, { recursive: true })
+  const circuitJsonPath = path.join(circuitDir, "circuit.json")
+
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "R1",
+      ftype: "simple_resistor",
+    },
+    {
+      type: "pcb_placement_warning",
+      message: "Component R1 is close to board edge",
+      warning_type: "placement_warning",
+    },
+  ]
+
+  await writeFile(circuitJsonPath, JSON.stringify(circuitJson, null, 2))
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout } = await runCommand(`tsci build ${circuitJsonPath}`)
+  expect(exitCode).toBe(2)
+  expect(stdout).toContain("warnings")
+}, 30_000)

--- a/tests/lib/analyze-circuit-json.test.ts
+++ b/tests/lib/analyze-circuit-json.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test"
+import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
+
+test("analyzeCircuitJson categorizes warnings and errors correctly", () => {
+  const circuitJson = [
+    { type: "source_component", source_component_id: "sc1", name: "R1" },
+    { type: "pcb_placement_warning", message: "Too close to edge" },
+    { type: "pcb_component_outside_board_error", message: "Outside board" },
+    { type: "normal_element" },
+  ]
+
+  const { errors, warnings } = analyzeCircuitJson(circuitJson)
+
+  expect(warnings).toHaveLength(1)
+  expect(warnings[0].type).toBe("pcb_placement_warning")
+  expect(errors).toHaveLength(1)
+  expect(errors[0].type).toBe("pcb_component_outside_board_error")
+})

--- a/tests/lib/build-file-errors.test.ts
+++ b/tests/lib/build-file-errors.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { buildFile } from "cli/build/build-file"
+import { writeFile, mkdtemp } from "node:fs/promises"
+import path from "node:path"
+import os from "node:os"
+
+test("buildFile returns hasErrors when circuit JSON contains errors", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "build-test-"))
+  const inputPath = path.join(tmpDir, "circuit.json")
+  const outputPath = path.join(tmpDir, "dist", "circuit.json")
+
+  const circuitJson = [
+    { type: "source_component", source_component_id: "sc1", name: "R1" },
+    {
+      type: "pcb_component_outside_board_error",
+      message: "Component outside board",
+    },
+  ]
+
+  await writeFile(inputPath, JSON.stringify(circuitJson))
+
+  const result = await buildFile(inputPath, outputPath, tmpDir)
+
+  expect(result.ok).toBe(true)
+  expect(result.hasErrors).toBe(true)
+  expect(result.hasWarnings).toBe(false)
+})

--- a/tests/lib/build-file-warnings.test.ts
+++ b/tests/lib/build-file-warnings.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test"
+import { buildFile } from "cli/build/build-file"
+import { writeFile, mkdir, mkdtemp } from "node:fs/promises"
+import path from "node:path"
+import os from "node:os"
+
+test("buildFile returns hasWarnings when circuit JSON contains warnings", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "build-test-"))
+  const inputPath = path.join(tmpDir, "circuit.json")
+  const outputPath = path.join(tmpDir, "dist", "circuit.json")
+
+  const circuitJson = [
+    { type: "source_component", source_component_id: "sc1", name: "R1" },
+    { type: "pcb_placement_warning", message: "Too close to edge" },
+  ]
+
+  await writeFile(inputPath, JSON.stringify(circuitJson))
+
+  const result = await buildFile(inputPath, outputPath, tmpDir)
+
+  expect(result.ok).toBe(true)
+  expect(result.hasWarnings).toBe(true)
+  expect(result.hasErrors).toBe(false)
+})


### PR DESCRIPTION
## Summary

- Adds distinct exit codes to `tsci build` for agent automation and CI/CD:
  - **Exit 0**: Build succeeded with no issues
  - **Exit 1**: Build failed with errors (fatal generation failures or analysis errors)
  - **Exit 2**: Build succeeded but with warnings (recoverable, actionable)
- Tracks `hasWarnings` through the build pipeline (build-file, worker types, worker pool, register)
- Adds unit tests for `analyzeCircuitJson`, `buildFile` warning/error detection, and integration tests for exit code behavior

Closes #2292

## Test plan
- [x] Unit test: `analyzeCircuitJson` correctly categorizes warnings vs errors
- [x] Unit test: `buildFile` returns `hasWarnings: true` for circuit JSON with warnings
- [x] Unit test: `buildFile` returns `hasErrors: true` for circuit JSON with errors
- [ ] Integration test: build exits with code 0 for clean circuit JSON
- [ ] Integration test: build exits with code 1 for circuit JSON with errors
- [ ] Integration test: build exits with code 2 for circuit JSON with warnings
- [ ] Existing `--ignore-errors` test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)