### PR TITLE
Enforce deterministic no-match failures for tsci snapshot <directory> and surface exact includeBoardFiles source

### DIFF
--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -42,13 +42,13 @@ type SnapshotOptions = {
   onSuccess?: (message: string) => void
 }
 
-const getIncludeBoardFilesSource = (projectDir: string): boolean => {
+const hasConfiguredIncludeBoardFiles = (projectDir: string): boolean => {
   const projectConfig = loadProjectConfig(projectDir)
-  const hasConfiguredIncludeBoardFiles = Boolean(
+  const hasConfiguredPatterns = Boolean(
     projectConfig?.includeBoardFiles?.some((pattern) => pattern.trim()),
   )
 
-  return hasConfiguredIncludeBoardFiles
+  return hasConfiguredPatterns
 }
 
 export const snapshotProject = async ({
@@ -96,8 +96,7 @@ export const snapshotProject = async ({
       const relativeDirectory =
         path.relative(projectDir, explicitDirectoryTarget) || "."
       const includeBoardFilePatterns = getBoardFilePatterns(projectDir)
-      const includeBoardFilesSource = getIncludeBoardFilesSource(projectDir)
-      const patternSourceMessage = includeBoardFilesSource
+      const patternSourceMessage = hasConfiguredIncludeBoardFiles(projectDir)
         ? "Searched using tscircuit.config.json includeBoardFiles"
         : "Searched using default includeBoardFiles"
 

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -1,8 +1,13 @@
+import fs from "node:fs"
 import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import { snapshotFilesWithWorkerPool } from "cli/snapshot/worker-pool"
 import kleur from "kleur"
-import { getSnapshotsDir } from "lib/project-config"
+import {
+  getBoardFilePatterns,
+  getSnapshotsDir,
+  loadProjectConfig,
+} from "lib/project-config"
 import type { CameraPreset } from "lib/shared/camera-presets"
 import { findBoardFiles } from "lib/shared/find-board-files"
 import { processSnapshotFile } from "lib/shared/process-snapshot-file"
@@ -37,6 +42,15 @@ type SnapshotOptions = {
   onSuccess?: (message: string) => void
 }
 
+const getIncludeBoardFilesSource = (projectDir: string): boolean => {
+  const projectConfig = loadProjectConfig(projectDir)
+  const hasConfiguredIncludeBoardFiles = Boolean(
+    projectConfig?.includeBoardFiles?.some((pattern) => pattern.trim()),
+  )
+
+  return hasConfiguredIncludeBoardFiles
+}
+
 export const snapshotProject = async ({
   update = false,
   ignored = [],
@@ -64,6 +78,13 @@ export const snapshotProject = async ({
   ]
 
   const resolvedPaths = filePaths.map((f) => path.resolve(projectDir, f))
+  const explicitDirectoryTarget = resolvedPaths.find((resolvedPath) => {
+    if (!fs.existsSync(resolvedPath)) {
+      return false
+    }
+
+    return fs.statSync(resolvedPath).isDirectory()
+  })
   const boardFiles = findBoardFiles({
     projectDir,
     ignore,
@@ -71,6 +92,24 @@ export const snapshotProject = async ({
   })
 
   if (boardFiles.length === 0) {
+    if (explicitDirectoryTarget) {
+      const relativeDirectory =
+        path.relative(projectDir, explicitDirectoryTarget) || "."
+      const includeBoardFilePatterns = getBoardFilePatterns(projectDir)
+      const includeBoardFilesSource = getIncludeBoardFilesSource(projectDir)
+      const patternSourceMessage = includeBoardFilesSource
+        ? "Searched using tscircuit.config.json includeBoardFiles"
+        : "Searched using default includeBoardFiles"
+
+      onError(
+        [
+          `No circuit files found to create snapshots in directory: "${relativeDirectory}"`,
+          `${patternSourceMessage}: ${JSON.stringify(includeBoardFilePatterns)}`,
+        ].join("\n"),
+      )
+      return onExit(1)
+    }
+
     console.log(
       "No entrypoint found. Run 'tsci init' to bootstrap a project or specify a file with 'tsci snapshot <file>'",
     )

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -351,6 +351,70 @@ test("snapshot command with directory path", async () => {
   expect(rootExists).toBe(false)
 }, 30_000)
 
+test("snapshot with directory path errors when no files match configured includeBoardFiles", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const srcDir = join(tmpDir, "src")
+  fs.mkdirSync(srcDir)
+
+  await Bun.write(
+    join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ includeBoardFiles: ["src/**/*.board.tsx"] }),
+  )
+  await Bun.write(
+    join(srcDir, "index.tsx"),
+    `
+    export const Component = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  const { stderr, stdout, exitCode } = await runCommand("tsci snapshot src")
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain(
+    'No circuit files found to create snapshots in directory: "src"',
+  )
+  expect(stderr).toContain(
+    'Searched using tscircuit.config.json includeBoardFiles: ["src/**/*.board.tsx"]',
+  )
+  expect(stderr).not.toContain("No entrypoint found")
+  expect(stdout).not.toContain("No entrypoint found")
+}, 30_000)
+
+test("snapshot with directory path and default includeBoardFiles returns clear no-match error", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const targetDir = join(tmpDir, "lib", "example_connectors", "example_header")
+  fs.mkdirSync(targetDir, { recursive: true })
+
+  await Bun.write(
+    join(targetDir, "index.tsx"),
+    `
+    export const Component = () => (
+      <board width="10mm" height="10mm">
+        <chip name="U1" footprint="soic8" />
+      </board>
+    )
+  `,
+  )
+
+  const { stderr, stdout, exitCode } = await runCommand(
+    "tsci snapshot lib/example_connectors/example_header --concurrency 4",
+  )
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain(
+    'No circuit files found to create snapshots in directory: "lib/example_connectors/example_header"',
+  )
+  expect(stderr).toContain(
+    'Searched using default includeBoardFiles: ["**/*.board.tsx","**/*.circuit.tsx","**/*.circuit.json"]',
+  )
+  expect(stderr).not.toContain("No entrypoint found")
+  expect(stdout).not.toContain("No entrypoint found")
+}, 30_000)
+
 test("snapshot command skips updates when snapshots match visually", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 


### PR DESCRIPTION
## Summary
`tsci snapshot <directory>` previously returned exit `0` with a generic `No entrypoint found. Run 'tsci init' to bootstrap a project or specify a file with 'tsci snapshot <file>` when the directory had no matching board/circuit files.

This change makes explicit directory no-match behavior strict and clear:
- exit code is now `1`
- error shows which `includeBoardFiles` patterns were used
- source is explicit: config vs default patterns
- no-target snapshot behavior stays unchanged

 Terminal Results (Before -> After)

 1) Directory has matching files
 tsci snapshot dir --update
 before: exit 0, Created snapshots
 after : exit 0, Created snapshots

 2) Directory no-match + config includeBoardFiles
 tsci snapshot src
 before: exit 0, `"No entrypoint found..."`
 after : exit 1
`No circuit files found to create snapshots in directory: "src"
Searched using tscircuit.config.json includeBoardFiles: ["src/**/*.board.tsx"]`

 3) Directory no-match + default patterns
$ tsci snapshot lib/example_connectors/example_header --concurrency 4
 before: `exit 0, "No entrypoint found..."`
 after : `exit 1`
`No circuit files found to create snapshots in directory: "lib/example_connectors/example_header"
Searched using default includeBoardFiles: ["**/*.board.tsx","**/*.circuit.tsx","**/*.circuit.json"]`
