### PR TITLE
Gate worker-pool heartbeat logs behind DEBUG=1

### DIFF
--- a/lib/shared/thread-worker-pool.ts
+++ b/lib/shared/thread-worker-pool.ts
@@ -94,6 +94,10 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
       return
     }
 
+    if (process.env.DEBUG !== "1") {
+      return
+    }
+
     const heartbeatIntervalMs = this.options.heartbeatIntervalMs ?? 5000
     if (heartbeatIntervalMs <= 0) {
       return

--- a/tests/shared/thread-worker-pool-timeout.test.ts
+++ b/tests/shared/thread-worker-pool-timeout.test.ts
@@ -136,7 +136,6 @@ test("thread worker pool emits heartbeat logs only when DEBUG=1", async () => {
   }
 })
 
-
 test("thread worker pool does not emit heartbeat logs when DEBUG is not 1", async () => {
   const previousDebug = process.env.DEBUG
   delete process.env.DEBUG

--- a/tests/shared/thread-worker-pool-timeout.test.ts
+++ b/tests/shared/thread-worker-pool-timeout.test.ts
@@ -84,7 +84,10 @@ test("thread worker pool times out stuck jobs and continues", async () => {
   }
 })
 
-test("thread worker pool emits heartbeat logs", async () => {
+test("thread worker pool emits heartbeat logs only when DEBUG=1", async () => {
+  const previousDebug = process.env.DEBUG
+  process.env.DEBUG = "1"
+
   const logs: string[] = []
   const pool = new ThreadWorkerPool<
     TestJob,
@@ -125,5 +128,60 @@ test("thread worker pool emits heartbeat logs", async () => {
     expect(detailedHeartbeat).toBeDefined()
   } finally {
     await pool.terminate()
+    if (previousDebug === undefined) {
+      delete process.env.DEBUG
+    } else {
+      process.env.DEBUG = previousDebug
+    }
+  }
+})
+
+
+test("thread worker pool does not emit heartbeat logs when DEBUG is not 1", async () => {
+  const previousDebug = process.env.DEBUG
+  delete process.env.DEBUG
+
+  const logs: string[] = []
+  const pool = new ThreadWorkerPool<
+    TestJob,
+    TestJob,
+    TestWorkerMessage,
+    string
+  >({
+    concurrency: 1,
+    workerEntrypointPath: writeTestWorker(),
+    createMessage: (job) => job,
+    isLogMessage: (message) => message.message_type === "log",
+    getLogLines: (message) =>
+      message.message_type === "log" ? message.log_lines : [],
+    isCompletionMessage: (message) => message.message_type === "done",
+    getResult: (message) => {
+      if (message.message_type !== "done") {
+        throw new Error("Expected done message")
+      }
+
+      return message.id
+    },
+    heartbeatIntervalMs: 20,
+    onLog: (lines) => logs.push(...lines),
+  })
+
+  try {
+    void pool.queueJob({ id: "stuck", hang: true }).catch(() => undefined)
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    const detailedHeartbeat = logs.find((line) =>
+      line.includes("[worker-pool] heartbeat:"),
+    )
+
+    expect(detailedHeartbeat).toBeUndefined()
+  } finally {
+    await pool.terminate()
+    if (previousDebug === undefined) {
+      delete process.env.DEBUG
+    } else {
+      process.env.DEBUG = previousDebug
+    }
   }
 })


### PR DESCRIPTION
### Motivation
- Reduce noisy heartbeat output from the thread worker pool so detailed heartbeat messages are only emitted during debugging. 

### Description
- Gate heartbeat scheduling in `ThreadWorkerPool.startHeartbeat` so it returns early unless `process.env.DEBUG === "1"` (file: `lib/shared/thread-worker-pool.ts`).
- Update the existing heartbeat test to explicitly set `DEBUG=1` during the test and restore the previous environment value afterward (file: `tests/shared/thread-worker-pool-timeout.test.ts`).
- Add a new test asserting heartbeat logs are not emitted when `DEBUG` is not set (file: `tests/shared/thread-worker-pool-timeout.test.ts`).

### Testing
- Ran `bun test tests/shared/thread-worker-pool-timeout.test.ts`, which produced `3 pass, 0 fail` for the updated test file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b40e0fa59c8327a23ea5649496eb5e)