### PR TITLE
Add support for `tsci build --3d-png`

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -37,6 +37,7 @@ export interface BuildCommandOptions {
   pcbPng?: boolean
   schematicSvgs?: boolean
   "3d"?: boolean
+  "3dPng"?: boolean
   pcbOnly?: boolean
   schematicOnly?: boolean
 }

--- a/cli/build/image-format-selection.ts
+++ b/cli/build/image-format-selection.ts
@@ -39,7 +39,12 @@ const hasNewOutputFlags = (options?: BuildCommandOptions) =>
   )
 
 const hasEstablishedOutputFlags = (options?: BuildCommandOptions) =>
-  Boolean(options?.["3d"] || options?.pcbOnly || options?.schematicOnly)
+  Boolean(
+    options?.["3d"] ||
+      options?.["3dPng"] ||
+      options?.pcbOnly ||
+      options?.schematicOnly,
+  )
 
 export const resolveImageFormatSelection = (
   options?: BuildCommandOptions,
@@ -60,7 +65,7 @@ export const resolveImageFormatSelection = (
 
   if (!hasNewFlags && hasEstablishedFlags) {
     const selection: BuildImageFormatSelection = {
-      threeDPngs: Boolean(options?.["3d"]),
+      threeDPngs: Boolean(options?.["3d"] || options?.["3dPng"]),
       pcbPngs: false,
       pcbSvgs: true,
       schematicSvgs: true,
@@ -94,7 +99,7 @@ export const resolveImageFormatSelection = (
   if (options?.schematicSvgs) {
     selection.schematicSvgs = true
   }
-  if (options?.pngs || options?.["3d"]) {
+  if (options?.pngs || options?.["3d"] || options?.["3dPng"]) {
     selection.threeDPngs = true
   }
 

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -147,6 +147,7 @@ export const registerBuild = (program: Command) => {
       "--schematic-svgs",
       "Generate schematic SVG outputs during build generation",
     )
+    .option("--3d-png", "Generate 3D PNG outputs during build generation")
     .option("--3d", "Generate 3D PNG outputs during build generation")
     .option(
       "--pcb-only",
@@ -885,6 +886,7 @@ export const registerBuild = (program: Command) => {
           resolvedOptions?.svgs && "svgs",
           resolvedOptions?.pcbSvgs && "pcb-svgs",
           resolvedOptions?.schematicSvgs && "schematic-svgs",
+          resolvedOptions?.["3dPng"] && "3d-png",
           resolvedOptions?.["3d"] && "3d",
           resolvedOptions?.pcbOnly && "pcb-only",
           resolvedOptions?.schematicOnly && "schematic-only",

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -160,6 +160,36 @@ test("build --3d generates pcb.svg, schematic.svg, and 3d.png", async () => {
   expect(preview3d[3]).toBe(0x47)
 }, 30_000)
 
+test("build --3d-png generates pcb.svg, schematic.svg, and 3d.png", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --3d-png ${circuitPath}`)
+
+  const pcbSvg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
+  expect(pcbSvg).toContain("<svg")
+
+  const schematicSvg = await readFile(
+    path.join(tmpDir, "dist", "preview", "schematic.svg"),
+    "utf-8",
+  )
+  expect(schematicSvg).toContain("<svg")
+
+  const preview3d = await readFile(
+    path.join(tmpDir, "dist", "preview", "3d.png"),
+  )
+  expect(preview3d.byteLength).toBeGreaterThan(0)
+  expect(preview3d[0]).toBe(0x89)
+  expect(preview3d[1]).toBe(0x50)
+  expect(preview3d[2]).toBe(0x4e)
+  expect(preview3d[3]).toBe(0x47)
+}, 30_000)
+
 test("build --pcb-only generates only pcb.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")


### PR DESCRIPTION
### Motivation
- Provide an explicit, discoverable `--3d-png` flag so users can request 3D PNG preview outputs independently of legacy flags and improve CLI clarity and compatibility.

### Description
- Add a new `"3dPng"?: boolean` field to `BuildCommandOptions` so the flag is typed and available through the build options surface (`cli/build/build-ci.ts`).
- Wire the `--3d-png` option into the CLI by registering `.option("--3d-png", ...)` and including `3d-png` in the build summary output list (`cli/build/register.ts`).
- Extend the image selection logic in `resolveImageFormatSelection` to treat `--3d-png` as an established flag and enable `threeDPngs` when present, preserving compatibility with other output flags (`cli/build/image-format-selection.ts`).
- Add an integration test that verifies `tsci build --3d-png` produces `pcb.svg`, `schematic.svg`, and `3d.png` (`tests/cli/build/build-output-flags.test.ts`).

### Testing
- Ran `bun test tests/cli/build/build-output-flags.test.ts` and the test file passed (9 passed, 0 failed). 
- Ran `bunx tsc --noEmit` for type checking which completed without errors. 
- Ran `bun run format` to apply formatting (no unexpected changes remain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c4a7fd11d4832eaf845a0515934060)