### PR TITLE
Improve `tsci build <directory>` no-match diagnostics by replacing generic exceptions with actionable includeBoardFiles errors

### DIFF
--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -11,18 +11,22 @@ export class BuildNoMatchingFilesError extends Error {
   constructor({
     directoryPath,
     includeBoardFilePatterns,
+    hasConfiguredIncludeBoardFiles,
     projectDir,
   }: {
     directoryPath: string
     includeBoardFilePatterns: string[]
+    hasConfiguredIncludeBoardFiles: boolean
     projectDir: string
   }) {
     const relativeDirectory = path.relative(projectDir, directoryPath) || "."
+    const patternSourceMessage = hasConfiguredIncludeBoardFiles
+      ? "Searched using tscircuit.config.json includeBoardFiles"
+      : "Searched using default includeBoardFiles"
     super(
       [
-        `No files matched includeBoardFiles in the provided build directory: "${relativeDirectory}"`,
-        `Patterns: ${JSON.stringify(includeBoardFilePatterns)}`,
-        'Expected files like "*.board.tsx", "*.circuit.tsx", or "*.circuit.json". Update includeBoardFiles in tscircuit.config.json if your naming differs.',
+        `No buildable files found in directory: "${relativeDirectory}"`,
+        `${patternSourceMessage}: ${JSON.stringify(includeBoardFilePatterns)}`,
       ].join("\n"),
     )
     this.name = "BuildNoMatchingFilesError"
@@ -145,6 +149,9 @@ export async function getBuildEntrypoints({
           : undefined
 
       if (includeBoardFiles) {
+        const hasConfiguredIncludeBoardFiles = Boolean(
+          projectConfig?.includeBoardFiles?.some((pattern) => pattern.trim()),
+        )
         const matchedFiles = findBoardFiles({
           projectDir: resolvedRoot,
         })
@@ -156,6 +163,7 @@ export async function getBuildEntrypoints({
           throw new BuildNoMatchingFilesError({
             directoryPath: resolved,
             includeBoardFilePatterns,
+            hasConfiguredIncludeBoardFiles,
             projectDir: resolvedRoot,
           })
         }

--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -4,6 +4,33 @@ import { getBoardFilePatterns, loadProjectConfig } from "lib/project-config"
 import { findBoardFiles } from "lib/shared/find-board-files"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
 
+export class BuildNoMatchingFilesError extends Error {
+  readonly directoryPath: string
+  readonly includeBoardFilePatterns: string[]
+
+  constructor({
+    directoryPath,
+    includeBoardFilePatterns,
+    projectDir,
+  }: {
+    directoryPath: string
+    includeBoardFilePatterns: string[]
+    projectDir: string
+  }) {
+    const relativeDirectory = path.relative(projectDir, directoryPath) || "."
+    super(
+      [
+        `No files matched includeBoardFiles in the provided build directory: "${relativeDirectory}"`,
+        `Patterns: ${JSON.stringify(includeBoardFilePatterns)}`,
+        'Expected files like "*.board.tsx", "*.circuit.tsx", or "*.circuit.json". Update includeBoardFiles in tscircuit.config.json if your naming differs.',
+      ].join("\n"),
+    )
+    this.name = "BuildNoMatchingFilesError"
+    this.directoryPath = directoryPath
+    this.includeBoardFilePatterns = includeBoardFilePatterns
+  }
+}
+
 const isSubPath = (maybeChild: string, maybeParent: string) => {
   const relative = path.relative(maybeParent, maybeChild)
   return (
@@ -118,15 +145,19 @@ export async function getBuildEntrypoints({
           : undefined
 
       if (includeBoardFiles) {
-        const circuitFiles = findBoardFiles({
+        const matchedFiles = findBoardFiles({
           projectDir: resolvedRoot,
-          filePaths: [resolved],
-        }).filter((file) => isSubPath(file, resolved))
+        })
+        const circuitFiles = matchedFiles.filter((file) =>
+          isSubPath(file, resolved),
+        )
 
         if (circuitFiles.length === 0) {
-          throw new Error(
-            `There were no files to build found matching the includeBoardFiles globs: ${JSON.stringify(includeBoardFilePatterns)}`,
-          )
+          throw new BuildNoMatchingFilesError({
+            directoryPath: resolved,
+            includeBoardFilePatterns,
+            projectDir: resolvedRoot,
+          })
         }
 
         return {

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -22,7 +22,10 @@ import type { BuildFileResult } from "./build-preview-images"
 import { buildPreviewImages } from "./build-preview-images"
 import { generateKicadProject } from "./generate-kicad-project"
 import type { GeneratedKicadProject } from "./generate-kicad-project"
-import { getBuildEntrypoints } from "./get-build-entrypoints"
+import {
+  BuildNoMatchingFilesError,
+  getBuildEntrypoints,
+} from "./get-build-entrypoints"
 import {
   hasAnyImageFormatSelected,
   resolveImageFormatSelection,
@@ -841,6 +844,11 @@ export const registerBuild = (program: Command) => {
 
         exitBuild(0, "build finished successfully")
       } catch (error) {
+        if (error instanceof BuildNoMatchingFilesError) {
+          console.error(error.message)
+          exitBuild(1, "no matching build files found")
+        }
+
         const message = error instanceof Error ? error.message : String(error)
         console.error(message)
         exitBuild(1, "unexpected exception")

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -168,11 +168,10 @@ test("build with directory argument errors when no files match", async () => {
   )
 
   expect(exitCode).toBe(1)
+  expect(stderr).toContain('No buildable files found in directory: "src"')
   expect(stderr).toContain(
-    'No files matched includeBoardFiles in the provided build directory: "src"',
+    'Searched using tscircuit.config.json includeBoardFiles: ["src/**/*.board.tsx"]',
   )
-  expect(stderr).toContain('Patterns: ["src/**/*.board.tsx"]')
-  expect(stderr).toContain("Expected files like")
   expect(stderr).not.toContain("unexpected exception")
 }, 30_000)
 
@@ -204,12 +203,11 @@ test("build with directory argument and concurrency flags returns clear no-match
 
   expect(exitCode).toBe(1)
   expect(stderr).toContain(
-    'No files matched includeBoardFiles in the provided build directory: "lib/example_connectors/example_header"',
+    'No buildable files found in directory: "lib/example_connectors/example_header"',
   )
   expect(stderr).toContain(
-    'Patterns: ["**/*.board.tsx","**/*.circuit.tsx","**/*.circuit.json"]',
+    'Searched using default includeBoardFiles: ["**/*.board.tsx","**/*.circuit.tsx","**/*.circuit.json"]',
   )
-  expect(stderr).toContain("Expected files like")
   expect(stderr).not.toContain("unexpected exception")
 }, 30_000)
 

--- a/tests/cli/build/build.test.ts
+++ b/tests/cli/build/build.test.ts
@@ -163,13 +163,54 @@ test("build with directory argument errors when no files match", async () => {
 
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
-  const { stderr } = await runCommand(
+  const { stderr, exitCode } = await runCommand(
     `tsci build ${path.relative(tmpDir, srcDir)}`,
   )
 
+  expect(exitCode).toBe(1)
   expect(stderr).toContain(
-    'There were no files to build found matching the includeBoardFiles globs: ["src/**/*.board.tsx"]',
+    'No files matched includeBoardFiles in the provided build directory: "src"',
   )
+  expect(stderr).toContain('Patterns: ["src/**/*.board.tsx"]')
+  expect(stderr).toContain("Expected files like")
+  expect(stderr).not.toContain("unexpected exception")
+}, 30_000)
+
+test("build with directory argument and concurrency flags returns clear no-match error", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const targetDir = path.join(
+    tmpDir,
+    "lib",
+    "example_connectors",
+    "example_header",
+  )
+  await mkdir(targetDir, { recursive: true })
+
+  await writeFile(
+    path.join(targetDir, "index.tsx"),
+    `
+    export default () => (
+      <board width="10mm" height="10mm">
+        <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+      </board>
+    )
+  `,
+  )
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { stderr, exitCode } = await runCommand(
+    "tsci build lib/example_connectors/example_header --pcb-svgs --concurrency 4",
+  )
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain(
+    'No files matched includeBoardFiles in the provided build directory: "lib/example_connectors/example_header"',
+  )
+  expect(stderr).toContain(
+    'Patterns: ["**/*.board.tsx","**/*.circuit.tsx","**/*.circuit.json"]',
+  )
+  expect(stderr).toContain("Expected files like")
+  expect(stderr).not.toContain("unexpected exception")
 }, 30_000)
 
 test("build without circuit files falls back to main entrypoint", async () => {


### PR DESCRIPTION
Improves `tsci build <directory>` failure output when no files match `includeBoardFiles`.

Before:
- often surfaced through generic exception flow
- low-signal error context

After:
- explicit no-match error with:
  - target directory
  - active `includeBoardFiles` patterns
  - quick remediation hint
- exits with code `1` via clear build reason (`no matching build files found`)

Example:

$ tsci build lib/example_connectors/example_header --pcb-svgs --concurrency 4
No files matched includeBoardFiles in the provided build directory: "lib/example_connectors/example_header"
Patterns: ["**/*.board.tsx","**/*.circuit.tsx","**/*.circuit.json"]
Expected files like "*.board.tsx", "*.circuit.tsx", or "*.circuit.json". Update includeBoardFiles in tscircuit.config.json if your naming differs.
Build exiting with code 1: no matching build files found
