### PR TITLE
Fix Build Output Consistency: Generate SVG/PNG Assets Per Circuit Directory

### DIFF
--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -199,7 +199,7 @@ export const buildPreviewImages = async ({
 
   await generatePreviewAssets({
     build: previewBuild,
-    outputDir: distDir,
+    outputDir: path.dirname(previewBuild.outputPath),
     distDir,
     imageFormats,
   })

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -472,11 +472,9 @@ export const registerBuild = (program: Command) => {
             })()
 
             const previewOutputDir =
-              shouldGeneratePreviewAssetsInWorker &&
-              generatePreviewAssets &&
-              !shouldGenerateAllPreviewImages
-                ? distDir
-                : path.join(distDir, outputDirName)
+              shouldGeneratePreviewAssetsInWorker && generatePreviewAssets
+                ? path.join(distDir, outputDirName)
+                : undefined
 
             return {
               filePath,

--- a/tests/cli/build/build-config-options.test.ts
+++ b/tests/cli/build/build-config-options.test.ts
@@ -90,12 +90,13 @@ test("build uses config build.previewImages setting", async () => {
 
   await runCommand(`tsci build ${circuitPath}`)
 
+  const outputDir = path.join(tmpDir, "dist", "preview")
   const schematicSvg = await readFile(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(outputDir, "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
-  const preview3d = await readFile(path.join(tmpDir, "dist", "3d.png"))
+  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  const preview3d = await readFile(path.join(outputDir, "3d.png"))
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")
@@ -173,7 +174,7 @@ test("CLI options override config build settings", async () => {
   expect(stdout).toContain("Generating preview images")
 
   const schematicSvgExists = await stat(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(tmpDir, "dist", "override", "schematic.svg"),
   )
     .then(() => true)
     .catch(() => false)
@@ -194,7 +195,9 @@ test("build without config or CLI options does not generate optional outputs", a
   )
   expect(JSON.parse(circuitJson)).toBeTruthy()
 
-  expect(stat(path.join(tmpDir, "dist", "schematic.svg"))).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "plain", "schematic.svg")),
+  ).rejects.toBeTruthy()
   expect(stat(path.join(tmpDir, "dist", "plain", "kicad"))).rejects.toBeTruthy()
 })
 
@@ -221,7 +224,7 @@ test("build with multiple config build options", async () => {
   expect((await stat(kicadDir)).isDirectory()).toBe(true)
 
   const schematicSvgExists = await stat(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(tmpDir, "dist", "multi", "schematic.svg"),
   )
     .then(() => true)
     .catch(() => false)
@@ -250,7 +253,7 @@ test("build with --ignore-config skips config options", async () => {
   expect(stdout).not.toContain("(from tscircuit.config.json)")
 
   const schematicSvgExists = await stat(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(tmpDir, "dist", "ignore-config", "schematic.svg"),
   )
     .then(() => true)
     .catch(() => false)

--- a/tests/cli/build/build-config-options.test.ts
+++ b/tests/cli/build/build-config-options.test.ts
@@ -90,13 +90,17 @@ test("build uses config build.previewImages setting", async () => {
 
   await runCommand(`tsci build ${circuitPath}`)
 
-  const outputDir = path.join(tmpDir, "dist", "preview")
   const schematicSvg = await readFile(
-    path.join(outputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "preview", "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
-  const preview3d = await readFile(path.join(outputDir, "3d.png"))
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
+  const preview3d = await readFile(
+    path.join(tmpDir, "dist", "preview", "3d.png"),
+  )
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -13,92 +13,134 @@ export default () => (
 test("build --pcb-svgs generates only pcb.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --pcb-svgs ${circuitPath}`)
 
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
   expect(pcbSvg).toContain("<svg")
 
-  expect(stat(path.join(tmpDir, "dist", "schematic.svg"))).rejects.toBeTruthy()
-  expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "schematic.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --pngs generates only 3d.png", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --pngs ${circuitPath}`)
 
-  const preview3d = await readFile(path.join(tmpDir, "dist", "3d.png"))
+  const preview3d = await readFile(path.join(outputDir, "3d.png"))
   expect(preview3d.byteLength).toBeGreaterThan(0)
   expect(preview3d[0]).toBe(0x89)
   expect(preview3d[1]).toBe(0x50)
   expect(preview3d[2]).toBe(0x4e)
   expect(preview3d[3]).toBe(0x47)
 
-  expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
-  expect(stat(path.join(tmpDir, "dist", "schematic.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "pcb.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "schematic.svg"))).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --svgs generates only pcb.svg and schematic.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --svgs ${circuitPath}`)
 
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
   expect(pcbSvg).toContain("<svg")
 
   const schematicSvg = await readFile(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(outputDir, "schematic.svg"),
     "utf-8",
   )
   expect(schematicSvg).toContain("<svg")
 
-  expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --schematic-svgs generates only schematic.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --schematic-svgs ${circuitPath}`)
 
   const schematicSvg = await readFile(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(outputDir, "schematic.svg"),
     "utf-8",
   )
   expect(schematicSvg).toContain("<svg")
 
-  expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
-  expect(stat(path.join(tmpDir, "dist", "3d.png"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "pcb.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
 }, 30_000)
 
-test("build established flags still work (--3d --pcb-only)", async () => {
+test("build --3d generates pcb.svg, schematic.svg, and 3d.png", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
-  await runCommand(`tsci build --3d --pcb-only ${circuitPath}`)
+  await runCommand(`tsci build --3d ${circuitPath}`)
 
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
   expect(pcbSvg).toContain("<svg")
 
-  const preview3d = await readFile(path.join(tmpDir, "dist", "3d.png"))
+  const schematicSvg = await readFile(
+    path.join(outputDir, "schematic.svg"),
+    "utf-8",
+  )
+  expect(schematicSvg).toContain("<svg")
+
+  const preview3d = await readFile(path.join(outputDir, "3d.png"))
   expect(preview3d.byteLength).toBeGreaterThan(0)
   expect(preview3d[0]).toBe(0x89)
   expect(preview3d[1]).toBe(0x50)
   expect(preview3d[2]).toBe(0x4e)
   expect(preview3d[3]).toBe(0x47)
+}, 30_000)
 
-  expect(stat(path.join(tmpDir, "dist", "schematic.svg"))).rejects.toBeTruthy()
+test("build --pcb-only generates only pcb.svg", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  const outputDir = path.join(tmpDir, "dist", "preview")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --pcb-only ${circuitPath}`)
+
+  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  expect(pcbSvg).toContain("<svg")
+  expect(stat(path.join(outputDir, "schematic.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
+}, 30_000)
+
+test("build --schematic-only generates only schematic.svg", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  const outputDir = path.join(tmpDir, "dist", "preview")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --schematic-only ${circuitPath}`)
+
+  const schematicSvg = await readFile(
+    path.join(outputDir, "schematic.svg"),
+    "utf-8",
+  )
+  expect(schematicSvg).toContain("<svg")
+  expect(stat(path.join(outputDir, "pcb.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
 }, 30_000)

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -13,98 +13,120 @@ export default () => (
 test("build --pcb-svgs generates only pcb.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
-  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --pcb-svgs ${circuitPath}`)
 
-  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
   expect(pcbSvg).toContain("<svg")
 
-  expect(stat(path.join(outputDir, "schematic.svg"))).rejects.toBeTruthy()
-  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "schematic.svg")),
+  ).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "3d.png")),
+  ).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --pngs generates only 3d.png", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
-  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --pngs ${circuitPath}`)
 
-  const preview3d = await readFile(path.join(outputDir, "3d.png"))
+  const preview3d = await readFile(
+    path.join(tmpDir, "dist", "preview", "3d.png"),
+  )
   expect(preview3d.byteLength).toBeGreaterThan(0)
   expect(preview3d[0]).toBe(0x89)
   expect(preview3d[1]).toBe(0x50)
   expect(preview3d[2]).toBe(0x4e)
   expect(preview3d[3]).toBe(0x47)
 
-  expect(stat(path.join(outputDir, "pcb.svg"))).rejects.toBeTruthy()
-  expect(stat(path.join(outputDir, "schematic.svg"))).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "pcb.svg")),
+  ).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "schematic.svg")),
+  ).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --svgs generates only pcb.svg and schematic.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
-  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --svgs ${circuitPath}`)
 
-  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
   expect(pcbSvg).toContain("<svg")
 
   const schematicSvg = await readFile(
-    path.join(outputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "preview", "schematic.svg"),
     "utf-8",
   )
   expect(schematicSvg).toContain("<svg")
 
-  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "3d.png")),
+  ).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --schematic-svgs generates only schematic.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
-  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --schematic-svgs ${circuitPath}`)
 
   const schematicSvg = await readFile(
-    path.join(outputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "preview", "schematic.svg"),
     "utf-8",
   )
   expect(schematicSvg).toContain("<svg")
 
-  expect(stat(path.join(outputDir, "pcb.svg"))).rejects.toBeTruthy()
-  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "pcb.svg")),
+  ).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "3d.png")),
+  ).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --3d generates pcb.svg, schematic.svg, and 3d.png", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
-  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --3d ${circuitPath}`)
 
-  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
   expect(pcbSvg).toContain("<svg")
 
   const schematicSvg = await readFile(
-    path.join(outputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "preview", "schematic.svg"),
     "utf-8",
   )
   expect(schematicSvg).toContain("<svg")
 
-  const preview3d = await readFile(path.join(outputDir, "3d.png"))
+  const preview3d = await readFile(
+    path.join(tmpDir, "dist", "preview", "3d.png"),
+  )
   expect(preview3d.byteLength).toBeGreaterThan(0)
   expect(preview3d[0]).toBe(0x89)
   expect(preview3d[1]).toBe(0x50)
@@ -115,32 +137,41 @@ test("build --3d generates pcb.svg, schematic.svg, and 3d.png", async () => {
 test("build --pcb-only generates only pcb.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
-  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --pcb-only ${circuitPath}`)
 
-  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
   expect(pcbSvg).toContain("<svg")
-  expect(stat(path.join(outputDir, "schematic.svg"))).rejects.toBeTruthy()
-  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "schematic.svg")),
+  ).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "3d.png")),
+  ).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --schematic-only generates only schematic.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
-  const outputDir = path.join(tmpDir, "dist", "preview")
   await writeFile(circuitPath, circuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
   await runCommand(`tsci build --schematic-only ${circuitPath}`)
 
   const schematicSvg = await readFile(
-    path.join(outputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "preview", "schematic.svg"),
     "utf-8",
   )
   expect(schematicSvg).toContain("<svg")
-  expect(stat(path.join(outputDir, "pcb.svg"))).rejects.toBeTruthy()
-  expect(stat(path.join(outputDir, "3d.png"))).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "pcb.svg")),
+  ).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "3d.png")),
+  ).rejects.toBeTruthy()
 }, 30_000)

--- a/tests/cli/build/build-with-concurrency-client-server-pattern.test.ts
+++ b/tests/cli/build/build-with-concurrency-client-server-pattern.test.ts
@@ -42,7 +42,9 @@ test("build with --ci generates index.html and circuit.json", async () => {
   expect(stdout).toContain("[second] Written 3d.glb")
   expect(stdout).toContain("[third] Written 3d.glb")
 
-  expect(stdout).toContain("Generating preview assets for dist in same worker")
+  expect(stdout).toContain(
+    "Generating preview assets for dist/first in same worker",
+  )
   expect(stdout).toContain("Generating preview images in worker threads")
   expect(stdout).not.toContain("Generating preview images for all builds")
   expect(stdout).not.toContain("Generating GLB models for all builds")

--- a/tests/cli/build/build-with-concurrency-generate-site.test.ts
+++ b/tests/cli/build/build-with-concurrency-generate-site.test.ts
@@ -1,6 +1,6 @@
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 import { test, expect } from "bun:test"
-import { writeFile, readFile, stat } from "node:fs/promises"
+import { writeFile, stat } from "node:fs/promises"
 import path from "node:path"
 
 const circuitCode = `
@@ -22,10 +22,29 @@ test("build with --ci generates index.html and circuit.json", async () => {
   expect(await stat(circuitJsonPath).then((stats) => stats.isFile())).toBe(true)
   const indexHtmlPath = path.join(tmpDir, "dist", "index.html")
   expect(await stat(indexHtmlPath).then((stats) => stats.isFile())).toBe(true)
-  const schematicSvgPath = path.join(tmpDir, "dist", "schematic.svg")
+  const outputDir = path.join(tmpDir, "dist", "index")
+  const schematicSvgPath = path.join(outputDir, "schematic.svg")
   expect(await stat(schematicSvgPath).then((stats) => stats.isFile())).toBe(
     true,
   )
-  const pcbSvgPath = path.join(tmpDir, "dist", "pcb.svg")
+  const pcbSvgPath = path.join(outputDir, "pcb.svg")
   expect(await stat(pcbSvgPath).then((stats) => stats.isFile())).toBe(true)
+}, 30_000)
+
+test("build --pngs --ci --concurrency 2 writes only 3d.png for selected build", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "index.tsx")
+  await writeFile(circuitPath, circuitCode)
+
+  await runCommand(`tsci install`)
+  await runCommand(`tsci build --ci --concurrency 2 --pngs`)
+
+  const outputDir = path.join(tmpDir, "dist", "index")
+  const pngPath = path.join(outputDir, "3d.png")
+  const pcbSvgPath = path.join(outputDir, "pcb.svg")
+  const schematicSvgPath = path.join(outputDir, "schematic.svg")
+
+  expect(await stat(pngPath).then((stats) => stats.isFile())).toBe(true)
+  await expect(stat(pcbSvgPath)).rejects.toBeTruthy()
+  await expect(stat(schematicSvgPath)).rejects.toBeTruthy()
 }, 30_000)

--- a/tests/cli/build/build-with-concurrency-generate-site.test.ts
+++ b/tests/cli/build/build-with-concurrency-generate-site.test.ts
@@ -22,12 +22,11 @@ test("build with --ci generates index.html and circuit.json", async () => {
   expect(await stat(circuitJsonPath).then((stats) => stats.isFile())).toBe(true)
   const indexHtmlPath = path.join(tmpDir, "dist", "index.html")
   expect(await stat(indexHtmlPath).then((stats) => stats.isFile())).toBe(true)
-  const outputDir = path.join(tmpDir, "dist", "index")
-  const schematicSvgPath = path.join(outputDir, "schematic.svg")
+  const schematicSvgPath = path.join(tmpDir, "dist", "index", "schematic.svg")
   expect(await stat(schematicSvgPath).then((stats) => stats.isFile())).toBe(
     true,
   )
-  const pcbSvgPath = path.join(outputDir, "pcb.svg")
+  const pcbSvgPath = path.join(tmpDir, "dist", "index", "pcb.svg")
   expect(await stat(pcbSvgPath).then((stats) => stats.isFile())).toBe(true)
 }, 30_000)
 
@@ -39,10 +38,9 @@ test("build --pngs --ci --concurrency 2 writes only 3d.png for selected build", 
   await runCommand(`tsci install`)
   await runCommand(`tsci build --ci --concurrency 2 --pngs`)
 
-  const outputDir = path.join(tmpDir, "dist", "index")
-  const pngPath = path.join(outputDir, "3d.png")
-  const pcbSvgPath = path.join(outputDir, "pcb.svg")
-  const schematicSvgPath = path.join(outputDir, "schematic.svg")
+  const pngPath = path.join(tmpDir, "dist", "index", "3d.png")
+  const pcbSvgPath = path.join(tmpDir, "dist", "index", "pcb.svg")
+  const schematicSvgPath = path.join(tmpDir, "dist", "index", "schematic.svg")
 
   expect(await stat(pngPath).then((stats) => stats.isFile())).toBe(true)
   await expect(stat(pcbSvgPath)).rejects.toBeTruthy()

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -197,12 +197,13 @@ test("build with --preview-images generates preview assets", async () => {
 
   await runCommand(`tsci build --preview-images ${circuitPath}`)
 
+  const outputDir = path.join(tmpDir, "dist", "preview")
   const schematicSvg = await readFile(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(outputDir, "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
-  const preview3d = await readFile(path.join(tmpDir, "dist", "3d.png"))
+  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  const preview3d = await readFile(path.join(outputDir, "3d.png"))
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")
@@ -323,12 +324,13 @@ test("build with --preview-images generates preview assets with GLB cad_model", 
   expect(stderr).not.toContain("ERR_INVALID_URL")
 
   // Preview images should be generated successfully
+  const outputDir = path.join(tmpDir, "dist", "glb-preview")
   const schematicSvg = await readFile(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(outputDir, "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
-  const preview3d = await readFile(path.join(tmpDir, "dist", "3d.png"))
+  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  const preview3d = await readFile(path.join(outputDir, "3d.png"))
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -197,13 +197,17 @@ test("build with --preview-images generates preview assets", async () => {
 
   await runCommand(`tsci build --preview-images ${circuitPath}`)
 
-  const outputDir = path.join(tmpDir, "dist", "preview")
   const schematicSvg = await readFile(
-    path.join(outputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "preview", "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
-  const preview3d = await readFile(path.join(outputDir, "3d.png"))
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
+  const preview3d = await readFile(
+    path.join(tmpDir, "dist", "preview", "3d.png"),
+  )
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")
@@ -324,13 +328,17 @@ test("build with --preview-images generates preview assets with GLB cad_model", 
   expect(stderr).not.toContain("ERR_INVALID_URL")
 
   // Preview images should be generated successfully
-  const outputDir = path.join(tmpDir, "dist", "glb-preview")
   const schematicSvg = await readFile(
-    path.join(outputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "glb-preview", "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
-  const preview3d = await readFile(path.join(outputDir, "3d.png"))
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "glb-preview", "pcb.svg"),
+    "utf-8",
+  )
+  const preview3d = await readFile(
+    path.join(tmpDir, "dist", "glb-preview", "3d.png"),
+  )
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")

--- a/tests/cli/build/preview-component-path/preview-build-selection-fallback-main.test.ts
+++ b/tests/cli/build/preview-component-path/preview-build-selection-fallback-main.test.ts
@@ -40,11 +40,12 @@ test("build --preview-images falls back to mainEntrypoint when no previewCompone
   await runCommand("tsci build --preview-images")
 
   // Check that preview images were generated
+  const previewOutputDir = path.join(tmpDir, "dist", "index")
   const schematicSvg = await readFile(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(previewOutputDir, "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(path.join(previewOutputDir, "pcb.svg"), "utf-8")
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")

--- a/tests/cli/build/preview-component-path/preview-build-selection-fallback-main.test.ts
+++ b/tests/cli/build/preview-component-path/preview-build-selection-fallback-main.test.ts
@@ -40,12 +40,14 @@ test("build --preview-images falls back to mainEntrypoint when no previewCompone
   await runCommand("tsci build --preview-images")
 
   // Check that preview images were generated
-  const previewOutputDir = path.join(tmpDir, "dist", "index")
   const schematicSvg = await readFile(
-    path.join(previewOutputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "index", "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(previewOutputDir, "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "index", "pcb.svg"),
+    "utf-8",
+  )
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")

--- a/tests/cli/build/preview-component-path/preview-build-selection-precedence.test.ts
+++ b/tests/cli/build/preview-component-path/preview-build-selection-precedence.test.ts
@@ -55,11 +55,12 @@ test("build --preview-images previewComponentPath takes precedence over mainEntr
   await runCommand("tsci build --preview-images")
 
   // Both should be built, but preview images should come from previewComponentPath
+  const previewOutputDir = path.join(tmpDir, "dist", "examples", "demo")
   const schematicSvg = await readFile(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(previewOutputDir, "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(path.join(previewOutputDir, "pcb.svg"), "utf-8")
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")

--- a/tests/cli/build/preview-component-path/preview-build-selection-precedence.test.ts
+++ b/tests/cli/build/preview-component-path/preview-build-selection-precedence.test.ts
@@ -55,12 +55,14 @@ test("build --preview-images previewComponentPath takes precedence over mainEntr
   await runCommand("tsci build --preview-images")
 
   // Both should be built, but preview images should come from previewComponentPath
-  const previewOutputDir = path.join(tmpDir, "dist", "examples", "demo")
   const schematicSvg = await readFile(
-    path.join(previewOutputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "examples", "demo", "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(previewOutputDir, "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "examples", "demo", "pcb.svg"),
+    "utf-8",
+  )
 
   expect(schematicSvg).toContain("<svg")
   expect(pcbSvg).toContain("<svg")

--- a/tests/cli/build/preview-component-path/preview-component-path-from-config.test.ts
+++ b/tests/cli/build/preview-component-path/preview-component-path-from-config.test.ts
@@ -55,11 +55,12 @@ test("build --preview-images uses previewComponentPath from config", async () =>
   await runCommand("tsci build --preview-images")
 
   // Check that preview images were generated
+  const previewOutputDir = path.join(tmpDir, "dist", "examples", "showcase")
   const schematicSvg = await readFile(
-    path.join(tmpDir, "dist", "schematic.svg"),
+    path.join(previewOutputDir, "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(tmpDir, "dist", "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(path.join(previewOutputDir, "pcb.svg"), "utf-8")
 
   // The preview should be valid SVGs
   expect(schematicSvg).toContain("<svg")

--- a/tests/cli/build/preview-component-path/preview-component-path-from-config.test.ts
+++ b/tests/cli/build/preview-component-path/preview-component-path-from-config.test.ts
@@ -55,12 +55,14 @@ test("build --preview-images uses previewComponentPath from config", async () =>
   await runCommand("tsci build --preview-images")
 
   // Check that preview images were generated
-  const previewOutputDir = path.join(tmpDir, "dist", "examples", "showcase")
   const schematicSvg = await readFile(
-    path.join(previewOutputDir, "schematic.svg"),
+    path.join(tmpDir, "dist", "examples", "showcase", "schematic.svg"),
     "utf-8",
   )
-  const pcbSvg = await readFile(path.join(previewOutputDir, "pcb.svg"), "utf-8")
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "examples", "showcase", "pcb.svg"),
+    "utf-8",
+  )
 
   // The preview should be valid SVGs
   expect(schematicSvg).toContain("<svg")


### PR DESCRIPTION
## Summary
This change makes build image outputs consistent across sequential and worker builds: generated files now live next to each circuit’s `circuit.json` in `dist/<outputDir>/`.

It keeps existing flag semantics (`--svgs`, `--pcb-svgs`, `--schematic-svgs`, `--pngs`, `--3d`, `--pcb-only`, `--schematic-only`) and updates tests to lock the new path behavior.

## Multi-file dist example

Input files:
- `index.tsx`
- `lib/dir-1/circuit-1/circuitExampl.tsx`

Output:
```txt
dist/
  index/
    circuit.json
    pcb.svg
    schematic.svg
    3d.png
  lib/dir-1/circuit-1/
    circuit.json
    pcb.svg
    schematic.svg
    3d.png
