### PR TITLE
Adjust build completion output to report error/warning counts

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -11,6 +11,8 @@ export type BuildFileOutcome = {
   ok: boolean
   circuitJson?: AnyCircuitElement[]
   hasErrors?: boolean
+  errorCount?: number
+  warningCount?: number
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
 }
@@ -81,6 +83,8 @@ export const buildFile = async (
       ok: true,
       circuitJson,
       hasErrors: errors.length > 0 && !options?.ignoreErrors,
+      errorCount: errors.length,
+      warningCount: warnings.length,
     }
   } catch (err) {
     console.error(err)
@@ -91,6 +95,8 @@ export const buildFile = async (
     // Fatal error: circuit generation itself failed (not just analysis errors)
     return {
       ok: false,
+      errorCount: 1,
+      warningCount: 0,
       isFatalError: {
         errorType: "circuit_generation_failed",
         message: err instanceof Error ? err.message : String(err),

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -264,6 +264,8 @@ export const registerBuild = (program: Command) => {
 
         let hasErrors = false
         let hasFatalErrors = false
+        let totalErrorCount = 0
+        let totalWarningCount = 0
         const staticFileReferences: StaticBuildFileReference[] = []
 
         const builtFiles: BuildFileResult[] = []
@@ -318,6 +320,8 @@ export const registerBuild = (program: Command) => {
             ok: boolean
             circuitJson?: unknown[]
             hasErrors?: boolean
+            errorCount?: number
+            warningCount?: number
             isFatalError?: { errorType: string; message: string }
           },
         ) => {
@@ -333,6 +337,8 @@ export const registerBuild = (program: Command) => {
           if (buildOutcome.hasErrors) {
             hasErrors = true
           }
+          totalErrorCount += buildOutcome.errorCount ?? 0
+          totalWarningCount += buildOutcome.warningCount ?? 0
 
           if (!buildOutcome.ok) {
             hasErrors = true
@@ -506,6 +512,8 @@ export const registerBuild = (program: Command) => {
               await processBuildResult(result.filePath, result.outputPath, {
                 ok: result.ok,
                 hasErrors: result.hasErrors,
+                errorCount: result.errorCount,
+                warningCount: result.warningCount,
                 isFatalError: result.isFatalError,
               })
 
@@ -795,9 +803,9 @@ export const registerBuild = (program: Command) => {
           `  Output    ${kleur.dim(path.relative(process.cwd(), distDir) || "dist")}`,
         )
         console.log(
-          hasErrors
-            ? kleur.yellow("\n⚠ Build completed with errors")
-            : kleur.green("\n✓ Done"),
+          kleur.green(
+            `\nBuild Completed with ${totalErrorCount} errors and ${totalWarningCount} warnings`,
+          ),
         )
         if (shouldExitNonZero) {
           exitBuild(1, "fatal circuit build errors occurred")

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -87,7 +87,9 @@ export const handleBuildFile = async (
       }
     }
 
-    const hasErrors = diagnostics.errors.length > 0 && !options?.ignoreErrors
+    const errorCount = diagnostics.errors.length
+    const warningCount = diagnostics.warnings.length
+    const hasErrors = errorCount > 0 && !options?.ignoreErrors
     let glbOk: boolean | undefined
     let glbError: string | undefined
     let previewOk: boolean | undefined
@@ -139,6 +141,8 @@ export const handleBuildFile = async (
       preview_error: previewError,
       ok: true,
       hasErrors,
+      errorCount,
+      warningCount,
       errors,
       warnings,
       durationMs: options?.profile ? performance.now() - startedAt : undefined,
@@ -157,6 +161,8 @@ export const handleBuildFile = async (
       preview_output_dir: previewOutputDir,
       ok: false,
       hasErrors: true,
+      errorCount: 1,
+      warningCount: 0,
       isFatalError: {
         errorType: "circuit_generation_failed",
         message: errorMsg,

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -108,6 +108,8 @@ export async function buildFilesWithWorkerPool(options: {
         previewError: completedMessage.preview_error,
         ok: completedMessage.ok,
         hasErrors: completedMessage.hasErrors,
+        errorCount: completedMessage.errorCount,
+        warningCount: completedMessage.warningCount,
         isFatalError: completedMessage.isFatalError,
         errors: completedMessage.errors,
         warnings: completedMessage.warnings,

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -36,6 +36,8 @@ export type BuildCompletedMessage = {
   preview_error?: string
   ok: boolean
   hasErrors?: boolean
+  errorCount?: number
+  warningCount?: number
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
   errors: string[]
@@ -75,6 +77,8 @@ export type BuildJobResult = {
   previewError?: string
   ok: boolean
   hasErrors?: boolean
+  errorCount?: number
+  warningCount?: number
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
   errors: string[]

--- a/tests/cli/build/build-with-drc-error.test.ts
+++ b/tests/cli/build/build-with-drc-error.test.ts
@@ -29,5 +29,5 @@ test("build succeeds when circuit JSON is generated with DRC errors", async () =
   )
 
   expect(exitCode).toBe(0)
-  expect(stdout).toContain("Build completed with errors")
+  expect(stdout).toMatch(/Build Completed with \d+ errors and \d+ warnings/)
 }, 30_000)


### PR DESCRIPTION
### Motivation
- Make the final build summary a stronger, machine-parseable signal by reporting total diagnostic counts so artifact generation doesn't mask design errors. 
- Ensure worker and sequential build flows both contribute to a single aggregated error/warning tally.

### Description
- Add `errorCount` and `warningCount` to the `BuildFileOutcome`, worker `BuildCompletedMessage`, and `BuildJobResult` types so counts travel with build results (`cli/build/build-file.ts`, `cli/build/worker-types.ts`).
- Compute and propagate per-file diagnostic totals from `analyzeCircuitJson` in both the sequential and worker paths (`cli/build/build-file.ts`, `cli/build/worker-build-handlers.ts`).
- Accumulate totals in the main build command and replace the previous success/failed line with: `Build Completed with ${totalErrorCount} errors and ${totalWarningCount} warnings` (`cli/build/register.ts`).
- Wire count propagation through the worker pool result mapping and update a unit test to assert the new completion format (`cli/build/worker-pool.ts`, `tests/cli/build/build-with-drc-error.test.ts`).

### Testing
- Ran `bun test tests/cli/build/build-with-drc-error.test.ts` and it passed. 
- Ran `bunx tsc --noEmit` to typecheck and it completed successfully. 
- Ran `bun run format` to format changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae5d2c5164832ea939cd0168d59410)