### PR TITLE
Use current package.json name when updating registry packages

### DIFF
--- a/cli/registry/packages/update/register.ts
+++ b/cli/registry/packages/update/register.ts
@@ -1,11 +1,26 @@
 import type { Command } from "commander"
 import { getRegistryApiKy } from "lib/registry-api/get-ky"
 import kleur from "kleur"
+import fs from "node:fs"
+import path from "node:path"
 
 interface RegistryPackagesUpdateOptions {
-  packageName: string
+  packageName?: string
   enablePublicDist?: boolean
   disablePublicDist?: boolean
+}
+
+export const getCurrentDirectoryPackageName = (): string | undefined => {
+  const packageJsonPath = path.join(process.cwd(), "package.json")
+
+  if (!fs.existsSync(packageJsonPath)) return undefined
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"))
+    return typeof packageJson.name === "string" ? packageJson.name : undefined
+  } catch {
+    return undefined
+  }
 }
 
 export const getPublicDistEnabledFromOptions = ({
@@ -26,10 +41,25 @@ export const registerRegistryPackagesUpdate = (program: Command) => {
     .commands.find((command) => command.name() === "packages")!
     .command("update")
     .description("Update a package in the tscircuit registry")
-    .requiredOption("--package-name <packageName>", "Package name to update")
+    .option("--package-name <packageName>", "Package name to update")
     .option("--enable-public-dist", "Enable public dist")
     .option("--disable-public-dist", "Disable public dist")
     .action(async (opts: RegistryPackagesUpdateOptions) => {
+      const packageName = opts.packageName ?? getCurrentDirectoryPackageName()
+
+      if (!opts.packageName && packageName) {
+        console.warn(
+          "No package specified, using package in current directory...",
+        )
+      }
+
+      if (!packageName) {
+        console.error(
+          "No package specified and no package name found in current directory package.json",
+        )
+        process.exit(1)
+      }
+
       if (opts.enablePublicDist && opts.disablePublicDist) {
         console.error(
           "Cannot use both --enable-public-dist and --disable-public-dist",
@@ -53,11 +83,11 @@ export const registerRegistryPackagesUpdate = (program: Command) => {
         const ky = getRegistryApiKy()
         await ky.post("packages/update", {
           json: {
-            package_name: opts.packageName,
+            package_name: packageName,
             public_dist_enabled: publicDistEnabled,
           },
         })
-        console.log(kleur.green(`Updated package ${opts.packageName}`))
+        console.log(kleur.green(`Updated package ${packageName}`))
       } catch (error) {
         console.error(error instanceof Error ? error.message : String(error))
         process.exit(1)

--- a/tests/cli/registry/registry-packages-update.test.ts
+++ b/tests/cli/registry/registry-packages-update.test.ts
@@ -1,5 +1,17 @@
-import { expect, test } from "bun:test"
-import { getPublicDistEnabledFromOptions } from "cli/registry/packages/update/register"
+import { afterEach, expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import { temporaryDirectory } from "tempy"
+import {
+  getCurrentDirectoryPackageName,
+  getPublicDistEnabledFromOptions,
+} from "cli/registry/packages/update/register"
+
+const originalCwd = process.cwd()
+
+afterEach(() => {
+  process.chdir(originalCwd)
+})
 
 test("public dist flags map to public_dist_enabled payload values", () => {
   expect(getPublicDistEnabledFromOptions({ enablePublicDist: true })).toBe(true)
@@ -7,4 +19,26 @@ test("public dist flags map to public_dist_enabled payload values", () => {
     false,
   )
   expect(getPublicDistEnabledFromOptions({})).toBeUndefined()
+})
+
+test("getCurrentDirectoryPackageName reads package name from package.json", () => {
+  const tmpDir = temporaryDirectory()
+  fs.writeFileSync(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name: "@tsci/test-user.board" }),
+  )
+
+  process.chdir(tmpDir)
+
+  expect(getCurrentDirectoryPackageName()).toBe("@tsci/test-user.board")
+})
+
+test("getCurrentDirectoryPackageName returns undefined when package.json is missing or invalid", () => {
+  const tmpDir = temporaryDirectory()
+
+  process.chdir(tmpDir)
+  expect(getCurrentDirectoryPackageName()).toBeUndefined()
+
+  fs.writeFileSync(path.join(tmpDir, "package.json"), "{not-valid-json")
+  expect(getCurrentDirectoryPackageName()).toBeUndefined()
 })


### PR DESCRIPTION
### Motivation
- Allow `tsci registry packages update` to be used inside a project without requiring `--package-name` to be passed. 
- Fall back to the current directory `package.json` name and surface a clear warning when that fallback is used. 
- Fail with a helpful error when neither a flag nor a valid `package.json` name can be resolved.

### Description
- Made `--package-name` optional and added `getCurrentDirectoryPackageName()` which reads `package.json` from `process.cwd()` and returns the `name` if present. 
- When `--package-name` is not provided but a `package.json` name is found, the CLI now prints: `No package specified, using package in current directory...` and uses that name for the update payload. 
- If no package can be resolved, the command exits with an error explaining the missing package name. 
- Wired the resolved package name through the API payload and success message (`Updated package <name>`). 
- Files changed: `cli/registry/packages/update/register.ts` and tests in `tests/cli/registry/registry-packages-update.test.ts` (added unit tests for `getCurrentDirectoryPackageName` and kept existing flag mapping tests).

### Testing
- Ran `bun test tests/cli/registry/registry-packages-update.test.ts` and the test file passed (all tests in that file succeeded). 
- Ran `bunx tsc --noEmit` for type checking and it completed with no errors. 
- Ran `bun run format` which formatted the tree successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b46a84e198832e80a859761eff38eb)