### PR TITLE
Prefer tscircuit version in tsci version output

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -97,7 +97,7 @@ if (
   process.argv.includes("-v") ||
   process.argv.includes("-V")
 ) {
-  console.log(getVersion())
+  console.log(getVersion({ verbose: process.argv.includes("--verbose") }))
   process.exit(0)
 }
 
@@ -105,8 +105,9 @@ if (
 program
   .command("version")
   .description("Print CLI version")
-  .action(() => {
-    console.log(getVersion())
+  .option("--verbose", "Print tscircuit + CLI dependency versions")
+  .action((options: { verbose?: boolean }) => {
+    console.log(getVersion({ verbose: options.verbose }))
   })
 
 if (process.argv.length === 2) {

--- a/lib/getVersion.ts
+++ b/lib/getVersion.ts
@@ -1,8 +1,55 @@
+import { createRequire } from "node:module"
 import pkg from "../package.json"
 import semver from "semver"
 
-// HACK: at build time the version is old (a patch release behind), we need to
-// fix this at some point...
-export const getVersion = () => {
-  return semver.inc(pkg.version, "patch") ?? pkg.version
+const require = createRequire(import.meta.url)
+
+type VersionResolver = (packageName: string) => string | undefined
+
+const resolvePackageVersionFromNodeModules: VersionResolver = (packageName) => {
+  try {
+    const packageJson = require(`${packageName}/package.json`) as {
+      version?: string
+    }
+    return packageJson.version
+  } catch {
+    return undefined
+  }
+}
+
+const getCliVersion = () => semver.inc(pkg.version, "patch") ?? pkg.version
+
+type GlobalWithTscircuitVersion = typeof globalThis & {
+  TSCIRCUIT_VERSION?: string
+}
+
+export const getVersionInfo = (
+  resolvePackageVersion: VersionResolver = resolvePackageVersionFromNodeModules,
+) => {
+  const cliVersion = getCliVersion()
+  const tscircuitVersion =
+    (globalThis as GlobalWithTscircuitVersion).TSCIRCUIT_VERSION ??
+    resolvePackageVersion("tscircuit")
+
+  return {
+    tscircuitVersion,
+    cliVersion,
+    runframeVersion: resolvePackageVersion("@tscircuit/runframe"),
+    coreVersion: resolvePackageVersion("@tscircuit/core"),
+  }
+}
+
+export const getVersion = ({ verbose = false }: { verbose?: boolean } = {}) => {
+  const versions = getVersionInfo()
+
+  if (!verbose) {
+    return versions.tscircuitVersion ?? versions.cliVersion
+  }
+
+  return [
+    `tscircuit: ${versions.tscircuitVersion ?? "not installed"}`,
+    `@tscircuit/cli: ${versions.cliVersion}`,
+    `@tscircuit/runframe: ${versions.runframeVersion ?? "not installed"}`,
+    `@tscircuit/core: ${versions.coreVersion ?? "not installed"}`,
+  ].join("\n")
 }

--- a/tests/lib/getVersion.test.ts
+++ b/tests/lib/getVersion.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, expect, test } from "bun:test"
+import { getVersion, getVersionInfo } from "lib/getVersion"
+
+type GlobalWithTscircuitVersion = typeof globalThis & {
+  TSCIRCUIT_VERSION?: string
+}
+
+afterEach(() => {
+  delete (globalThis as GlobalWithTscircuitVersion).TSCIRCUIT_VERSION
+})
+
+test("getVersion prefers global TSCIRCUIT_VERSION when available", () => {
+  ;(globalThis as GlobalWithTscircuitVersion).TSCIRCUIT_VERSION = "9.9.9"
+
+  const output = getVersion()
+
+  expect(output).toBe("9.9.9")
+})
+
+test("getVersionInfo falls back to package resolver when global version is absent", () => {
+  const versions = getVersionInfo((packageName) => {
+    if (packageName === "tscircuit") return "1.2.3"
+    if (packageName === "@tscircuit/runframe") return "4.5.6"
+    if (packageName === "@tscircuit/core") return "7.8.9"
+    return undefined
+  })
+
+  expect(versions.tscircuitVersion).toBe("1.2.3")
+  expect(versions.runframeVersion).toBe("4.5.6")
+  expect(versions.coreVersion).toBe("7.8.9")
+  expect(versions.cliVersion).toBeString()
+})
+
+test("getVersion verbose output prints all requested packages", () => {
+  ;(globalThis as GlobalWithTscircuitVersion).TSCIRCUIT_VERSION = "3.2.1"
+
+  const output = getVersion({ verbose: true })
+
+  expect(output).toContain("tscircuit: 3.2.1")
+  expect(output).toContain("@tscircuit/cli:")
+  expect(output).toContain("@tscircuit/runframe:")
+  expect(output).toContain("@tscircuit/core:")
+})


### PR DESCRIPTION
### Motivation
- Ensure `tsci --version`/`tsci version` show the actual `tscircuit` version when available (including the `globalThis.TSCIRCUIT_VERSION` hook) instead of always showing the `@tscircuit/cli` package version.
- Provide a `--verbose` option that surfaces related package versions (`tscircuit`, `@tscircuit/cli`, `@tscircuit/runframe`, `@tscircuit/core`) for debugging and support scenarios.

### Description
- Reworked version resolution in `lib/getVersion.ts` to export `getVersionInfo` and `getVersion`, preferring `globalThis.TSCIRCUIT_VERSION` then installed `tscircuit` and falling back to the CLI package version, and to resolve `@tscircuit/runframe` and `@tscircuit/core` when requested.
- Updated CLI wiring in `cli/main.ts` so the manual `--version` handling and the `version` subcommand accept `--verbose` and pass a `verbose` flag into `getVersion`.
- Added unit tests in `tests/lib/getVersion.test.ts` covering global `TSCIRCUIT_VERSION` precedence, resolver fallback behavior, and verbose multi-package output formatting.

### Testing
- Ran `bun test tests/lib/getVersion.test.ts` which passed (3 tests, 0 failures). 
- Ran type-checking with `bunx tsc --noEmit` which completed successfully. 
- Ran formatting with `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b46e8dd544832e90fbd45e857ff7f1)