### PR TITLE
feat: add bom-csv export format

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "@tscircuit/cli",
+      "dependencies": {
+        "circuit-json-to-bom-csv": "^0.0.8",
+      },
       "devDependencies": {
         "@babel/standalone": "^7.26.9",
         "@biomejs/biome": "^1.9.4",
@@ -456,6 +459,8 @@
 
     "circuit-json": ["circuit-json@0.0.403", "", {}, "sha512-38PION1aDrNiRZbht7X2dsfhJ8DCUG4l4d9iSOowEppBFZqM5uV1av0ipB7jc/k6+/Bva1k17XsFFoiJ1RNxNw=="],
 
+    "circuit-json-to-bom-csv": ["circuit-json-to-bom-csv@0.0.8", "", { "dependencies": { "format-si-prefix": "^0.3.2", "papaparse": "^5.4.1" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-y04yF4TvEMgjFtpkqMkkxcME7apNeIo9q8OPiaj+QeuAWBd+LS7VeYVfFYTj3yKdet6SgE2pzMMVrcSPEd2ucQ=="],
+
     "circuit-json-to-bpc": ["circuit-json-to-bpc@0.0.13", "", { "peerDependencies": { "bpc-graph": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg=="],
 
     "circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.23", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-DSOiXaXOTvjU+7et8ITXb2LjgKto6cQzLv3hReYdXuUNtLw2GVnpOly1G83VcIBcSQ4hRVHI4VMKRyZB3XVzdg=="],
@@ -631,6 +636,8 @@
     "flatqueue": ["flatqueue@3.0.0", "", {}, "sha512-y1deYaVt+lIc/d2uIcWDNd0CrdQTO5xoCjeFdhX0kSXvm2Acm0o+3bAOiYklTEoRyzwio3sv3/IiBZdusbAe2Q=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "format-si-prefix": ["format-si-prefix@0.3.2", "", { "dependencies": { "parseunit": "^0" } }, "sha512-gtCZh4RpmlmEZtyzyvs+FXXWOmdfpQQ0M7mjc81zpAYm5QpsoUDPKhAK+Lj7fJCtZSJpE5xbpCYgspCBxahObQ=="],
 
     "format-si-unit": ["format-si-unit@0.0.3", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-rhw1g1mOoLV497FtKNbzBPE4fJXfWRmIEPRO0DKXpEPvS54vRLjG8e1jE4vOcjZg4bsoOPJkM9jB6yGk+0XKmQ=="],
 
@@ -864,6 +871,8 @@
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "papaparse": ["papaparse@5.5.3", "", {}, "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-color": ["parse-color@1.0.0", "", { "dependencies": { "color-convert": "~0.5.0" } }, "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw=="],
@@ -873,6 +882,8 @@
     "parse-ms": ["parse-ms@2.1.0", "", {}, "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="],
 
     "parsel-js": ["parsel-js@1.2.2", "", {}, "sha512-AVJMlwQ4bL2Y0VvYJGk+Fp7eX4SCH2uFoNApmn4yKWACUewZ+alwW3tyoe1r5Z3aLYQTuAuPZIyGghMfO/Tlxw=="],
+
+    "parseunit": ["parseunit@0.3.1", "", {}, "sha512-kKtTgCJDsktOHsnvRR/B5DhWi3a/RZ5M9XjVQZGbOatcam+/tk4sMOCQ1WM9Rswfr78zWGBgHNbWTyJvfR0ejg=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -10,6 +10,10 @@ import {
   CircuitJsonToKicadProConverter,
   CircuitJsonToKicadSchConverter,
 } from "circuit-json-to-kicad"
+import {
+  convertCircuitJsonToBomRows,
+  convertBomRowsToCsv,
+} from "circuit-json-to-bom-csv"
 import { convertCircuitJsonToReadableNetlist } from "circuit-json-to-readable-netlist"
 import {
   convertCircuitJsonToPcbSvg,
@@ -39,6 +43,7 @@ export const ALLOWED_EXPORT_FORMATS = [
   "kicad_zip",
   "kicad-library",
   "srj",
+  "bom-csv",
 ] as const
 
 export type ExportFormat = (typeof ALLOWED_EXPORT_FORMATS)[number]
@@ -58,6 +63,7 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   kicad_zip: "-kicad.zip",
   "kicad-library": "",
   srj: ".simple-route.json",
+  "bom-csv": ".bom.csv",
 }
 
 type ExportOptions = {
@@ -163,6 +169,14 @@ export const exportSnippet = async ({
       break
     case "readable-netlist":
       outputContent = convertCircuitJsonToReadableNetlist(circuitJson)
+      break
+    case "bom-csv":
+      {
+        const bomRows = await convertCircuitJsonToBomRows({
+          circuitJson,
+        })
+        outputContent = convertBomRowsToCsv(bomRows)
+      }
       break
     case "gltf":
       outputContent = JSON.stringify(

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bun-match-svg": "^0.0.12",
     "chokidar": "4.0.1",
     "circuit-json": "^0.0.403",
+    "circuit-json-to-bom-csv": "^0.0.8",
     "circuit-json-to-kicad": "^0.0.86",
     "circuit-json-to-readable-netlist": "^0.0.15",
     "circuit-json-to-spice": "^0.0.10",
@@ -95,8 +96,5 @@
     "cli": "bun ./cli/main.ts",
     "pkg-pr-new-release": "bunx pkg-pr-new publish --comment=off --peerDeps"
   },
-  "type": "module",
-  "dependencies": {
-    "circuit-json-to-bom-csv": "^0.0.8"
-  }
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -95,5 +95,8 @@
     "cli": "bun ./cli/main.ts",
     "pkg-pr-new-release": "bunx pkg-pr-new publish --comment=off --peerDeps"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "circuit-json-to-bom-csv": "^0.0.8"
+  }
 }

--- a/tests/cli/export/export-bom-csv.test.ts
+++ b/tests/cli/export/export-bom-csv.test.ts
@@ -1,0 +1,45 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readFile } from "node:fs/promises"
+import path from "node:path"
+
+const circuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor
+      resistance="1k"
+      footprint="0402"
+      name="R1"
+      schX={3}
+      pcbX={3}
+    />
+    <capacitor
+      capacitance="1000pF"
+      footprint="0402"
+      name="C1"
+      schX={-3}
+      pcbX={-3}
+    />
+    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+  </board>
+)`
+
+test("export bom-csv", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "test-circuit.tsx")
+
+  await writeFile(circuitPath, circuitCode)
+
+  const { stdout, stderr } = await runCommand(
+    `tsci export ${circuitPath} -f bom-csv`,
+  )
+  expect(stderr).toBe("")
+
+  const bomCsv = await readFile(
+    path.join(tmpDir, "test-circuit.bom.csv"),
+    "utf-8",
+  )
+  expect(bomCsv).toContain("Designator")
+  expect(bomCsv).toContain("R1")
+  expect(bomCsv).toContain("C1")
+})


### PR DESCRIPTION
/claim #1950

## Summary
- Add `bom-csv` to the list of allowed export formats in `tsci export`
- Use the existing `circuit-json-to-bom-csv` package to convert circuit JSON to BOM CSV
- Add `.bom.csv` output extension mapping
- Add test covering the new export format

## Usage
```bash
tsci export path/to/example.tsx --format bom-csv
# or with custom output path:
tsci export path/to/example.tsx --format bom-csv --output path/to/bom.csv
```

## Changes
- `lib/shared/export-snippet.ts`: Added `bom-csv` format, import, extension mapping, and switch case
- `package.json`: Added `circuit-json-to-bom-csv` dependency
- `tests/cli/export/export-bom-csv.test.ts`: New test for BOM CSV export

## Test plan
- [x] `bun test tests/cli/export/export-bom-csv.test.ts` passes
- [x] Existing export tests still pass (verified readable-netlist)
- [x] `bun run format:check` passes