### PR TITLE
Add `tsci registry packages create` command

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -29,6 +29,9 @@ import { registerInit } from "./init/register"
 import { registerInstall } from "./install/register"
 import { registerPush } from "./push/register"
 import { registerRemove } from "./remove/register"
+import { registerRegistryPackagesCreate } from "./registry/packages/create/register"
+import { registerRegistryPackages } from "./registry/packages/register"
+import { registerRegistry } from "./registry/register"
 import { registerSearch } from "./search/register"
 import { registerSetup } from "./setup/register"
 import { registerSimulate } from "./simulate/register"
@@ -74,6 +77,10 @@ registerCheck(program)
 registerCheckNetlist(program)
 registerCheckPlacement(program)
 registerCheckRouting(program)
+
+registerRegistry(program)
+registerRegistryPackages(program)
+registerRegistryPackagesCreate(program)
 
 registerSearch(program)
 registerImport(program)

--- a/cli/registry/packages/create/register.ts
+++ b/cli/registry/packages/create/register.ts
@@ -1,0 +1,78 @@
+import type { Command } from "commander"
+import { getRegistryApiKy } from "lib/registry-api/get-ky"
+import kleur from "kleur"
+
+interface RegistryPackagesCreateOptions {
+  packageName: string
+  org?: string
+  unlisted?: boolean
+  private?: boolean
+  public?: boolean
+}
+
+export const getRegistryPackageName = ({
+  packageName,
+  org,
+}: {
+  packageName: string
+  org?: string
+}) => {
+  if (!org) return packageName
+  return `@tsci/${org}.${packageName}`
+}
+
+export const getIsPrivateFromOptions = ({
+  isPrivate,
+  isPublic,
+}: {
+  isPrivate?: boolean
+  isPublic?: boolean
+}) => {
+  if (isPublic) return false
+  if (isPrivate) return true
+  return true
+}
+
+export const registerRegistryPackagesCreate = (program: Command) => {
+  program.commands
+    .find((command) => command.name() === "registry")!
+    .commands.find((command) => command.name() === "packages")!
+    .command("create")
+    .description("Create a package in the tscircuit registry")
+    .requiredOption("--package-name <packageName>", "Package name to create")
+    .option("--org <org>", "Organization name")
+    .option("--unlisted", "Create package as unlisted")
+    .option("--private", "Create package as private")
+    .option("--public", "Create package as public")
+    .action(async (opts: RegistryPackagesCreateOptions) => {
+      if (opts.private && opts.public) {
+        console.error("Cannot use both --private and --public")
+        process.exit(1)
+      }
+
+      const packageName = getRegistryPackageName({
+        packageName: opts.packageName,
+        org: opts.org,
+      })
+
+      const isPrivate = getIsPrivateFromOptions({
+        isPrivate: opts.private,
+        isPublic: opts.public,
+      })
+
+      try {
+        const ky = getRegistryApiKy()
+        await ky.post("packages/create", {
+          json: {
+            name: packageName,
+            ...(opts.unlisted ? { is_unlisted: true } : {}),
+            is_private: isPrivate,
+          },
+        })
+        console.log(kleur.green(`Created package ${packageName}`))
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exit(1)
+      }
+    })
+}

--- a/cli/registry/packages/register.ts
+++ b/cli/registry/packages/register.ts
@@ -1,0 +1,8 @@
+import type { Command } from "commander"
+
+export const registerRegistryPackages = (program: Command) => {
+  program.commands
+    .find((command) => command.name() === "registry")!
+    .command("packages")
+    .description("Manage packages in the tscircuit registry")
+}

--- a/cli/registry/register.ts
+++ b/cli/registry/register.ts
@@ -1,0 +1,5 @@
+import type { Command } from "commander"
+
+export const registerRegistry = (program: Command) => {
+  program.command("registry").description("Manage tscircuit registry resources")
+}

--- a/tests/cli/registry/registry-packages-create.test.ts
+++ b/tests/cli/registry/registry-packages-create.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "bun:test"
+import { getCliTestFixture } from "tests/fixtures/get-cli-test-fixture"
+import {
+  getIsPrivateFromOptions,
+  getRegistryPackageName,
+} from "cli/registry/packages/create/register"
+
+test(
+  "tsci registry packages create creates a private package by default",
+  async () => {
+    const { runCommand, registryDb } = await getCliTestFixture({
+      loggedIn: true,
+    })
+
+    const { stdout, stderr, exitCode } = await runCommand(
+      "tsci registry packages create --package-name test-user/demo-package",
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stderr).toBe("")
+    expect(stdout).toContain("Created package test-user/demo-package")
+
+    const createdPackage = registryDb.packages.find(
+      (pkg) => pkg.name === "test-user/demo-package",
+    )
+    expect(createdPackage).toBeDefined()
+    expect(createdPackage?.is_private).toBe(true)
+  },
+  { timeout: 30_000 },
+)
+
+test("registry package name uses @tsci org prefix when --org is provided", () => {
+  expect(getRegistryPackageName({ packageName: "adc", org: "acme" })).toBe(
+    "@tsci/acme.adc",
+  )
+  expect(getRegistryPackageName({ packageName: "test-user/adc" })).toBe(
+    "test-user/adc",
+  )
+})
+
+test("visibility flags default to private and --public overrides", () => {
+  expect(getIsPrivateFromOptions({})).toBe(true)
+  expect(getIsPrivateFromOptions({ isPrivate: true })).toBe(true)
+  expect(getIsPrivateFromOptions({ isPublic: true })).toBe(false)
+})


### PR DESCRIPTION
### Motivation
- Provide a dedicated `tsci registry` namespace and a `packages create` workflow to allow creating packages in the tscircuit registry from the CLI.
- Support organization-scoped package naming and visibility/unlisted semantics to match registry API expectations.

### Description
- Add a new `registry` command group and `packages` subgroup with `tsci registry packages create` implemented in `cli/registry/packages/create/register.ts` which calls the registry API at `packages/create` via `getRegistryApiKy()`.
- Implement `--package-name` as a required option and `--org` which rewrites the name to `@tsci/<org>.<packageName>` when provided via `getRegistryPackageName`.
- Map `--unlisted` to `is_unlisted` (included only when provided) and implement `--private` / `--public` flags with default private behavior via `getIsPrivateFromOptions`, and emit an error if both visibility flags are supplied.
- Wire command registration into the CLI entrypoint (`cli/main.ts`) and add unit/integration tests in `tests/cli/registry/registry-packages-create.test.ts` covering execution, org name formatting, and visibility flag behavior.

### Testing
- Ran `bun test tests/cli/registry/registry-packages-create.test.ts` which completed successfully with all tests passing (3 pass, 0 fail). 
- Ran `bunx tsc --noEmit` for type checking which succeeded with no errors. 
- Ran `bun run format` which completed and formatted files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b19eca4a00832eb2d20a6b82503ed1)