### PR TITLE
Add `--compress` flag to `tsci push` to enable archive uploads

### DIFF
--- a/cli/push/register.ts
+++ b/cli/push/register.ts
@@ -12,6 +12,10 @@ export const registerPush = (program: Command) => {
       "Publish as a non-latest version using the provided tag",
     )
     .option("--include-dist", "Include the dist directory in the push")
+    .option(
+      "--compress",
+      "Compress project files into a single archive upload for faster pushes",
+    )
     .action(
       async (
         filePath?: string,
@@ -19,6 +23,7 @@ export const registerPush = (program: Command) => {
           private?: boolean
           versionTag?: string
           includeDist?: boolean
+          compress?: boolean
         } = {},
       ) => {
         await pushSnippet({
@@ -26,6 +31,7 @@ export const registerPush = (program: Command) => {
           isPrivate: options.private ?? false,
           versionTag: options.versionTag,
           includeDist: options.includeDist ?? false,
+          compress: options.compress ?? false,
           onExit: (code) => process.exit(code),
           onError: (message) => console.error(message),
           onSuccess: (message) => console.log(message),

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -21,6 +21,7 @@ type PushOptions = {
   isPrivate?: boolean
   versionTag?: string
   includeDist?: boolean
+  compress?: boolean
   log?: (message: string) => void
   onExit?: (code: number) => void
   onError?: (message: string) => void
@@ -59,6 +60,7 @@ export const pushSnippet = async ({
   isPrivate,
   versionTag,
   includeDist = false,
+  compress = false,
   log = console.log,
   onExit = (code) => process.exit(code),
   onError = (message) => console.error(message),
@@ -354,7 +356,7 @@ export const pushSnippet = async ({
   } = { succeeded: [], failed: [] }
 
   const packageNameWithVersion = `${scopedPackageName}@${releaseVersion}`
-  const shouldUploadArchive = process.env.TSCI_PUSH_ARCHIVE === "1"
+  const shouldUploadArchive = compress || process.env.TSCI_PUSH_ARCHIVE === "1"
 
   if (shouldUploadArchive) {
     log(kleur.gray("Uploading package archive..."))

--- a/tests/cli/push/push14-upload-archive.test.ts
+++ b/tests/cli/push/push14-upload-archive.test.ts
@@ -35,3 +35,27 @@ test("should attempt archive upload when TSCI_PUSH_ARCHIVE is enabled", async ()
   expect(stdout).toContain("⬆︎ snippet.tsx")
   expect(stdout).toContain('"@tsci/test-user.test-package@1.0.0" published!')
 }, 30_000)
+
+test("should attempt archive upload when --compress is passed", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture({ loggedIn: true })
+  const snippetFilePath = path.resolve(tmpDir, "snippet.tsx")
+
+  fs.writeFileSync(snippetFilePath, "// Snippet content")
+  fs.writeFileSync(
+    path.resolve(tmpDir, "package.json"),
+    JSON.stringify({ name: "@tsci/test-user.test-package", version: "1.0.0" }),
+  )
+
+  const { stdout, stderr } = await runCommand(
+    `tsci push ${snippetFilePath} --compress`,
+  )
+
+  expect(stderr).toBe("")
+  expect(stdout).toContain("Uploading package archive...")
+  expect(stdout).toContain(
+    "Archive upload failed, falling back to file-by-file upload",
+  )
+  expect(stdout).toContain("⬆︎ package.json")
+  expect(stdout).toContain("⬆︎ snippet.tsx")
+  expect(stdout).toContain('"@tsci/test-user.test-package@1.0.0" published!')
+}, 30_000)


### PR DESCRIPTION
### Motivation

- Improve push performance by allowing the CLI to upload a single compressed archive of the project instead of per-file uploads.
- Provide an explicit CLI switch so users can opt into archive uploads without relying on the environment flag `TSCI_PUSH_ARCHIVE`.

### Description

- Add a new `--compress` option to the `tsci push` command and thread it into `pushSnippet` via `cli/push/register.ts`.
- Extend `PushOptions` with a `compress?: boolean` and default it to `false` in `lib/shared/push-snippet.ts`.
- Enable archive upload when `compress` is true or when `TSCI_PUSH_ARCHIVE=1` by changing the `shouldUploadArchive` gate to `compress || process.env.TSCI_PUSH_ARCHIVE === "1"` in `lib/shared/push-snippet.ts`.
- Add an integration test `tests/cli/push/push14-upload-archive.test.ts` that asserts `--compress` triggers the archive upload attempt and falls back to per-file upload when the archive endpoint is unavailable.

### Testing

- Ran `bun test tests/cli/push/push14-upload-archive.test.ts` and the new test passed (the archive attempt is made and the fallback behavior is exercised). 
- Ran `bunx tsc --noEmit` which failed due to pre-existing type errors in `cli/build/generate-kicad-project.ts` unrelated to this change.
- Ran `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0a15416fc832e8103f9a69bbdcecc)