### PR TITLE
Add `tsci registry packages update` command to toggle public dist

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -30,6 +30,7 @@ import { registerInstall } from "./install/register"
 import { registerPush } from "./push/register"
 import { registerRemove } from "./remove/register"
 import { registerRegistryPackagesCreate } from "./registry/packages/create/register"
+import { registerRegistryPackagesUpdate } from "./registry/packages/update/register"
 import { registerRegistryPackages } from "./registry/packages/register"
 import { registerRegistry } from "./registry/register"
 import { registerSearch } from "./search/register"
@@ -81,6 +82,7 @@ registerCheckRouting(program)
 registerRegistry(program)
 registerRegistryPackages(program)
 registerRegistryPackagesCreate(program)
+registerRegistryPackagesUpdate(program)
 
 registerSearch(program)
 registerImport(program)

--- a/cli/registry/packages/update/register.ts
+++ b/cli/registry/packages/update/register.ts
@@ -1,0 +1,66 @@
+import type { Command } from "commander"
+import { getRegistryApiKy } from "lib/registry-api/get-ky"
+import kleur from "kleur"
+
+interface RegistryPackagesUpdateOptions {
+  packageName: string
+  enablePublicDist?: boolean
+  disablePublicDist?: boolean
+}
+
+export const getPublicDistEnabledFromOptions = ({
+  enablePublicDist,
+  disablePublicDist,
+}: {
+  enablePublicDist?: boolean
+  disablePublicDist?: boolean
+}) => {
+  if (enablePublicDist) return true
+  if (disablePublicDist) return false
+  return undefined
+}
+
+export const registerRegistryPackagesUpdate = (program: Command) => {
+  program.commands
+    .find((command) => command.name() === "registry")!
+    .commands.find((command) => command.name() === "packages")!
+    .command("update")
+    .description("Update a package in the tscircuit registry")
+    .requiredOption("--package-name <packageName>", "Package name to update")
+    .option("--enable-public-dist", "Enable public dist")
+    .option("--disable-public-dist", "Disable public dist")
+    .action(async (opts: RegistryPackagesUpdateOptions) => {
+      if (opts.enablePublicDist && opts.disablePublicDist) {
+        console.error(
+          "Cannot use both --enable-public-dist and --disable-public-dist",
+        )
+        process.exit(1)
+      }
+
+      const publicDistEnabled = getPublicDistEnabledFromOptions({
+        enablePublicDist: opts.enablePublicDist,
+        disablePublicDist: opts.disablePublicDist,
+      })
+
+      if (publicDistEnabled === undefined) {
+        console.error(
+          "You must provide either --enable-public-dist or --disable-public-dist",
+        )
+        process.exit(1)
+      }
+
+      try {
+        const ky = getRegistryApiKy()
+        await ky.post("packages/update", {
+          json: {
+            package_name: opts.packageName,
+            public_dist_enabled: publicDistEnabled,
+          },
+        })
+        console.log(kleur.green(`Updated package ${opts.packageName}`))
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exit(1)
+      }
+    })
+}

--- a/tests/cli/registry/registry-packages-update.test.ts
+++ b/tests/cli/registry/registry-packages-update.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test"
+import { getPublicDistEnabledFromOptions } from "cli/registry/packages/update/register"
+
+test("public dist flags map to public_dist_enabled payload values", () => {
+  expect(getPublicDistEnabledFromOptions({ enablePublicDist: true })).toBe(true)
+  expect(getPublicDistEnabledFromOptions({ disablePublicDist: true })).toBe(
+    false,
+  )
+  expect(getPublicDistEnabledFromOptions({})).toBeUndefined()
+})


### PR DESCRIPTION
### Motivation
- Provide CLI controls to toggle a package's public distribution state by exposing the `public_dist_enabled` property on the registry API.

### Description
- Add a new `tsci registry packages update` subcommand that accepts `--package-name`, `--enable-public-dist`, and `--disable-public-dist` and posts to the `/packages/update` endpoint with `package_name` and `public_dist_enabled`.
- Introduce `getPublicDistEnabledFromOptions` to map the CLI flags to `true | false | undefined` and validate that the two flags are mutually exclusive and that one is required.
- Register the new command in `cli/main.ts` and add the implementation at `cli/registry/packages/update/register.ts`.
- Add unit tests in `tests/cli/registry/registry-packages-update.test.ts` to verify flag-to-payload mapping.

### Testing
- Ran `bun test tests/cli/registry/registry-packages-update.test.ts` which passed.
- Ran `bun test tests/cli/registry/registry-packages-create.test.ts` which passed to ensure no regressions.
- Ran `bunx tsc --noEmit` for type checking which succeeded.
- Ran `bun run format` to apply formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1f380a254832ea0c1313917c3283f)