### PR TITLE
feat: distinguish error and warning exit codes in tsci build

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -11,6 +11,7 @@ export type BuildFileOutcome = {
   ok: boolean
   circuitJson?: AnyCircuitElement[]
   hasErrors?: boolean
+  hasWarnings?: boolean
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
 }
@@ -77,10 +78,13 @@ export const buildFile = async (
       }
     }
 
+    const hasWarnings = warnings.length > 0 && !options?.ignoreWarnings
+
     return {
       ok: true,
       circuitJson,
       hasErrors: errors.length > 0 && !options?.ignoreErrors,
+      hasWarnings,
     }
   } catch (err) {
     console.error(err)

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -263,6 +263,7 @@ export const registerBuild = (program: Command) => {
         }
 
         let hasErrors = false
+        let hasWarnings = false
         let hasFatalErrors = false
         const staticFileReferences: StaticBuildFileReference[] = []
 
@@ -318,6 +319,7 @@ export const registerBuild = (program: Command) => {
             ok: boolean
             circuitJson?: unknown[]
             hasErrors?: boolean
+            hasWarnings?: boolean
             isFatalError?: { errorType: string; message: string }
           },
         ) => {
@@ -332,6 +334,9 @@ export const registerBuild = (program: Command) => {
 
           if (buildOutcome.hasErrors) {
             hasErrors = true
+          }
+          if (buildOutcome.hasWarnings) {
+            hasWarnings = true
           }
 
           if (!buildOutcome.ok) {
@@ -506,6 +511,7 @@ export const registerBuild = (program: Command) => {
               await processBuildResult(result.filePath, result.outputPath, {
                 ok: result.ok,
                 hasErrors: result.hasErrors,
+                hasWarnings: result.hasWarnings,
                 isFatalError: result.isFatalError,
               })
 
@@ -748,7 +754,14 @@ export const registerBuild = (program: Command) => {
         }
 
         // Fatal errors (e.g., circuit generation exceptions) always cause exit code 1.
-        const shouldExitNonZero = hasFatalErrors
+        // Non-fatal errors (circuit analysis errors) cause exit code 1 unless --ignore-errors.
+        // Warnings cause exit code 2 unless --ignore-warnings.
+        const shouldExitWithError =
+          hasFatalErrors || (hasErrors && !resolvedOptions?.ignoreErrors)
+        const shouldExitWithWarning =
+          !shouldExitWithError &&
+          hasWarnings &&
+          !resolvedOptions?.ignoreWarnings
 
         const successCount = builtFiles.filter((f) => f.ok).length
         const failCount = builtFiles.length - successCount
@@ -795,12 +808,17 @@ export const registerBuild = (program: Command) => {
           `  Output    ${kleur.dim(path.relative(process.cwd(), distDir) || "dist")}`,
         )
         console.log(
-          hasErrors
-            ? kleur.yellow("\n⚠ Build completed with errors")
-            : kleur.green("\n✓ Done"),
+          shouldExitWithError
+            ? kleur.red("\n✗ Build completed with errors")
+            : hasWarnings
+              ? kleur.yellow("\n⚠ Build completed with warnings")
+              : kleur.green("\n✓ Done"),
         )
-        if (shouldExitNonZero) {
-          exitBuild(1, "fatal circuit build errors occurred")
+        if (shouldExitWithError) {
+          exitBuild(1, "circuit build errors occurred")
+        }
+        if (shouldExitWithWarning) {
+          exitBuild(2, "circuit build warnings occurred")
         }
 
         exitBuild(0, "build finished successfully")

--- a/cli/build/utils/exit-build.ts
+++ b/cli/build/utils/exit-build.ts
@@ -2,7 +2,7 @@ import kleur from "kleur"
 
 export const exitBuild = (code: number, reason: string): never => {
   const message = `Build exiting with code ${code}: ${reason}`
-  if (code === 0) {
+  if (code === 0 || code === 2) {
     console.log(kleur.dim(message))
   } else {
     console.error(kleur.yellow(message))

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -88,6 +88,8 @@ export const handleBuildFile = async (
     }
 
     const hasErrors = diagnostics.errors.length > 0 && !options?.ignoreErrors
+    const hasWarnings =
+      diagnostics.warnings.length > 0 && !options?.ignoreWarnings
     let glbOk: boolean | undefined
     let glbError: string | undefined
     let previewOk: boolean | undefined
@@ -139,6 +141,7 @@ export const handleBuildFile = async (
       preview_error: previewError,
       ok: true,
       hasErrors,
+      hasWarnings,
       errors,
       warnings,
       durationMs: options?.profile ? performance.now() - startedAt : undefined,

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -108,6 +108,7 @@ export async function buildFilesWithWorkerPool(options: {
         previewError: completedMessage.preview_error,
         ok: completedMessage.ok,
         hasErrors: completedMessage.hasErrors,
+        hasWarnings: completedMessage.hasWarnings,
         isFatalError: completedMessage.isFatalError,
         errors: completedMessage.errors,
         warnings: completedMessage.warnings,

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -36,6 +36,7 @@ export type BuildCompletedMessage = {
   preview_error?: string
   ok: boolean
   hasErrors?: boolean
+  hasWarnings?: boolean
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
   errors: string[]
@@ -75,6 +76,7 @@ export type BuildJobResult = {
   previewError?: string
   ok: boolean
   hasErrors?: boolean
+  hasWarnings?: boolean
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
   errors: string[]

--- a/tests/cli/build/build-exit-code-error-ignore.test.ts
+++ b/tests/cli/build/build-exit-code-error-ignore.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const circuitWithError = JSON.stringify([
+  {
+    type: "source_component",
+    source_component_id: "sc1",
+    name: "R1",
+    ftype: "simple_resistor",
+  },
+  {
+    type: "pcb_component_outside_board_error",
+    message: "Component R1 extends outside board boundaries",
+  },
+])
+
+test("build exits with code 0 when errors present but --ignore-errors is set", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await writeFile(path.join(tmpDir, "circuit.json"), circuitWithError)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout } = await runCommand(
+    "tsci build circuit.json --ignore-errors",
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stdout).toContain("Done")
+}, 30_000)

--- a/tests/cli/build/build-exit-code-warning1.test.ts
+++ b/tests/cli/build/build-exit-code-warning1.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const circuitWithWarning = JSON.stringify([
+  {
+    type: "source_component",
+    source_component_id: "sc1",
+    name: "R1",
+    ftype: "simple_resistor",
+  },
+  {
+    type: "pcb_placement_warning",
+    message: "Component R1 placed near board edge",
+  },
+])
+
+test("build exits with code 2 when circuit JSON has warnings but no errors", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await writeFile(path.join(tmpDir, "circuit.json"), circuitWithWarning)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout } = await runCommand("tsci build circuit.json")
+
+  expect(exitCode).toBe(2)
+  expect(stdout).toContain("Build completed with warnings")
+}, 30_000)

--- a/tests/cli/build/build-exit-code-warning2.test.ts
+++ b/tests/cli/build/build-exit-code-warning2.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const circuitWithWarning = JSON.stringify([
+  {
+    type: "source_component",
+    source_component_id: "sc1",
+    name: "R1",
+    ftype: "simple_resistor",
+  },
+  {
+    type: "pcb_placement_warning",
+    message: "Component R1 placed near board edge",
+  },
+])
+
+test("build exits with code 0 when warnings present but --ignore-warnings is set", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await writeFile(path.join(tmpDir, "circuit.json"), circuitWithWarning)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout } = await runCommand(
+    "tsci build circuit.json --ignore-warnings",
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stdout).toContain("Done")
+}, 30_000)

--- a/tests/cli/build/build-with-drc-error.test.ts
+++ b/tests/cli/build/build-with-drc-error.test.ts
@@ -10,7 +10,7 @@ export default () => (
   </board>
 )`
 
-test("build succeeds when circuit JSON is generated with DRC errors", async () => {
+test("build exits with code 1 when circuit JSON has DRC errors", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   await writeFile(path.join(tmpDir, "test.circuit.tsx"), validCircuitCode)
@@ -28,6 +28,6 @@ test("build succeeds when circuit JSON is generated with DRC errors", async () =
     "Component R1 extends outside board boundaries",
   )
 
-  expect(exitCode).toBe(0)
+  expect(exitCode).toBe(1)
   expect(stdout).toContain("Build completed with errors")
 }, 30_000)


### PR DESCRIPTION
## Summary

- `tsci build` now exits with distinct codes: **0** (clean), **1** (errors), **2** (warnings only)
- Enables agents, CI/CD, and programmatic callers to detect build health without parsing stdout/stderr
- `--ignore-errors` suppresses error exit codes (except fatal); `--ignore-warnings` suppresses warning exit codes
- Tracks `hasWarnings` through the full build pipeline (build-file, worker types, worker handlers, worker pool, register)

Closes #2292

## Test plan

- [x] New test: build exits code 2 when circuit JSON has warnings but no errors
- [x] New test: build exits code 0 when warnings present but `--ignore-warnings` is set
- [x] New test: build exits code 0 when errors present but `--ignore-errors` is set
- [x] Updated existing DRC error test to expect exit code 1
- [x] All 11 tests in `build.test.ts` pass
- [x] `build-with-ignore-error`, `build-fail-fast`, `build-transpile` tests pass
- [x] Formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)