### PR TITLE
Eliminate duplicate preview builds with single-pass output flags: --pngs, --svgs, --pcb-svgs, --schematic-svgs

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -25,6 +25,13 @@ export interface BuildCommandOptions {
   concurrency?: string
   injectProps?: string
   injectPropsFile?: string
+  pngs?: boolean
+  svgs?: boolean
+  pcbSvgs?: boolean
+  schematicSvgs?: boolean
+  "3d"?: boolean
+  pcbOnly?: boolean
+  schematicOnly?: boolean
 }
 
 const runCommand = (command: string, cwd: string) => {

--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -126,13 +126,7 @@ const generatePreviewAssets = async ({
       )
       console.log(`${prefix}Rendering GLB to PNG buffer...`)
       const glbArrayBuffer = await normalizeToArrayBuffer(glbBuffer)
-      const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(
-        glbArrayBuffer,
-        {
-          camPos: [10, 10, 10],
-          lookAt: [0, 0, 0],
-        },
-      )
+      const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(glbArrayBuffer)
       fs.writeFileSync(
         path.join(outputDir, "3d.png"),
         Buffer.from(normalizeToUint8Array(pngBuffer)),

--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -9,6 +9,7 @@ import {
 import { getCircuitJsonToGltfOptions } from "lib/shared/get-circuit-json-to-gltf-options"
 import { renderGLTFToPNGBufferFromGLBBuffer } from "poppygl"
 import { convertModelUrlsToFileUrls } from "./convert-model-urls-to-file-urls"
+import type { BuildPreviewOutputSelection } from "./preview-output-selection"
 
 export interface BuildFileResult {
   sourcePath: string
@@ -68,10 +69,12 @@ const generatePreviewAssets = async ({
   build,
   outputDir,
   distDir,
+  previewOutputs,
 }: {
   build: BuildFileResult
   outputDir: string
   distDir: string
+  previewOutputs: BuildPreviewOutputSelection
 }) => {
   const prefixRelative = path.relative(distDir, outputDir) || "."
   const prefix = prefixRelative === "." ? "" : `[${prefixRelative}] `
@@ -87,51 +90,57 @@ const generatePreviewAssets = async ({
 
   fs.mkdirSync(outputDir, { recursive: true })
 
-  // Generate PCB SVG
-  try {
-    console.log(`${prefix}Generating PCB SVG...`)
-    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
-    fs.writeFileSync(path.join(outputDir, "pcb.svg"), pcbSvg, "utf-8")
-    console.log(`${prefix}Written pcb.svg`)
-  } catch (error) {
-    console.error(`${prefix}Failed to generate PCB SVG:`, error)
+  if (previewOutputs.pcbSvgs) {
+    try {
+      console.log(`${prefix}Generating PCB SVG...`)
+      const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+      fs.writeFileSync(path.join(outputDir, "pcb.svg"), pcbSvg, "utf-8")
+      console.log(`${prefix}Written pcb.svg`)
+    } catch (error) {
+      console.error(`${prefix}Failed to generate PCB SVG:`, error)
+    }
   }
 
-  // Generate schematic SVG
-  try {
-    console.log(`${prefix}Generating schematic SVG...`)
-    const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
-    fs.writeFileSync(
-      path.join(outputDir, "schematic.svg"),
-      schematicSvg,
-      "utf-8",
-    )
-    console.log(`${prefix}Written schematic.svg`)
-  } catch (error) {
-    console.error(`${prefix}Failed to generate schematic SVG:`, error)
+  if (previewOutputs.schematicSvgs) {
+    try {
+      console.log(`${prefix}Generating schematic SVG...`)
+      const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
+      fs.writeFileSync(
+        path.join(outputDir, "schematic.svg"),
+        schematicSvg,
+        "utf-8",
+      )
+      console.log(`${prefix}Written schematic.svg`)
+    } catch (error) {
+      console.error(`${prefix}Failed to generate schematic SVG:`, error)
+    }
   }
 
-  // Generate 3D PNG
-  try {
-    console.log(`${prefix}Converting circuit to GLB...`)
-    const circuitJsonWithFileUrls = convertModelUrlsToFileUrls(circuitJson)
-    const glbBuffer = await convertCircuitJsonToGltf(
-      circuitJsonWithFileUrls,
-      getCircuitJsonToGltfOptions({ format: "glb" }),
-    )
-    console.log(`${prefix}Rendering GLB to PNG buffer...`)
-    const glbArrayBuffer = await normalizeToArrayBuffer(glbBuffer)
-    const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(glbArrayBuffer, {
-      camPos: [10, 10, 10],
-      lookAt: [0, 0, 0],
-    })
-    fs.writeFileSync(
-      path.join(outputDir, "3d.png"),
-      Buffer.from(normalizeToUint8Array(pngBuffer)),
-    )
-    console.log(`${prefix}Written 3d.png`)
-  } catch (error) {
-    console.error(`${prefix}Failed to generate 3D PNG:`, error)
+  if (previewOutputs.threeDPngs) {
+    try {
+      console.log(`${prefix}Converting circuit to GLB...`)
+      const circuitJsonWithFileUrls = convertModelUrlsToFileUrls(circuitJson)
+      const glbBuffer = await convertCircuitJsonToGltf(
+        circuitJsonWithFileUrls,
+        getCircuitJsonToGltfOptions({ format: "glb" }),
+      )
+      console.log(`${prefix}Rendering GLB to PNG buffer...`)
+      const glbArrayBuffer = await normalizeToArrayBuffer(glbBuffer)
+      const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(
+        glbArrayBuffer,
+        {
+          camPos: [10, 10, 10],
+          lookAt: [0, 0, 0],
+        },
+      )
+      fs.writeFileSync(
+        path.join(outputDir, "3d.png"),
+        Buffer.from(normalizeToUint8Array(pngBuffer)),
+      )
+      console.log(`${prefix}Written 3d.png`)
+    } catch (error) {
+      console.error(`${prefix}Failed to generate 3D PNG:`, error)
+    }
   }
 }
 
@@ -141,12 +150,14 @@ export const buildPreviewImages = async ({
   mainEntrypoint,
   previewComponentPath,
   allImages,
+  previewOutputs,
 }: {
   builtFiles: BuildFileResult[]
   distDir: string
   mainEntrypoint?: string
   previewComponentPath?: string
   allImages?: boolean
+  previewOutputs: BuildPreviewOutputSelection
 }) => {
   const successfulBuilds = builtFiles.filter((file) => file.ok)
   // previewComponentPath takes precedence over mainEntrypoint for preview images
@@ -169,6 +180,7 @@ export const buildPreviewImages = async ({
         build,
         outputDir,
         distDir,
+        previewOutputs,
       })
     }
     return
@@ -195,5 +207,6 @@ export const buildPreviewImages = async ({
     build: previewBuild,
     outputDir: distDir,
     distDir,
+    previewOutputs,
   })
 }

--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -9,7 +9,7 @@ import {
 import { getCircuitJsonToGltfOptions } from "lib/shared/get-circuit-json-to-gltf-options"
 import { renderGLTFToPNGBufferFromGLBBuffer } from "poppygl"
 import { convertModelUrlsToFileUrls } from "./convert-model-urls-to-file-urls"
-import type { BuildPreviewOutputSelection } from "./preview-output-selection"
+import type { BuildImageFormatSelection } from "./image-format-selection"
 
 export interface BuildFileResult {
   sourcePath: string
@@ -69,12 +69,12 @@ const generatePreviewAssets = async ({
   build,
   outputDir,
   distDir,
-  previewOutputs,
+  imageFormats,
 }: {
   build: BuildFileResult
   outputDir: string
   distDir: string
-  previewOutputs: BuildPreviewOutputSelection
+  imageFormats: BuildImageFormatSelection
 }) => {
   const prefixRelative = path.relative(distDir, outputDir) || "."
   const prefix = prefixRelative === "." ? "" : `[${prefixRelative}] `
@@ -90,7 +90,7 @@ const generatePreviewAssets = async ({
 
   fs.mkdirSync(outputDir, { recursive: true })
 
-  if (previewOutputs.pcbSvgs) {
+  if (imageFormats.pcbSvgs) {
     try {
       console.log(`${prefix}Generating PCB SVG...`)
       const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
@@ -101,7 +101,7 @@ const generatePreviewAssets = async ({
     }
   }
 
-  if (previewOutputs.schematicSvgs) {
+  if (imageFormats.schematicSvgs) {
     try {
       console.log(`${prefix}Generating schematic SVG...`)
       const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
@@ -116,7 +116,7 @@ const generatePreviewAssets = async ({
     }
   }
 
-  if (previewOutputs.threeDPngs) {
+  if (imageFormats.threeDPngs) {
     try {
       console.log(`${prefix}Converting circuit to GLB...`)
       const circuitJsonWithFileUrls = convertModelUrlsToFileUrls(circuitJson)
@@ -150,14 +150,14 @@ export const buildPreviewImages = async ({
   mainEntrypoint,
   previewComponentPath,
   allImages,
-  previewOutputs,
+  imageFormats,
 }: {
   builtFiles: BuildFileResult[]
   distDir: string
   mainEntrypoint?: string
   previewComponentPath?: string
   allImages?: boolean
-  previewOutputs: BuildPreviewOutputSelection
+  imageFormats: BuildImageFormatSelection
 }) => {
   const successfulBuilds = builtFiles.filter((file) => file.ok)
   // previewComponentPath takes precedence over mainEntrypoint for preview images
@@ -180,7 +180,7 @@ export const buildPreviewImages = async ({
         build,
         outputDir,
         distDir,
-        previewOutputs,
+        imageFormats,
       })
     }
     return
@@ -207,6 +207,6 @@ export const buildPreviewImages = async ({
     build: previewBuild,
     outputDir: distDir,
     distDir,
-    previewOutputs,
+    imageFormats,
   })
 }

--- a/cli/build/image-format-selection.ts
+++ b/cli/build/image-format-selection.ts
@@ -1,25 +1,26 @@
 import type { BuildCommandOptions } from "./build-ci"
 
-export type BuildPreviewOutputSelection = {
+export type BuildImageFormatSelection = {
   threeDPngs: boolean
   pcbSvgs: boolean
   schematicSvgs: boolean
 }
 
-export const DEFAULT_PREVIEW_OUTPUT_SELECTION: BuildPreviewOutputSelection = {
+export const DEFAULT_IMAGE_FORMAT_SELECTION: BuildImageFormatSelection = {
   threeDPngs: true,
   pcbSvgs: true,
   schematicSvgs: true,
 }
 
-export const EMPTY_PREVIEW_OUTPUT_SELECTION: BuildPreviewOutputSelection = {
+export const EMPTY_IMAGE_FORMAT_SELECTION: BuildImageFormatSelection = {
   threeDPngs: false,
   pcbSvgs: false,
   schematicSvgs: false,
 }
 
-export const hasAnyPreviewOutput = (selection: BuildPreviewOutputSelection) =>
-  selection.threeDPngs || selection.pcbSvgs || selection.schematicSvgs
+export const hasAnyImageFormatSelected = (
+  selection: BuildImageFormatSelection,
+) => selection.threeDPngs || selection.pcbSvgs || selection.schematicSvgs
 
 const hasNewOutputFlags = (options?: BuildCommandOptions) =>
   Boolean(
@@ -29,28 +30,28 @@ const hasNewOutputFlags = (options?: BuildCommandOptions) =>
       options?.schematicSvgs,
   )
 
-const hasLegacyOutputFlags = (options?: BuildCommandOptions) =>
+const hasEstablishedOutputFlags = (options?: BuildCommandOptions) =>
   Boolean(options?.["3d"] || options?.pcbOnly || options?.schematicOnly)
 
-export const resolvePreviewOutputSelection = (
+export const resolveImageFormatSelection = (
   options?: BuildCommandOptions,
 ): {
-  selection: BuildPreviewOutputSelection
+  selection: BuildImageFormatSelection
   hasExplicitSelection: boolean
 } => {
   const hasNewFlags = hasNewOutputFlags(options)
-  const hasLegacyFlags = hasLegacyOutputFlags(options)
-  const hasExplicitSelection = hasNewFlags || hasLegacyFlags
+  const hasEstablishedFlags = hasEstablishedOutputFlags(options)
+  const hasExplicitSelection = hasNewFlags || hasEstablishedFlags
 
   if (!hasExplicitSelection) {
     return {
-      selection: { ...DEFAULT_PREVIEW_OUTPUT_SELECTION },
+      selection: { ...DEFAULT_IMAGE_FORMAT_SELECTION },
       hasExplicitSelection: false,
     }
   }
 
-  if (!hasNewFlags && hasLegacyFlags) {
-    const selection: BuildPreviewOutputSelection = {
+  if (!hasNewFlags && hasEstablishedFlags) {
+    const selection: BuildImageFormatSelection = {
       threeDPngs: Boolean(options?.["3d"]),
       pcbSvgs: true,
       schematicSvgs: true,
@@ -67,8 +68,8 @@ export const resolvePreviewOutputSelection = (
     return { selection, hasExplicitSelection: true }
   }
 
-  const selection: BuildPreviewOutputSelection = {
-    ...EMPTY_PREVIEW_OUTPUT_SELECTION,
+  const selection: BuildImageFormatSelection = {
+    ...EMPTY_IMAGE_FORMAT_SELECTION,
   }
 
   if (options?.svgs) {
@@ -85,7 +86,7 @@ export const resolvePreviewOutputSelection = (
     selection.threeDPngs = true
   }
 
-  // Preserve compatibility with legacy filtering flags when used together.
+  // Preserve compatibility with filtering flags when used together.
   if (options?.pcbOnly && !options?.schematicOnly) {
     selection.schematicSvgs = false
   }

--- a/cli/build/preview-output-selection.ts
+++ b/cli/build/preview-output-selection.ts
@@ -1,0 +1,97 @@
+import type { BuildCommandOptions } from "./build-ci"
+
+export type BuildPreviewOutputSelection = {
+  threeDPngs: boolean
+  pcbSvgs: boolean
+  schematicSvgs: boolean
+}
+
+export const DEFAULT_PREVIEW_OUTPUT_SELECTION: BuildPreviewOutputSelection = {
+  threeDPngs: true,
+  pcbSvgs: true,
+  schematicSvgs: true,
+}
+
+export const EMPTY_PREVIEW_OUTPUT_SELECTION: BuildPreviewOutputSelection = {
+  threeDPngs: false,
+  pcbSvgs: false,
+  schematicSvgs: false,
+}
+
+export const hasAnyPreviewOutput = (selection: BuildPreviewOutputSelection) =>
+  selection.threeDPngs || selection.pcbSvgs || selection.schematicSvgs
+
+const hasNewOutputFlags = (options?: BuildCommandOptions) =>
+  Boolean(
+    options?.pngs ||
+      options?.svgs ||
+      options?.pcbSvgs ||
+      options?.schematicSvgs,
+  )
+
+const hasLegacyOutputFlags = (options?: BuildCommandOptions) =>
+  Boolean(options?.["3d"] || options?.pcbOnly || options?.schematicOnly)
+
+export const resolvePreviewOutputSelection = (
+  options?: BuildCommandOptions,
+): {
+  selection: BuildPreviewOutputSelection
+  hasExplicitSelection: boolean
+} => {
+  const hasNewFlags = hasNewOutputFlags(options)
+  const hasLegacyFlags = hasLegacyOutputFlags(options)
+  const hasExplicitSelection = hasNewFlags || hasLegacyFlags
+
+  if (!hasExplicitSelection) {
+    return {
+      selection: { ...DEFAULT_PREVIEW_OUTPUT_SELECTION },
+      hasExplicitSelection: false,
+    }
+  }
+
+  if (!hasNewFlags && hasLegacyFlags) {
+    const selection: BuildPreviewOutputSelection = {
+      threeDPngs: Boolean(options?.["3d"]),
+      pcbSvgs: true,
+      schematicSvgs: true,
+    }
+
+    if (options?.pcbOnly && !options?.schematicOnly) {
+      selection.schematicSvgs = false
+    }
+
+    if (options?.schematicOnly && !options?.pcbOnly) {
+      selection.pcbSvgs = false
+    }
+
+    return { selection, hasExplicitSelection: true }
+  }
+
+  const selection: BuildPreviewOutputSelection = {
+    ...EMPTY_PREVIEW_OUTPUT_SELECTION,
+  }
+
+  if (options?.svgs) {
+    selection.pcbSvgs = true
+    selection.schematicSvgs = true
+  }
+  if (options?.pcbSvgs) {
+    selection.pcbSvgs = true
+  }
+  if (options?.schematicSvgs) {
+    selection.schematicSvgs = true
+  }
+  if (options?.pngs || options?.["3d"]) {
+    selection.threeDPngs = true
+  }
+
+  // Preserve compatibility with legacy filtering flags when used together.
+  if (options?.pcbOnly && !options?.schematicOnly) {
+    selection.schematicSvgs = false
+  }
+  if (options?.schematicOnly && !options?.pcbOnly) {
+    selection.pcbSvgs = false
+  }
+
+  return { selection, hasExplicitSelection: true }
+}

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -24,9 +24,9 @@ import { generateKicadProject } from "./generate-kicad-project"
 import type { GeneratedKicadProject } from "./generate-kicad-project"
 import { getBuildEntrypoints } from "./get-build-entrypoints"
 import {
-  hasAnyPreviewOutput,
-  resolvePreviewOutputSelection,
-} from "./preview-output-selection"
+  hasAnyImageFormatSelected,
+  resolveImageFormatSelection,
+} from "./image-format-selection"
 import { resolveBuildOptions } from "./resolve-build-options"
 import { transpileFile } from "./transpile"
 import { exitBuild } from "./utils/exit-build"
@@ -123,24 +123,21 @@ export const registerBuild = (program: Command) => {
       "--all-images",
       "Generate preview images for every successful build output",
     )
-    .option("--pngs", "Generate PNG outputs during build preview generation")
-    .option("--svgs", "Generate SVG outputs during build preview generation")
-    .option(
-      "--pcb-svgs",
-      "Generate PCB SVG outputs during build preview generation",
-    )
+    .option("--pngs", "Generate PNG outputs during build generation")
+    .option("--svgs", "Generate SVG outputs during build generation")
+    .option("--pcb-svgs", "Generate PCB SVG outputs during build generation")
     .option(
       "--schematic-svgs",
-      "Generate schematic SVG outputs during build preview generation",
+      "Generate schematic SVG outputs during build generation",
     )
-    .option("--3d", "Legacy alias for generating PNG preview outputs")
+    .option("--3d", "Generate 3D PNG outputs during build generation")
     .option(
       "--pcb-only",
-      "Legacy compatibility flag: omit schematic SVG preview outputs",
+      "Generate only PCB SVG outputs during build generation",
     )
     .option(
       "--schematic-only",
-      "Legacy compatibility flag: omit PCB SVG preview outputs",
+      "Generate only schematic SVG outputs outputs during build generation",
     )
     .option(
       "--kicad-project",
@@ -307,9 +304,9 @@ export const registerBuild = (program: Command) => {
 
         // Prepare build options for reuse
         const {
-          selection: previewOutputSelection,
-          hasExplicitSelection: hasExplicitPreviewOutputSelection,
-        } = resolvePreviewOutputSelection(resolvedOptions)
+          selection: imageFormatSelection,
+          hasExplicitSelection: hasExplicitImageFormatSelection,
+        } = resolveImageFormatSelection(resolvedOptions)
 
         const buildOptions = {
           ignoreErrors: resolvedOptions?.ignoreErrors,
@@ -318,14 +315,14 @@ export const registerBuild = (program: Command) => {
           profile: resolvedOptions?.profile,
           injectedProps,
           generatePreviewAssets: false,
-          previewOutputs: previewOutputSelection,
+          imageFormats: imageFormatSelection,
         }
 
         const shouldGeneratePreviewImages = Boolean(
           (resolvedOptions?.previewImages ||
             resolvedOptions?.allImages ||
-            hasExplicitPreviewOutputSelection) &&
-            hasAnyPreviewOutput(previewOutputSelection),
+            hasExplicitImageFormatSelection) &&
+            hasAnyImageFormatSelected(imageFormatSelection),
         )
         const shouldGenerateAllPreviewImages = Boolean(
           resolvedOptions?.allImages,
@@ -585,7 +582,7 @@ export const registerBuild = (program: Command) => {
               mainEntrypoint,
               previewComponentPath,
               allImages: shouldGenerateAllPreviewImages,
-              previewOutputs: previewOutputSelection,
+              imageFormats: imageFormatSelection,
             })
           }
         }

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -23,6 +23,10 @@ import { buildPreviewImages } from "./build-preview-images"
 import { generateKicadProject } from "./generate-kicad-project"
 import type { GeneratedKicadProject } from "./generate-kicad-project"
 import { getBuildEntrypoints } from "./get-build-entrypoints"
+import {
+  hasAnyPreviewOutput,
+  resolvePreviewOutputSelection,
+} from "./preview-output-selection"
 import { resolveBuildOptions } from "./resolve-build-options"
 import { transpileFile } from "./transpile"
 import { exitBuild } from "./utils/exit-build"
@@ -118,6 +122,25 @@ export const registerBuild = (program: Command) => {
     .option(
       "--all-images",
       "Generate preview images for every successful build output",
+    )
+    .option("--pngs", "Generate PNG outputs during build preview generation")
+    .option("--svgs", "Generate SVG outputs during build preview generation")
+    .option(
+      "--pcb-svgs",
+      "Generate PCB SVG outputs during build preview generation",
+    )
+    .option(
+      "--schematic-svgs",
+      "Generate schematic SVG outputs during build preview generation",
+    )
+    .option("--3d", "Legacy alias for generating PNG preview outputs")
+    .option(
+      "--pcb-only",
+      "Legacy compatibility flag: omit schematic SVG preview outputs",
+    )
+    .option(
+      "--schematic-only",
+      "Legacy compatibility flag: omit PCB SVG preview outputs",
     )
     .option(
       "--kicad-project",
@@ -283,6 +306,11 @@ export const registerBuild = (program: Command) => {
         })
 
         // Prepare build options for reuse
+        const {
+          selection: previewOutputSelection,
+          hasExplicitSelection: hasExplicitPreviewOutputSelection,
+        } = resolvePreviewOutputSelection(resolvedOptions)
+
         const buildOptions = {
           ignoreErrors: resolvedOptions?.ignoreErrors,
           ignoreWarnings: resolvedOptions?.ignoreWarnings,
@@ -290,10 +318,15 @@ export const registerBuild = (program: Command) => {
           profile: resolvedOptions?.profile,
           injectedProps,
           generatePreviewAssets: false,
+          previewOutputs: previewOutputSelection,
         }
 
-        const shouldGeneratePreviewImages =
-          resolvedOptions?.previewImages || resolvedOptions?.allImages
+        const shouldGeneratePreviewImages = Boolean(
+          (resolvedOptions?.previewImages ||
+            resolvedOptions?.allImages ||
+            hasExplicitPreviewOutputSelection) &&
+            hasAnyPreviewOutput(previewOutputSelection),
+        )
         const shouldGenerateAllPreviewImages = Boolean(
           resolvedOptions?.allImages,
         )
@@ -552,6 +585,7 @@ export const registerBuild = (program: Command) => {
               mainEntrypoint,
               previewComponentPath,
               allImages: shouldGenerateAllPreviewImages,
+              previewOutputs: previewOutputSelection,
             })
           }
         }
@@ -757,6 +791,13 @@ export const registerBuild = (program: Command) => {
           resolvedOptions?.transpile && "transpile",
           resolvedOptions?.previewImages && "preview-images",
           resolvedOptions?.allImages && "all-images",
+          resolvedOptions?.pngs && "pngs",
+          resolvedOptions?.svgs && "svgs",
+          resolvedOptions?.pcbSvgs && "pcb-svgs",
+          resolvedOptions?.schematicSvgs && "schematic-svgs",
+          resolvedOptions?.["3d"] && "3d",
+          resolvedOptions?.pcbOnly && "pcb-only",
+          resolvedOptions?.schematicOnly && "schematic-only",
           resolvedOptions?.glbs && "glbs",
           resolvedOptions?.kicadProject && "kicad-project",
           resolvedOptions?.kicadLibrary && "kicad-library",

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -137,7 +137,7 @@ export const registerBuild = (program: Command) => {
     )
     .option(
       "--schematic-only",
-      "Generate only schematic SVG outputs outputs during build generation",
+      "Generate only schematic SVG outputs during build generation",
     )
     .option(
       "--kicad-project",

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -10,6 +10,7 @@ import {
   writeGlbFromCircuitJson,
   writePreviewAssetsFromCircuitJson,
 } from "./worker-output-generators"
+import { DEFAULT_PREVIEW_OUTPUT_SELECTION } from "./preview-output-selection"
 import type { BuildCompletedMessage, BuildFileMessage } from "./worker-types"
 
 type WorkerLogger = (...args: unknown[]) => void
@@ -117,6 +118,7 @@ export const handleBuildFile = async (
         await writePreviewAssetsFromCircuitJson(
           circuitJson,
           resolvedPreviewOutputDir,
+          options?.previewOutputs ?? DEFAULT_PREVIEW_OUTPUT_SELECTION,
         )
         previewOk = true
       } catch (err) {

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -8,9 +8,9 @@ import { getCompletePlatformConfig } from "../../lib/shared/get-complete-platfor
 import { registerStaticAssetLoaders } from "../../lib/shared/register-static-asset-loaders"
 import {
   writeGlbFromCircuitJson,
-  writePreviewAssetsFromCircuitJson,
+  writeImageAssetsFromCircuitJson,
 } from "./worker-output-generators"
-import { DEFAULT_PREVIEW_OUTPUT_SELECTION } from "./preview-output-selection"
+import { DEFAULT_IMAGE_FORMAT_SELECTION } from "./image-format-selection"
 import type { BuildCompletedMessage, BuildFileMessage } from "./worker-types"
 
 type WorkerLogger = (...args: unknown[]) => void
@@ -115,11 +115,10 @@ export const handleBuildFile = async (
         workerLog(
           `Generating preview assets for ${path.relative(projectDir, resolvedPreviewOutputDir)} in same worker...`,
         )
-        await writePreviewAssetsFromCircuitJson(
-          circuitJson,
-          resolvedPreviewOutputDir,
-          options?.previewOutputs ?? DEFAULT_PREVIEW_OUTPUT_SELECTION,
-        )
+        await writeImageAssetsFromCircuitJson(circuitJson, {
+          outputDir: resolvedPreviewOutputDir,
+          imageFormats: options?.imageFormats ?? DEFAULT_IMAGE_FORMAT_SELECTION,
+        })
         previewOk = true
       } catch (err) {
         previewOk = false

--- a/cli/build/worker-output-generators.ts
+++ b/cli/build/worker-output-generators.ts
@@ -61,10 +61,7 @@ export const writeImageAssetsFromCircuitJson = async (
       getCircuitJsonToGltfOptions({ format: "glb" }),
     )
     const glbArrayBuffer = await normalizeToArrayBuffer(glbBuffer)
-    const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(glbArrayBuffer, {
-      camPos: [10, 10, 10],
-      lookAt: [0, 0, 0],
-    })
+    const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(glbArrayBuffer)
 
     fs.writeFileSync(
       path.join(outputDir, "3d.png"),

--- a/cli/build/worker-output-generators.ts
+++ b/cli/build/worker-output-generators.ts
@@ -13,7 +13,7 @@ import {
   normalizeToArrayBuffer,
   normalizeToUint8Array,
 } from "./worker-binary-utils"
-import type { BuildPreviewOutputSelection } from "./preview-output-selection"
+import type { BuildImageFormatSelection } from "./image-format-selection"
 
 export const writeGlbFromCircuitJson = async (
   circuitJson: AnyCircuitElement[],
@@ -30,19 +30,22 @@ export const writeGlbFromCircuitJson = async (
   fs.writeFileSync(glbOutputPath, Buffer.from(glbData))
 }
 
-export const writePreviewAssetsFromCircuitJson = async (
+export const writeImageAssetsFromCircuitJson = async (
   circuitJson: AnyCircuitElement[],
-  outputDir: string,
-  outputs: BuildPreviewOutputSelection,
+  options: {
+    outputDir: string
+    imageFormats: BuildImageFormatSelection
+  },
 ) => {
+  const { outputDir, imageFormats } = options
   fs.mkdirSync(outputDir, { recursive: true })
 
-  if (outputs.pcbSvgs) {
+  if (imageFormats.pcbSvgs) {
     const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
     fs.writeFileSync(path.join(outputDir, "pcb.svg"), pcbSvg, "utf-8")
   }
 
-  if (outputs.schematicSvgs) {
+  if (imageFormats.schematicSvgs) {
     const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
     fs.writeFileSync(
       path.join(outputDir, "schematic.svg"),
@@ -51,7 +54,7 @@ export const writePreviewAssetsFromCircuitJson = async (
     )
   }
 
-  if (outputs.threeDPngs) {
+  if (imageFormats.threeDPngs) {
     const circuitJsonWithFileUrls = convertModelUrlsToFileUrls(circuitJson)
     const glbBuffer = await convertCircuitJsonToGltf(
       circuitJsonWithFileUrls,

--- a/cli/build/worker-output-generators.ts
+++ b/cli/build/worker-output-generators.ts
@@ -13,6 +13,7 @@ import {
   normalizeToArrayBuffer,
   normalizeToUint8Array,
 } from "./worker-binary-utils"
+import type { BuildPreviewOutputSelection } from "./preview-output-selection"
 
 export const writeGlbFromCircuitJson = async (
   circuitJson: AnyCircuitElement[],
@@ -32,28 +33,39 @@ export const writeGlbFromCircuitJson = async (
 export const writePreviewAssetsFromCircuitJson = async (
   circuitJson: AnyCircuitElement[],
   outputDir: string,
+  outputs: BuildPreviewOutputSelection,
 ) => {
   fs.mkdirSync(outputDir, { recursive: true })
 
-  const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
-  fs.writeFileSync(path.join(outputDir, "pcb.svg"), pcbSvg, "utf-8")
+  if (outputs.pcbSvgs) {
+    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+    fs.writeFileSync(path.join(outputDir, "pcb.svg"), pcbSvg, "utf-8")
+  }
 
-  const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
-  fs.writeFileSync(path.join(outputDir, "schematic.svg"), schematicSvg, "utf-8")
+  if (outputs.schematicSvgs) {
+    const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
+    fs.writeFileSync(
+      path.join(outputDir, "schematic.svg"),
+      schematicSvg,
+      "utf-8",
+    )
+  }
 
-  const circuitJsonWithFileUrls = convertModelUrlsToFileUrls(circuitJson)
-  const glbBuffer = await convertCircuitJsonToGltf(
-    circuitJsonWithFileUrls,
-    getCircuitJsonToGltfOptions({ format: "glb" }),
-  )
-  const glbArrayBuffer = await normalizeToArrayBuffer(glbBuffer)
-  const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(glbArrayBuffer, {
-    camPos: [10, 10, 10],
-    lookAt: [0, 0, 0],
-  })
+  if (outputs.threeDPngs) {
+    const circuitJsonWithFileUrls = convertModelUrlsToFileUrls(circuitJson)
+    const glbBuffer = await convertCircuitJsonToGltf(
+      circuitJsonWithFileUrls,
+      getCircuitJsonToGltfOptions({ format: "glb" }),
+    )
+    const glbArrayBuffer = await normalizeToArrayBuffer(glbBuffer)
+    const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(glbArrayBuffer, {
+      camPos: [10, 10, 10],
+      lookAt: [0, 0, 0],
+    })
 
-  fs.writeFileSync(
-    path.join(outputDir, "3d.png"),
-    Buffer.from(normalizeToUint8Array(pngBuffer)),
-  )
+    fs.writeFileSync(
+      path.join(outputDir, "3d.png"),
+      Buffer.from(normalizeToUint8Array(pngBuffer)),
+    )
+  }
 }

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -2,6 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
+import type { BuildPreviewOutputSelection } from "./preview-output-selection"
 import type {
   BuildCompletedMessage,
   BuildFileMessage,
@@ -22,6 +23,7 @@ type BuildJob = {
     profile?: boolean
     injectedProps?: Record<string, unknown>
     generatePreviewAssets?: boolean
+    previewOutputs?: BuildPreviewOutputSelection
   }
 }
 
@@ -62,6 +64,7 @@ export async function buildFilesWithWorkerPool(options: {
     profile?: boolean
     injectedProps?: Record<string, unknown>
     generatePreviewAssets?: boolean
+    previewOutputs?: BuildPreviewOutputSelection
   }
   onLog?: (lines: string[]) => void
   onJobComplete?: (result: BuildJobResult) => void

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -2,7 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
-import type { BuildPreviewOutputSelection } from "./preview-output-selection"
+import type { BuildImageFormatSelection } from "./image-format-selection"
 import type {
   BuildCompletedMessage,
   BuildFileMessage,
@@ -23,7 +23,7 @@ type BuildJob = {
     profile?: boolean
     injectedProps?: Record<string, unknown>
     generatePreviewAssets?: boolean
-    previewOutputs?: BuildPreviewOutputSelection
+    imageFormats?: BuildImageFormatSelection
   }
 }
 
@@ -64,7 +64,7 @@ export async function buildFilesWithWorkerPool(options: {
     profile?: boolean
     injectedProps?: Record<string, unknown>
     generatePreviewAssets?: boolean
-    previewOutputs?: BuildPreviewOutputSelection
+    imageFormats?: BuildImageFormatSelection
   }
   onLog?: (lines: string[]) => void
   onJobComplete?: (result: BuildJobResult) => void

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -1,5 +1,5 @@
 import type { PlatformConfig } from "@tscircuit/props"
-import type { BuildPreviewOutputSelection } from "./preview-output-selection"
+import type { BuildImageFormatSelection } from "./image-format-selection"
 
 /**
  * Message sent from main thread to worker to build a file
@@ -18,7 +18,7 @@ export type BuildFileMessage = {
     profile?: boolean
     injectedProps?: Record<string, unknown>
     generatePreviewAssets?: boolean
-    previewOutputs?: BuildPreviewOutputSelection
+    imageFormats?: BuildImageFormatSelection
   }
 }
 

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -1,4 +1,5 @@
 import type { PlatformConfig } from "@tscircuit/props"
+import type { BuildPreviewOutputSelection } from "./preview-output-selection"
 
 /**
  * Message sent from main thread to worker to build a file
@@ -17,6 +18,7 @@ export type BuildFileMessage = {
     profile?: boolean
     injectedProps?: Record<string, unknown>
     generatePreviewAssets?: boolean
+    previewOutputs?: BuildPreviewOutputSelection
   }
 }
 

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "bun:test"
+import { readFile, stat, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const circuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)`
+
+test("build --pcb-svgs generates only pcb.svg", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --pcb-svgs ${circuitPath}`)
+
+  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  expect(pcbSvg).toContain("<svg")
+
+  await expect(
+    stat(path.join(tmpDir, "dist", "schematic.svg")),
+  ).rejects.toBeTruthy()
+  await expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+}, 30_000)
+
+test("build --pngs generates only 3d.png", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --pngs ${circuitPath}`)
+
+  const preview3d = await readFile(path.join(tmpDir, "dist", "3d.png"))
+  expect(preview3d.byteLength).toBeGreaterThan(0)
+  expect(preview3d[0]).toBe(0x89)
+  expect(preview3d[1]).toBe(0x50)
+  expect(preview3d[2]).toBe(0x4e)
+  expect(preview3d[3]).toBe(0x47)
+
+  await expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
+  await expect(
+    stat(path.join(tmpDir, "dist", "schematic.svg")),
+  ).rejects.toBeTruthy()
+}, 30_000)
+
+test("build --svgs generates only pcb.svg and schematic.svg", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --svgs ${circuitPath}`)
+
+  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  expect(pcbSvg).toContain("<svg")
+
+  const schematicSvg = await readFile(
+    path.join(tmpDir, "dist", "schematic.svg"),
+    "utf-8",
+  )
+  expect(schematicSvg).toContain("<svg")
+
+  await expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+}, 30_000)
+
+test("build --schematic-svgs generates only schematic.svg", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --schematic-svgs ${circuitPath}`)
+
+  const schematicSvg = await readFile(
+    path.join(tmpDir, "dist", "schematic.svg"),
+    "utf-8",
+  )
+  expect(schematicSvg).toContain("<svg")
+
+  await expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
+  await expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+}, 30_000)
+
+test("build legacy flags still work (--3d --pcb-only)", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --3d --pcb-only ${circuitPath}`)
+
+  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  expect(pcbSvg).toContain("<svg")
+
+  const preview3d = await readFile(path.join(tmpDir, "dist", "3d.png"))
+  expect(preview3d.byteLength).toBeGreaterThan(0)
+  expect(preview3d[0]).toBe(0x89)
+  expect(preview3d[1]).toBe(0x50)
+  expect(preview3d[2]).toBe(0x4e)
+  expect(preview3d[3]).toBe(0x47)
+
+  await expect(
+    stat(path.join(tmpDir, "dist", "schematic.svg")),
+  ).rejects.toBeTruthy()
+}, 30_000)

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -86,7 +86,7 @@ test("build --schematic-svgs generates only schematic.svg", async () => {
   await expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
 }, 30_000)
 
-test("build legacy flags still work (--3d --pcb-only)", async () => {
+test("build established flags still work (--3d --pcb-only)", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
   await writeFile(circuitPath, circuitCode)

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -21,10 +21,8 @@ test("build --pcb-svgs generates only pcb.svg", async () => {
   const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
   expect(pcbSvg).toContain("<svg")
 
-  await expect(
-    stat(path.join(tmpDir, "dist", "schematic.svg")),
-  ).rejects.toBeTruthy()
-  await expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "schematic.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --pngs generates only 3d.png", async () => {
@@ -42,10 +40,8 @@ test("build --pngs generates only 3d.png", async () => {
   expect(preview3d[2]).toBe(0x4e)
   expect(preview3d[3]).toBe(0x47)
 
-  await expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
-  await expect(
-    stat(path.join(tmpDir, "dist", "schematic.svg")),
-  ).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "schematic.svg"))).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --svgs generates only pcb.svg and schematic.svg", async () => {
@@ -65,7 +61,7 @@ test("build --svgs generates only pcb.svg and schematic.svg", async () => {
   )
   expect(schematicSvg).toContain("<svg")
 
-  await expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --schematic-svgs generates only schematic.svg", async () => {
@@ -82,8 +78,8 @@ test("build --schematic-svgs generates only schematic.svg", async () => {
   )
   expect(schematicSvg).toContain("<svg")
 
-  await expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
-  await expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
 }, 30_000)
 
 test("build established flags still work (--3d --pcb-only)", async () => {
@@ -104,7 +100,5 @@ test("build established flags still work (--3d --pcb-only)", async () => {
   expect(preview3d[2]).toBe(0x4e)
   expect(preview3d[3]).toBe(0x47)
 
-  await expect(
-    stat(path.join(tmpDir, "dist", "schematic.svg")),
-  ).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "schematic.svg"))).rejects.toBeTruthy()
 }, 30_000)


### PR DESCRIPTION


This PR adds granular preview output flags to `tsci build` so only requested assets are generated in the same build pass (no second build step). Since snapshot flows through build, this also enables snapshot-related preview generation to reuse the same single-pass pipeline. Worker/CI paths are included, and legacy compatibility (`--3d`, `--pcb-only`, `--schematic-only`) is preserved.