### PR TITLE
Emit warning when multiple common entrypoints are detected

### DIFF
--- a/lib/shared/get-entrypoint.ts
+++ b/lib/shared/get-entrypoint.ts
@@ -8,6 +8,7 @@ type EntrypointOptions = {
   projectDir?: string
   onSuccess?: (message: string) => void
   onError?: (message: string) => void
+  onWarning?: (message: string) => void
 }
 
 const ALLOWED_ENTRYPOINT_NAMES = Object.freeze([
@@ -111,6 +112,7 @@ export const getEntrypoint = async ({
   projectDir = process.cwd(),
   onSuccess = (message: string) => console.log(message),
   onError = (message: string) => console.error(message),
+  onWarning = (message: string) => console.warn(kleur.yellow(message)),
 }: EntrypointOptions): Promise<string | null> => {
   try {
     const validatedProjectDir = validateProjectDir(projectDir)
@@ -163,6 +165,25 @@ export const getEntrypoint = async ({
       "src/main.tsx",
       "src/main.circuit.tsx",
     ].map((location) => path.resolve(validatedProjectDir, location))
+
+    const existingCommonEntrypoints = commonLocations.filter(
+      (entrypoint) =>
+        fs.existsSync(entrypoint) &&
+        isValidDirectory(entrypoint, validatedProjectDir),
+    )
+
+    if (existingCommonEntrypoints.length > 1) {
+      const chosenEntrypoint = path.relative(
+        validatedProjectDir,
+        existingCommonEntrypoints[0],
+      )
+      const ignoredEntrypoints = existingCommonEntrypoints
+        .slice(1)
+        .map((entrypoint) => path.relative(validatedProjectDir, entrypoint))
+      onWarning(
+        `Multiple common entrypoints found. Choosing '${chosenEntrypoint}' and ignoring: ${ignoredEntrypoints.map((entrypoint) => `'${entrypoint}'`).join(", ")}.`,
+      )
+    }
 
     const recursiveEntrypoints = findEntrypointsRecursively(
       validatedProjectDir,

--- a/tests/get-entrypoint.test.ts
+++ b/tests/get-entrypoint.test.ts
@@ -493,3 +493,29 @@ test("getEntrypoint uses custom callback functions", async () => {
   expect(successMessage).toContain("Detected entrypoint")
   expect(errorMessage).toBe("")
 })
+
+test("getEntrypoint warns when multiple common locations exist", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  await fs.writeFile(
+    path.join(tmpDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+  await fs.mkdir(path.join(tmpDir, "src"))
+  await fs.writeFile(
+    path.join(tmpDir, "src", "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const warnings: string[] = []
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    onWarning: (message) => warnings.push(message),
+  })
+
+  expect(entrypoint).toBe(path.join(tmpDir, "index.tsx"))
+  expect(warnings).toHaveLength(1)
+  expect(warnings[0]).toContain("Multiple common entrypoints found")
+  expect(warnings[0]).toContain("Choosing 'index.tsx'")
+  expect(warnings[0]).toContain("'src/index.tsx'")
+})


### PR DESCRIPTION
### Motivation
- Make it explicit when a project contains multiple common-location entrypoint files and the tool must pick one, so users understand which file was chosen and which were ignored.

### Description
- Added an optional `onWarning` callback to `getEntrypoint` with a default implementation that prints a yellow warning to the console.
- Detect when more than one common-location entrypoint exists and emit a clear warning that names the chosen entrypoint and lists the ignored common-location files.
- Kept existing `onSuccess`/`onError` behavior unchanged and implemented the warning emission before recursive search.
- Added a regression test (`tests/get-entrypoint.test.ts`) asserting the warning is emitted and contains both the selected and ignored paths.

### Testing
- Ran `bun test tests/get-entrypoint.test.ts` which passed (22 tests, 0 failures).
- Ran typecheck with `bunx tsc --noEmit`, which succeeded.
- Ran formatter with `bun run format` and re-ran the tests with `bun test tests/get-entrypoint.test.ts`, all succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adaf04ce10832e813094d414a0fbcf)