### PR TITLE
fix: upgrade prompt never showing when tsci is outdated

### DIFF
--- a/lib/shared/check-for-cli-update.ts
+++ b/lib/shared/check-for-cli-update.ts
@@ -9,8 +9,7 @@ import kleur from "kleur"
 import { prompts } from "lib/utils/prompts"
 import { shouldBeInteractive } from "lib/utils/should-be-interactive"
 
-export const currentCliVersion = () =>
-  program?.version() ?? semver.inc(pkgVersion, "patch") ?? pkgVersion
+export const currentCliVersion = () => program?.version() ?? pkgVersion
 
 export const getLatestVersion = async () => {
   const { version: latestCliVersion } = await ky

--- a/tests/cli/upgrade/check-for-cli-update.test.ts
+++ b/tests/cli/upgrade/check-for-cli-update.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import semver from "semver"
+import { currentCliVersion } from "lib/shared/check-for-cli-update"
+import { version as pkgVersion } from "../../../package.json"
+
+test("currentCliVersion matches package.json version exactly", () => {
+  expect(currentCliVersion()).toBe(pkgVersion)
+})
+
+test("update prompt fires when behind latest by one patch", () => {
+  const npmLatest = semver.inc(pkgVersion, "patch")!
+  expect(semver.gt(npmLatest, currentCliVersion())).toBe(true)
+})
+
+test("update prompt fires when behind latest by many versions", () => {
+  const npmLatest = semver.inc(semver.inc(pkgVersion, "minor")!, "patch")!
+  expect(semver.gt(npmLatest, currentCliVersion())).toBe(true)
+})
+
+test("update prompt does not fire when already on latest", () => {
+  expect(semver.gt(pkgVersion, currentCliVersion())).toBe(false)
+})


### PR DESCRIPTION
`currentCliVersion()` imports program from cli/main but `.version()` is never set on the commander program (version flags are handled manually). This caused `program.version()` to always return undefined, falling back to `semver.inc(pkgVersion, "patch")` — one patch above the real version. Since the reported version was always artificially higher `semver.gt(latestNpmVersion, currentCliVersion())`was always false and the update prompt never fired. Fixed by falling back directly to pkgVersion.