### PR TITLE
Make JLCPCB the default search target (registry opt-in)

### DIFF
--- a/cli/import/register.ts
+++ b/cli/import/register.ts
@@ -32,7 +32,7 @@ export const registerImport = (program: Command) => {
         const query = getQueryFromParts(queryParts)
         const hasFilters = opts.jlcpcb || opts.lcsc || opts.tscircuit
         const searchJlc = opts.jlcpcb || opts.lcsc || !hasFilters
-        const searchTscircuit = opts.tscircuit || !hasFilters
+        const searchTscircuit = opts.tscircuit
         const ky = getRegistryApiKy()
         const spinner = ora({
           text: "Searching...",

--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -33,9 +33,9 @@ export const registerSearch = (program: Command) => {
         const query = getQueryFromParts(queryParts)
         const hasFilters =
           opts.kicad || opts.jlcpcb || opts.lcsc || opts.tscircuit
-        const searchKicad = opts.kicad || !hasFilters
+        const searchKicad = opts.kicad
         const searchJlc = opts.jlcpcb || opts.lcsc || !hasFilters
-        const searchTscircuit = opts.tscircuit || !hasFilters
+        const searchTscircuit = opts.tscircuit
 
         let results: {
           packages: Array<{

--- a/tests/cli/search/search-kicad.test.ts
+++ b/tests/cli/search/search-kicad.test.ts
@@ -1,10 +1,12 @@
 import { expect, test } from "bun:test"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
-test("search command returns kicad footprint results", async () => {
+test("search --kicad returns kicad footprint results", async () => {
   const { runCommand } = await getCliTestFixture()
-  const { stdout, stderr } = await runCommand("tsci search R_0805")
+  const { stdout, stderr } = await runCommand("tsci search --kicad R_0805")
   expect(stderr).toBe("")
   expect(stdout).toContain("KiCad")
   expect(stdout).toMatch(/kicad:.*R_0805/)
+  expect(stdout).not.toContain("tscircuit registry")
+  expect(stdout).not.toContain("JLC search")
 })

--- a/tests/cli/search/search.test.ts
+++ b/tests/cli/search/search.test.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "bun:test"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
-test("search command returns registry and jlc results", async () => {
+test("search command returns jlc results by default", async () => {
   const { runCommand } = await getCliTestFixture()
   const { stdout, stderr } = await runCommand("tsci search 555")
   // Should not output prompts in test mode
   expect(stderr).toBe("")
-  expect(stdout).toContain("tscircuit registry")
   expect(stdout).toContain("JLC search")
-  expect(stdout.toLowerCase()).toContain("stars")
+  expect(stdout).not.toContain("tscircuit registry")
 })


### PR DESCRIPTION
### Motivation
- The search/import commands should not query the tscircuit registry by default and should only search JLCPCB unless the user explicitly opts into registry or KiCad results.

### Description
- Changed `cli/search/register.ts` so `--tscircuit` and `--kicad` are opt-in flags rather than defaults when no filters are provided. 
- Changed `cli/import/register.ts` so the tscircuit registry is only searched when `--tscircuit` is passed. 
- Updated `tests/cli/search/search.test.ts` to assert that JLCPCB results are returned by default and the tscircuit registry is not included.

### Testing
- Ran `bun test tests/cli/search/search.test.ts` which passed. 
- Ran `bun test tests/cli/search` where unrelated KiCad-oriented tests timed out/failed in this environment (note: failure appears unrelated to these changes). 
- Ran `bunx tsc --noEmit` which completed successfully. 
- Ran `bun run format` to apply formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c4651432b4832eba2fc96cd7eb14da)