### PR TITLE
Fix direct LCSC code import when search returns no results

### DIFF
--- a/cli/import/parse-direct-lcsc-part-number.ts
+++ b/cli/import/parse-direct-lcsc-part-number.ts
@@ -1,0 +1,6 @@
+export const parseDirectLcscPartNumber = (query: string): string | null => {
+  const normalizedQuery = query.trim().toUpperCase()
+  const directPartMatch = normalizedQuery.match(/^C?(\d+)$/)
+  if (!directPartMatch) return null
+  return `C${directPartMatch[1]}`
+}

--- a/cli/import/register.ts
+++ b/cli/import/register.ts
@@ -6,6 +6,7 @@ import { getRegistryApiKy } from "lib/registry-api/get-ky"
 import { addPackage } from "lib/shared/add-package"
 import { prompts } from "lib/utils/prompts"
 import ora from "ora"
+import { parseDirectLcscPartNumber } from "./parse-direct-lcsc-part-number"
 
 export const registerImport = (program: Command) => {
   program
@@ -87,6 +88,29 @@ export const registerImport = (program: Command) => {
         spinner.stop()
 
         if (!registryResults.length && !jlcResults?.length) {
+          const directLcscPartNumber = searchJlc
+            ? parseDirectLcscPartNumber(query)
+            : null
+          if (directLcscPartNumber) {
+            const importSpinner = ora({
+              text: `Importing "${directLcscPartNumber}" from JLCPCB...`,
+              stream: process.stdout,
+            }).start()
+            try {
+              const { filePath } = await importComponentFromJlcpcb(
+                directLcscPartNumber,
+                process.cwd(),
+                { download: opts.download },
+              )
+              importSpinner.succeed(kleur.green(`Imported ${filePath}`))
+              return
+            } catch (error) {
+              importSpinner.fail(kleur.red("Failed to import part"))
+              console.error(error instanceof Error ? error.message : error)
+              return process.exit(1)
+            }
+          }
+
           console.log(
             kleur.yellow(
               `No results found for "${query}" in the tscircuit registry or JLCPCB.`,

--- a/tests/cli/import/parse-direct-lcsc-part-number.test.ts
+++ b/tests/cli/import/parse-direct-lcsc-part-number.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { parseDirectLcscPartNumber } from "cli/import/parse-direct-lcsc-part-number"
+
+test("parseDirectLcscPartNumber returns C-prefixed part for raw part number", () => {
+  expect(parseDirectLcscPartNumber("14877")).toBe("C14877")
+})
+
+test("parseDirectLcscPartNumber returns normalized C-prefixed part for prefixed query", () => {
+  expect(parseDirectLcscPartNumber("c14877")).toBe("C14877")
+})
+
+test("parseDirectLcscPartNumber returns null for non-part queries", () => {
+  expect(parseDirectLcscPartNumber("RP2040")).toBe(null)
+})


### PR DESCRIPTION
### Motivation
- The `tsci import` command would immediately fail with "No results found" when both registry and JLCPCB searches returned empty even if the query was a direct LCSC/JLC part code like `14877` or `C14877`.
- Provide a better UX by attempting a direct import for numeric/LCSC-style queries before bailing out.

### Description
- Add `cli/import/parse-direct-lcsc-part-number.ts` which normalizes numeric or `C`-prefixed queries to the form `C<digits>` via `parseDirectLcscPartNumber`.
- Update `cli/import/register.ts` to call `parseDirectLcscPartNumber` as a fallback when both registry and JLC search results are empty and to attempt `importComponentFromJlcpcb` for matched direct part numbers.
- Add unit tests in `tests/cli/import/parse-direct-lcsc-part-number.test.ts` to validate parsing of raw numbers, `C`-prefixed input, and non-part strings.

### Testing
- Ran `bun test tests/cli/import/parse-direct-lcsc-part-number.test.ts` and all tests passed.
- Ran typecheck with `bunx tsc --noEmit` and it succeeded with no errors.
- Ran formatting with `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c45b72da00832eacb1235c54aceda7)