### PR TITLE
feat: add allowedSources policy to restrict tsci import sources

### DIFF
--- a/cli/import/register.ts
+++ b/cli/import/register.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander"
 import kleur from "kleur"
 import { getQueryFromParts } from "cli/utils/get-query-from-parts"
 import { importComponentFromJlcpcb } from "lib/import/import-component-from-jlcpcb"
+import { loadProjectConfig } from "lib/project-config"
 import { getRegistryApiKy } from "lib/registry-api/get-ky"
 import { addPackage } from "lib/shared/add-package"
 import { prompts } from "lib/utils/prompts"
@@ -28,8 +29,41 @@ export const registerImport = (program: Command) => {
       ) => {
         const query = getQueryFromParts(queryParts)
         const hasFilters = opts.jlcpcb || opts.lcsc || opts.tscircuit
-        const searchJlc = opts.jlcpcb || opts.lcsc || !hasFilters
-        const searchTscircuit = opts.tscircuit || !hasFilters
+        let searchJlc = opts.jlcpcb || opts.lcsc || !hasFilters
+        let searchTscircuit = opts.tscircuit || !hasFilters
+
+        // Enforce project-level source policy from tscircuit.config.json
+        const projectConfig = loadProjectConfig(process.cwd())
+        const allowedSources = projectConfig?.allowedSources
+        if (allowedSources) {
+          if (
+            (opts.jlcpcb || opts.lcsc) &&
+            !allowedSources.includes("jlcpcb")
+          ) {
+            console.error(
+              kleur.red(
+                `Import from JLCPCB is not allowed by this project's policy.\n` +
+                  `Allowed sources: ${allowedSources.join(", ")}\n` +
+                  `To change this, update "allowedSources" in tscircuit.config.json.`,
+              ),
+            )
+            process.exit(1)
+          }
+          if (opts.tscircuit && !allowedSources.includes("tscircuit")) {
+            console.error(
+              kleur.red(
+                `Import from the tscircuit registry is not allowed by this project's policy.\n` +
+                  `Allowed sources: ${allowedSources.join(", ")}\n` +
+                  `To change this, update "allowedSources" in tscircuit.config.json.`,
+              ),
+            )
+            process.exit(1)
+          }
+          // Restrict default (unflagged) searches to allowed sources
+          if (!allowedSources.includes("jlcpcb")) searchJlc = false
+          if (!allowedSources.includes("tscircuit")) searchTscircuit = false
+        }
+
         const ky = getRegistryApiKy()
         const spinner = ora("Searching...").start()
 
@@ -84,7 +118,7 @@ export const registerImport = (program: Command) => {
         if (!registryResults.length && !jlcResults?.length) {
           console.log(
             kleur.yellow(
-              `No results found for "${query}" in the tscircuit registry or JLCPCB.`,
+              `No results found for "${query}" in ${[searchTscircuit && "tscircuit registry", searchJlc && "JLCPCB"].filter(Boolean).join(" or ")}.`,
             ),
           )
           return

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -13,6 +13,12 @@ export const projectConfigSchema = z.object({
   kicadProjectEntrypointPath: z.string().optional(),
   kicadLibraryEntrypointPath: z.string().optional(),
   kicadLibraryName: z.string().optional(),
+  allowedSources: z
+    .array(z.enum(["jlcpcb", "tscircuit"]))
+    .optional()
+    .describe(
+      "Restrict which sources tsci import may pull from. Omit to allow all.",
+    ),
   alwaysUseLatestTscircuitOnCloud: z.boolean().optional(),
   build: z
     .object({

--- a/tests/cli/import/import-allowed-sources.test.ts
+++ b/tests/cli/import/import-allowed-sources.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test"
+import { join } from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("import respects allowedSources: jlcpcb-only policy blocks --tscircuit flag", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await Bun.write(
+    join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ allowedSources: ["jlcpcb"] }),
+  )
+
+  const { stderr, exitCode } = await runCommand("tsci import --tscircuit 555")
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toMatchInlineSnapshot(`
+    "Import from the tscircuit registry is not allowed by this project's policy.
+    Allowed sources: jlcpcb
+    To change this, update "allowedSources" in tscircuit.config.json.
+    "
+  `)
+})
+
+test("import respects allowedSources: tscircuit-only policy blocks --jlcpcb flag", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await Bun.write(
+    join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ allowedSources: ["tscircuit"] }),
+  )
+
+  const { stderr, exitCode } = await runCommand("tsci import --jlcpcb 555")
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toMatchInlineSnapshot(`
+    "Import from JLCPCB is not allowed by this project's policy.
+    Allowed sources: tscircuit
+    To change this, update "allowedSources" in tscircuit.config.json.
+    "
+  `)
+})
+
+test("import with no config has no source restrictions", async () => {
+  const { runCommand } = await getCliTestFixture()
+
+  const { stderr } = await runCommand("tsci import --tscircuit 555")
+
+  expect(stderr).not.toContain("not allowed by this project's policy")
+})
+
+test("import with allowedSources both sources has no restrictions", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await Bun.write(
+    join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ allowedSources: ["jlcpcb", "tscircuit"] }),
+  )
+
+  const { stderr } = await runCommand("tsci import --tscircuit 555")
+
+  expect(stderr).not.toContain("not allowed by this project's policy")
+})

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -64,6 +64,14 @@
       "type": "string",
       "description": "Name for the generated KiCad library. Falls back to package.json name, then directory name."
     },
+    "allowedSources": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["jlcpcb", "tscircuit"]
+      },
+      "description": "Restrict which sources tsci import may pull from. Omit to allow all sources."
+    },
     "alwaysUseLatestTscircuitOnCloud": {
       "type": "boolean",
       "description": "Always use the latest TSCircuit version when building on the cloud."


### PR DESCRIPTION
Ref https://github.com/tscircuit/agent-benchmarking-2026-02/issues/5

![Screenshot_2026-03-09-19-17-36-44_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/user-attachments/assets/ecad2dcc-bf5f-4f45-82d3-73098006fcd5)

Adds a project-level allowedSources field to `tscircuit.config.json` that controls which sources tsci import is allowed to pull components from.

**Behaviour**
- Omitting allowedSources keeps the current behaviour — both JLCPCB and the tscircuit registry are searched
- Setting `allowedSources: ["jlcpcb"]` restricts import to JLCPCB only; using `--tscircuit` fails immediately with a clear error pointing to the config
- Setting `allowedSources: ["tscircuit"]` restricts to the tscircuit registry only; `--jlcpcb` and `--lcsc` are both blocked