### PR TITLE
Accept unquoted multi-word queries in search/import CLI commands

### DIFF
--- a/cli/import/register.ts
+++ b/cli/import/register.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander"
 import kleur from "kleur"
+import { getQueryFromParts } from "cli/utils/get-query-from-parts"
 import { importComponentFromJlcpcb } from "lib/import/import-component-from-jlcpcb"
 import { getRegistryApiKy } from "lib/registry-api/get-ky"
 import { addPackage } from "lib/shared/add-package"
@@ -12,19 +13,20 @@ export const registerImport = (program: Command) => {
     .description(
       "Search JLCPCB or the tscircuit registry and import a component",
     )
-    .argument("<query>", "Chip name, part number, or package name")
+    .argument("<query...>", "Chip name, part number, or package name")
     .option("--jlcpcb", "Search JLCPCB components")
     .option("--lcsc", "Alias for --jlcpcb")
     .option("--tscircuit", "Search tscircuit registry packages")
     .action(
       async (
-        query: string,
+        queryParts: string[],
         opts: {
           jlcpcb?: boolean
           lcsc?: boolean
           tscircuit?: boolean
         },
       ) => {
+        const query = getQueryFromParts(queryParts)
         const hasFilters = opts.jlcpcb || opts.lcsc || opts.tscircuit
         const searchJlc = opts.jlcpcb || opts.lcsc || !hasFilters
         const searchTscircuit = opts.tscircuit || !hasFilters

--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander"
 import { getRegistryApiKy } from "lib/registry-api/get-ky"
 import Fuse from "fuse.js"
 import kleur from "kleur"
+import { getQueryFromParts } from "cli/utils/get-query-from-parts"
 
 export const registerSearch = (program: Command) => {
   program
@@ -9,7 +10,10 @@ export const registerSearch = (program: Command) => {
     .description(
       "Search for footprints, CAD models or packages in the tscircuit ecosystem",
     )
-    .argument("<query>", "Search query (e.g. keyword, author, or package name)")
+    .argument(
+      "<query...>",
+      "Search query (e.g. keyword, author, or package name)",
+    )
     .option("--kicad", "Search KiCad footprints")
     .option("--jlcpcb", "Search JLCPCB components")
     .option("--lcsc", "Alias for --jlcpcb")
@@ -17,7 +21,7 @@ export const registerSearch = (program: Command) => {
     .option("--json", "Output search results as JSON")
     .action(
       async (
-        query: string,
+        queryParts: string[],
         opts: {
           kicad?: boolean
           jlcpcb?: boolean
@@ -26,6 +30,7 @@ export const registerSearch = (program: Command) => {
           json?: boolean
         },
       ) => {
+        const query = getQueryFromParts(queryParts)
         const hasFilters =
           opts.kicad || opts.jlcpcb || opts.lcsc || opts.tscircuit
         const searchKicad = opts.kicad || !hasFilters

--- a/cli/utils/get-query-from-parts.test.ts
+++ b/cli/utils/get-query-from-parts.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { getQueryFromParts } from "./get-query-from-parts"
+
+describe("getQueryFromParts", () => {
+  test("joins multi-word query parts", () => {
+    expect(getQueryFromParts(["USB", "Type", "C", "receptacle", "16P"])).toBe(
+      "USB Type C receptacle 16P",
+    )
+  })
+
+  test("trims surrounding whitespace", () => {
+    expect(getQueryFromParts([" LED", "0603", "green "])).toBe("LED 0603 green")
+  })
+})

--- a/cli/utils/get-query-from-parts.ts
+++ b/cli/utils/get-query-from-parts.ts
@@ -1,0 +1,2 @@
+export const getQueryFromParts = (queryParts: string[]) =>
+  queryParts.join(" ").trim()


### PR DESCRIPTION
### Motivation
- The search and import CLI commands were brittle for autonomous/agent use because they required a single quoted query token and failed with "too many arguments" when callers passed unquoted multi-word queries.
- The intent is to make `search` and `import` resilient to common agent-driven argument shapes by accepting variadic positional arguments and normalizing them into a single query string.

### Description
- Change `search` to accept a variadic positional argument by replacing `.argument("<query>")` with `.argument("<query...>")` and reconstruct the query from parts. (`cli/search/register.ts`)
- Make the same variadic-argument change for `import` and reconstruct the query there as well. (`cli/import/register.ts`)
- Add a small helper `getQueryFromParts` to normalize the reconstructed query and add unit tests for it. (`cli/utils/get-query-from-parts.ts`, `cli/utils/get-query-from-parts.test.ts`)

### Testing
- Ran the unit tests with `bun test cli/utils/get-query-from-parts.test.ts` and they all passed. 
- Type-checked the project with `bunx tsc --noEmit` and it completed with no errors. 
- Exercised the CLI manually with `bun ./cli/main.ts search --jlcpcb USB Type C receptacle 16P --json` which produced the reconstructed query in the JSON output, and ran formatting with `bun run format` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae4fce0598832e9654318d035bbf66)