### PR TITLE
Add periodic heartbeat logs for thread worker pool

### DIFF
--- a/lib/shared/thread-worker-pool.ts
+++ b/lib/shared/thread-worker-pool.ts
@@ -25,6 +25,7 @@ type ThreadWorkerPoolOptions<TJob, TWorkerInput, TWorkerOutput, TResult> = {
   onLog?: (lines: string[]) => void
   cancellationError?: Error
   jobTimeoutMs?: number
+  heartbeatIntervalMs?: number
 }
 
 export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
@@ -40,6 +41,7 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
   private initialized = false
   private stopped = false
   private stopReason: Error | null = null
+  private heartbeatIntervalId: NodeJS.Timeout | null = null
 
   constructor(
     options: ThreadWorkerPoolOptions<
@@ -60,7 +62,41 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
       this.workers.push(this.createThreadWorker())
     }
 
+    this.startHeartbeat()
     this.initialized = true
+  }
+
+  private startHeartbeat(): void {
+    if (!this.options.onLog || this.heartbeatIntervalId) {
+      return
+    }
+
+    const heartbeatIntervalMs = this.options.heartbeatIntervalMs ?? 5000
+    if (heartbeatIntervalMs <= 0) {
+      return
+    }
+
+    this.heartbeatIntervalId = setInterval(() => {
+      const busyWorkers = this.workers.filter((worker) => worker.busy).length
+      const totalWorkers = this.workers.length
+      const idleWorkers = totalWorkers - busyWorkers
+      const queuedJobs = this.jobQueue.length
+
+      this.options.onLog?.([
+        `[worker-pool] heartbeat: workers busy=${busyWorkers}/${totalWorkers}, idle=${idleWorkers}, queued_jobs=${queuedJobs}`,
+      ])
+    }, heartbeatIntervalMs)
+
+    this.heartbeatIntervalId.unref?.()
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatIntervalId) {
+      return
+    }
+
+    clearInterval(this.heartbeatIntervalId)
+    this.heartbeatIntervalId = null
   }
 
   private createThreadWorker(): ThreadWorker<TJob, TResult> {
@@ -242,6 +278,7 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
     if (this.stopped) return
 
     this.stopped = true
+    this.stopHeartbeat()
     this.stopReason = reason
     for (const queuedJob of this.jobQueue) {
       queuedJob.reject(reason)
@@ -250,6 +287,7 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
   }
 
   async terminate(): Promise<void> {
+    this.stopHeartbeat()
     await Promise.all(
       this.workers.map((worker) => {
         this.clearWorkerTimeout(worker)

--- a/lib/shared/thread-worker-pool.ts
+++ b/lib/shared/thread-worker-pool.ts
@@ -10,6 +10,7 @@ type ThreadWorker<TJob, TResult> = {
   worker: Worker
   busy: boolean
   currentJob: QueuedJob<TJob, TResult> | null
+  currentJobStartedAt: number | null
   timeoutId: NodeJS.Timeout | null
 }
 
@@ -26,6 +27,7 @@ type ThreadWorkerPoolOptions<TJob, TWorkerInput, TWorkerOutput, TResult> = {
   cancellationError?: Error
   jobTimeoutMs?: number
   heartbeatIntervalMs?: number
+  describeJob?: (job: TJob) => string
 }
 
 export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
@@ -66,6 +68,27 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
     this.initialized = true
   }
 
+  private describeJob(job: TJob): string {
+    if (this.options.describeJob) {
+      return this.options.describeJob(job)
+    }
+
+    if (typeof job === "object" && job !== null) {
+      const jobCandidate = job as Record<string, unknown>
+      if (typeof jobCandidate.filePath === "string") {
+        return jobCandidate.filePath
+      }
+      if (typeof jobCandidate.id === "string") {
+        return jobCandidate.id
+      }
+      if (typeof jobCandidate.outputPath === "string") {
+        return jobCandidate.outputPath
+      }
+    }
+
+    return "unknown-job"
+  }
+
   private startHeartbeat(): void {
     if (!this.options.onLog || this.heartbeatIntervalId) {
       return
@@ -81,9 +104,19 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
       const totalWorkers = this.workers.length
       const idleWorkers = totalWorkers - busyWorkers
       const queuedJobs = this.jobQueue.length
+      const now = Date.now()
+      const workerDetails = this.workers.map((worker, index) => {
+        if (!worker.busy || !worker.currentJob || !worker.currentJobStartedAt) {
+          return `w${index}:idle`
+        }
+
+        const runningForMs = now - worker.currentJobStartedAt
+        const jobDescription = this.describeJob(worker.currentJob.job)
+        return `w${index}:busy task=${jobDescription} running_ms=${runningForMs}`
+      })
 
       this.options.onLog?.([
-        `[worker-pool] heartbeat: workers busy=${busyWorkers}/${totalWorkers}, idle=${idleWorkers}, queued_jobs=${queuedJobs}`,
+        `[worker-pool] heartbeat: workers busy=${busyWorkers}/${totalWorkers}, idle=${idleWorkers}, queued_jobs=${queuedJobs} | ${workerDetails.join(" | ")}`,
       ])
     }, heartbeatIntervalMs)
 
@@ -104,6 +137,7 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
       worker: new Worker(this.options.workerEntrypointPath),
       busy: false,
       currentJob: null,
+      currentJobStartedAt: null,
       timeoutId: null,
     }
 
@@ -154,6 +188,7 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
     threadWorker.worker = new Worker(this.options.workerEntrypointPath)
     threadWorker.busy = false
     threadWorker.currentJob = null
+    threadWorker.currentJobStartedAt = null
 
     this.attachWorkerHandlers(threadWorker)
   }
@@ -169,6 +204,7 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
 
     this.clearWorkerTimeout(threadWorker)
     threadWorker.currentJob = null
+    threadWorker.currentJobStartedAt = null
     threadWorker.busy = false
     action(job)
     this.processQueue()
@@ -255,6 +291,7 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
 
     availableWorker.busy = true
     availableWorker.currentJob = queuedJob
+    availableWorker.currentJobStartedAt = Date.now()
     this.startJobTimeout(availableWorker)
     availableWorker.worker.postMessage(
       this.options.createMessage(queuedJob.job),

--- a/tests/shared/thread-worker-pool-timeout.test.ts
+++ b/tests/shared/thread-worker-pool-timeout.test.ts
@@ -123,7 +123,6 @@ test("thread worker pool emits heartbeat logs", async () => {
     )
 
     expect(detailedHeartbeat).toBeDefined()
-
   } finally {
     await pool.terminate()
   }

--- a/tests/shared/thread-worker-pool-timeout.test.ts
+++ b/tests/shared/thread-worker-pool-timeout.test.ts
@@ -111,14 +111,19 @@ test("thread worker pool emits heartbeat logs", async () => {
   })
 
   try {
-    const result = await pool.queueJob({ id: "success" })
-    expect(result).toBe("success")
+    void pool.queueJob({ id: "stuck", hang: true }).catch(() => undefined)
 
-    await new Promise((resolve) => setTimeout(resolve, 60))
+    await new Promise((resolve) => setTimeout(resolve, 80))
 
-    expect(logs.some((line) => line.includes("[worker-pool] heartbeat:"))).toBe(
-      true,
+    const detailedHeartbeat = logs.find(
+      (line) =>
+        line.includes("[worker-pool] heartbeat:") &&
+        line.includes("task=stuck") &&
+        line.includes("running_ms="),
     )
+
+    expect(detailedHeartbeat).toBeDefined()
+
   } finally {
     await pool.terminate()
   }

--- a/tests/shared/thread-worker-pool-timeout.test.ts
+++ b/tests/shared/thread-worker-pool-timeout.test.ts
@@ -83,3 +83,43 @@ test("thread worker pool times out stuck jobs and continues", async () => {
     await pool.terminate()
   }
 })
+
+test("thread worker pool emits heartbeat logs", async () => {
+  const logs: string[] = []
+  const pool = new ThreadWorkerPool<
+    TestJob,
+    TestJob,
+    TestWorkerMessage,
+    string
+  >({
+    concurrency: 1,
+    workerEntrypointPath: writeTestWorker(),
+    createMessage: (job) => job,
+    isLogMessage: (message) => message.message_type === "log",
+    getLogLines: (message) =>
+      message.message_type === "log" ? message.log_lines : [],
+    isCompletionMessage: (message) => message.message_type === "done",
+    getResult: (message) => {
+      if (message.message_type !== "done") {
+        throw new Error("Expected done message")
+      }
+
+      return message.id
+    },
+    heartbeatIntervalMs: 20,
+    onLog: (lines) => logs.push(...lines),
+  })
+
+  try {
+    const result = await pool.queueJob({ id: "success" })
+    expect(result).toBe("success")
+
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    expect(logs.some((line) => line.includes("[worker-pool] heartbeat:"))).toBe(
+      true,
+    )
+  } finally {
+    await pool.terminate()
+  }
+})


### PR DESCRIPTION
### Motivation
- Provide periodic visibility into worker pool health so consumers can monitor busy/idle worker counts and queue depth.
- Follow an industry convention of emitting heartbeat-style status lines at a regular interval to aid debugging and observability.

### Description
- Add an optional `heartbeatIntervalMs` option to `ThreadWorkerPool` with a default of `5000`ms and emit heartbeat logs when `onLog` is provided.
- Heartbeat messages are emitted as `[worker-pool] heartbeat: workers busy=<busy>/<total>, idle=<idle>, queued_jobs=<n>` and are produced on a repeating interval started during initialization.
- Ensure heartbeat lifecycle is cleaned up by stopping the interval in both `stop()` and `terminate()` to avoid lingering timers.
- Add a unit test `tests/shared/thread-worker-pool-timeout.test.ts` that verifies heartbeat log emission using a short interval.

### Testing
- Ran `bun test tests/shared/thread-worker-pool-timeout.test.ts` which executed 2 tests and both passed.
- The heartbeat test asserted that logs contain the `[worker-pool] heartbeat:` string and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b30dfe0fcc8327a58d53806449dca9)