### PR TITLE
fix: place SVGs in component subdirectories with explicit format flags

### DIFF
--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -356,7 +356,7 @@ export const registerBuild = (program: Command) => {
             hasAnyImageFormatSelected(imageFormatSelection),
         )
         const shouldGenerateAllPreviewImages = Boolean(
-          resolvedOptions?.allImages,
+          resolvedOptions?.allImages || hasExplicitImageFormatSelection,
         )
         const shouldGeneratePreviewAssetsInWorker = Boolean(
           resolvedOptions?.ci &&

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { readFile, stat, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
@@ -154,6 +154,36 @@ test("build --pcb-only generates only pcb.svg", async () => {
     stat(path.join(tmpDir, "dist", "preview", "3d.png")),
   ).rejects.toBeTruthy()
 }, 30_000)
+
+test("build --pcb-svgs --schematic-svgs places SVGs in each component subdirectory", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const firstCircuit = path.join(tmpDir, "first.circuit.tsx")
+  const secondCircuit = path.join(tmpDir, "second.circuit.tsx")
+  await writeFile(firstCircuit, circuitCode)
+  await writeFile(secondCircuit, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --pcb-svgs --schematic-svgs`)
+
+  // SVGs should be in each component's subdirectory
+  for (const name of ["first", "second"]) {
+    const pcbSvg = await readFile(
+      path.join(tmpDir, "dist", name, "pcb.svg"),
+      "utf-8",
+    )
+    expect(pcbSvg).toContain("<svg")
+
+    const schematicSvg = await readFile(
+      path.join(tmpDir, "dist", name, "schematic.svg"),
+      "utf-8",
+    )
+    expect(schematicSvg).toContain("<svg")
+  }
+
+  // SVGs should NOT be at dist root
+  expect(stat(path.join(tmpDir, "dist", "pcb.svg"))).rejects.toBeTruthy()
+  expect(stat(path.join(tmpDir, "dist", "schematic.svg"))).rejects.toBeTruthy()
+}, 60_000)
 
 test("build --schematic-only generates only schematic.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()


### PR DESCRIPTION
## Summary

- When `--pcb-svgs`, `--schematic-svgs`, or other explicit image format flags are used, SVGs are now generated for **all** builds (matching `--glbs` behavior) instead of only the preview build
- Previously, building multiple components with `--pcb-svgs --schematic-svgs` would only generate SVGs for the preview component, and multi-build scenarios could result in SVGs landing at the dist root instead of component subdirectories

Fixes tscircuit/tscircuit#2550


## Test plan

- [x] Added test: `build --pcb-svgs --schematic-svgs places SVGs in each component subdirectory` — builds two components, verifies SVGs exist in `dist/first/` and `dist/second/`, and verifies no SVGs at `dist/` root
- [x] All existing build tests pass (12/12 in `build.test.ts`, 8/8 in `build-output-flags.test.ts`, 2/2 in concurrency tests)