### PR TITLE
Add --routing-disabled support to tsci build

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -7,6 +7,7 @@ export interface BuildCommandOptions {
   ignoreErrors?: boolean
   ignoreWarnings?: boolean
   disablePcb?: boolean
+  routingDisabled?: boolean
   disablePartsEngine?: boolean
   ignoreConfig?: boolean
   ci?: boolean

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -115,6 +115,7 @@ export const registerBuild = (program: Command) => {
     .option("--ignore-warnings", "Do not log warnings")
     .option("--ignore-config", "Ignore options from tscircuit.config.json")
     .option("--disable-pcb", "Disable PCB outputs")
+    .option("--routing-disabled", "Disable routing during circuit generation")
     .option("--disable-parts-engine", "Disable the parts engine")
     .option("--site", "Generate a static site in the dist directory")
     .option("--transpile", "Transpile the entry file to JavaScript")
@@ -247,6 +248,7 @@ export const registerBuild = (program: Command) => {
         const platformConfig: PlatformConfig | undefined = (() => {
           if (
             !resolvedOptions?.disablePcb &&
+            !resolvedOptions?.routingDisabled &&
             !resolvedOptions?.disablePartsEngine
           ) {
             return
@@ -256,6 +258,10 @@ export const registerBuild = (program: Command) => {
 
           if (resolvedOptions?.disablePcb) {
             config.pcbDisabled = true
+          }
+
+          if (resolvedOptions?.routingDisabled) {
+            config.routingDisabled = true
           }
 
           if (resolvedOptions?.disablePartsEngine) {

--- a/cli/build/resolve-build-options.ts
+++ b/cli/build/resolve-build-options.ts
@@ -36,6 +36,12 @@ export const resolveBuildOptions = ({
   if (!cliOptions?.glbs && configBuild?.glbs) {
     configAppliedOpts.push("glbs")
   }
+  if (
+    cliOptions?.routingDisabled === undefined &&
+    configBuild?.routingDisabled
+  ) {
+    configAppliedOpts.push("routing-disabled")
+  }
   if (!cliOptions?.transpile && configBuild?.typescriptLibrary) {
     configAppliedOpts.push("transpile")
   }
@@ -49,6 +55,8 @@ export const resolveBuildOptions = ({
     kicadPcm: cliOptions?.kicadPcm ?? configBuild?.kicadPcm,
     previewImages: cliOptions?.previewImages ?? configBuild?.previewImages,
     glbs: cliOptions?.glbs ?? configBuild?.glbs,
+    routingDisabled:
+      cliOptions?.routingDisabled ?? configBuild?.routingDisabled,
     transpile: cliOptions?.transpile ?? configBuild?.typescriptLibrary,
   }
 

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -22,6 +22,7 @@ export const projectConfigSchema = z.object({
       kicadPcm: z.boolean().optional(),
       previewImages: z.boolean().optional(),
       glbs: z.boolean().optional(),
+      routingDisabled: z.boolean().optional(),
       typescriptLibrary: z.boolean().optional(),
     })
     .optional(),

--- a/tests/cli/build/build-routing-disabled.test.ts
+++ b/tests/cli/build/build-routing-disabled.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const circuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)`
+
+test("build supports --routing-disabled flag", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  const circuitPath = path.join(tmpDir, "routing-disabled.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { stdout, exitCode } = await runCommand(
+    `tsci build ${circuitPath} --routing-disabled`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stdout).toContain("Build complete")
+}, 30_000)

--- a/tests/cli/build/resolve-build-options.test.ts
+++ b/tests/cli/build/resolve-build-options.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { resolveBuildOptions } from "cli/build/resolve-build-options"
+
+test("resolveBuildOptions applies build.routingDisabled from config", () => {
+  const { options, configAppliedOpts } = resolveBuildOptions({
+    projectConfig: {
+      build: {
+        routingDisabled: true,
+      },
+    },
+  })
+
+  expect(options.routingDisabled).toBe(true)
+  expect(configAppliedOpts).toContain("routing-disabled")
+})
+
+test("resolveBuildOptions gives CLI routingDisabled precedence over config", () => {
+  const { options, configAppliedOpts } = resolveBuildOptions({
+    cliOptions: {
+      routingDisabled: false,
+    },
+    projectConfig: {
+      build: {
+        routingDisabled: true,
+      },
+    },
+  })
+
+  expect(options.routingDisabled).toBe(false)
+  expect(configAppliedOpts).not.toContain("routing-disabled")
+})

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -96,6 +96,10 @@
           "type": "boolean",
           "description": "Enable GLB 3D model outputs for each circuit in build."
         },
+        "routingDisabled": {
+          "type": "boolean",
+          "description": "Disable routing during circuit generation in build."
+        },
         "typescriptLibrary": {
           "type": "boolean",
           "description": "Enable TypeScript library output in build."


### PR DESCRIPTION
### Motivation
- Allow disabling routing during circuit generation via CLI and project config so builds can opt out of autorouting behavior consistently.

### Description
- Add a `--routing-disabled` CLI flag in `cli/build/register.ts` and expose `routingDisabled` on `BuildCommandOptions` in `cli/build/build-ci.ts`.
- Wire `routingDisabled` through `resolveBuildOptions` so `build.routingDisabled` from `tscircuit.config.json` is applied when CLI does not explicitly set it and is reported as `routing-disabled` in config-applied options.
- Translate `routingDisabled` into the runtime `PlatformConfig` used during generation in `cli/build/register.ts` so the generator sees `platformConfig.routingDisabled` when requested.
- Extend project config validation and the JSON schema by adding `routingDisabled` to `lib/project-config/project-config-schema.ts` and `types/tscircuit.config.schema.json`.
- Add tests `tests/cli/build/build-routing-disabled.test.ts` and `tests/cli/build/resolve-build-options.test.ts` to verify CLI acceptance and config precedence.

### Testing
- Ran `bun test tests/cli/build/build-routing-disabled.test.ts tests/cli/build/resolve-build-options.test.ts` and both tests passed.
- Ran TypeScript check with `bunx tsc --noEmit` which succeeded with no type errors.
- Ran formatting with `bun run format` which completed successfully.
- Note: a broader `tests/cli/build/build-config-options.test.ts` run exhibited timeouts/flakiness in this environment earlier during investigation, but the focused tests for the new flag and option-resolution passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b33c6b9584832eb19847238251527c)