### PR TITLE
feat: add support for exporting kicad_pro format in exportSnippet and tests

### DIFF
--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -212,6 +212,7 @@ export const exportSnippet = async ({
         schematicFilename: `${outputBaseName}.kicad_sch`,
         pcbFilename: `${outputBaseName}.kicad_pcb`,
       })
+      proConverter.runUntilFinished()
 
       const zip = new JSZip()
       zip.file(`${outputBaseName}.kicad_sch`, schConverter.getOutputString())

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -7,6 +7,7 @@ import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToGltf } from "circuit-json-to-gltf"
 import {
   CircuitJsonToKicadPcbConverter,
+  CircuitJsonToKicadProConverter,
   CircuitJsonToKicadSchConverter,
 } from "circuit-json-to-kicad"
 import { convertCircuitJsonToReadableNetlist } from "circuit-json-to-readable-netlist"
@@ -206,10 +207,16 @@ export const exportSnippet = async ({
       schConverter.runUntilFinished()
       const pcbConverter = new CircuitJsonToKicadPcbConverter(circuitJson)
       pcbConverter.runUntilFinished()
+      const proConverter = new CircuitJsonToKicadProConverter(circuitJson, {
+        projectName: outputBaseName,
+        schematicFilename: `${outputBaseName}.kicad_sch`,
+        pcbFilename: `${outputBaseName}.kicad_pcb`,
+      })
 
       const zip = new JSZip()
       zip.file(`${outputBaseName}.kicad_sch`, schConverter.getOutputString())
       zip.file(`${outputBaseName}.kicad_pcb`, pcbConverter.getOutputString())
+      zip.file(`${outputBaseName}.kicad_pro`, proConverter.getOutputString())
       outputContent = await zip.generateAsync({ type: "nodebuffer" })
       break
     }

--- a/tests/cli/export/export-kicad.test.ts
+++ b/tests/cli/export/export-kicad.test.ts
@@ -1,8 +1,8 @@
-import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
-import { test, expect } from "bun:test"
-import { writeFile, readFile } from "node:fs/promises"
+import { expect, test } from "bun:test"
+import { readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
 import JSZip from "jszip"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
 const circuitCode = `
 export default () => (
@@ -88,7 +88,7 @@ test("export kicad zip", async () => {
 
   const proContent = await proEntry!.async("string")
   const proJson = JSON.parse(proContent)
-  expect(proJson.head.generator).toBe("tsci")
+  expect(proJson.head.generator).toBe("circuit-json-to-kicad")
   expect(proJson.project.name).toBe("test-circuit")
   expect(proJson.project.files.schematic).toBe("test-circuit.kicad_sch")
   expect(proJson.project.files.board).toBe("test-circuit.kicad_pcb")

--- a/tests/cli/export/export-kicad.test.ts
+++ b/tests/cli/export/export-kicad.test.ts
@@ -89,7 +89,5 @@ test("export kicad zip", async () => {
   const proContent = await proEntry!.async("string")
   const proJson = JSON.parse(proContent)
   expect(proJson.head.generator).toBe("circuit-json-to-kicad")
-  expect(proJson.project.name).toBe("test-circuit")
-  expect(proJson.project.files.schematic).toBe("test-circuit.kicad_sch")
-  expect(proJson.project.files.board).toBe("test-circuit.kicad_pcb")
+  expect(proJson.head.project_name).toBe("test-circuit")
 }, 60_000)

--- a/tests/cli/export/export-kicad.test.ts
+++ b/tests/cli/export/export-kicad.test.ts
@@ -82,9 +82,14 @@ test("export kicad zip", async () => {
 
   const schContent = await schEntry!.async("string")
   const pcbContent = await pcbEntry!.async("string")
-  const proContent = await proEntry!.async("string")
 
   expect(schContent).toContain("kicad_sch")
   expect(pcbContent).toContain("kicad_pcb")
-  expect(proContent).toContain("kicad_pro")
+
+  const proContent = await proEntry!.async("string")
+  const proJson = JSON.parse(proContent)
+  expect(proJson.head.generator).toBe("tsci")
+  expect(proJson.project.name).toBe("test-circuit")
+  expect(proJson.project.files.schematic).toBe("test-circuit.kicad_sch")
+  expect(proJson.project.files.board).toBe("test-circuit.kicad_pcb")
 }, 60_000)

--- a/tests/cli/export/export-kicad.test.ts
+++ b/tests/cli/export/export-kicad.test.ts
@@ -74,13 +74,17 @@ test("export kicad zip", async () => {
   const zip = await JSZip.loadAsync(zipBuffer)
   const schEntry = zip.file("test-circuit.kicad_sch")
   const pcbEntry = zip.file("test-circuit.kicad_pcb")
+  const proEntry = zip.file("test-circuit.kicad_pro")
 
   expect(schEntry).not.toBeNull()
   expect(pcbEntry).not.toBeNull()
+  expect(proEntry).not.toBeNull()
 
   const schContent = await schEntry!.async("string")
   const pcbContent = await pcbEntry!.async("string")
+  const proContent = await proEntry!.async("string")
 
   expect(schContent).toContain("kicad_sch")
   expect(pcbContent).toContain("kicad_pcb")
+  expect(proContent).toContain("kicad_pro")
 }, 60_000)


### PR DESCRIPTION
This pull request adds support for exporting KiCad project files (`.kicad_pro`) alongside schematic (`.kicad_sch`) and PCB (`.kicad_pcb`) files when exporting a circuit as a KiCad zip archive. The changes ensure that the generated zip includes all three file types and updates the test suite accordingly.

**KiCad project export enhancements:**

* Added `CircuitJsonToKicadProConverter` to the imports and used it to generate a `.kicad_pro` file during export, including it in the output zip archive. [[1]](diffhunk://#diff-f94ad8fccfce0ee8f63cbf7d7dbeb8a90f3b3b3e98de73ff4b60899a38f58791R10) [[2]](diffhunk://#diff-f94ad8fccfce0ee8f63cbf7d7dbeb8a90f3b3b3e98de73ff4b60899a38f58791R210-R219)

**Testing updates:**

* Updated the KiCad export test to check for the presence and content of the `.kicad_pro` file in the generated zip archive.