### PR TITLE
Enable worker pool heartbeat logs by default and increase interval to 30s

### DIFF
--- a/lib/shared/thread-worker-pool.ts
+++ b/lib/shared/thread-worker-pool.ts
@@ -31,6 +31,7 @@ type ThreadWorkerPoolOptions<TJob, TWorkerInput, TWorkerOutput, TResult> = {
 }
 
 const DEFAULT_WORKER_JOB_TIMEOUT_MS = 3 * 60 * 1000
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30 * 1000
 
 export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
   private workers: Array<ThreadWorker<TJob, TResult>> = []
@@ -96,11 +97,8 @@ export class ThreadWorkerPool<TJob, TWorkerInput, TWorkerOutput, TResult> {
       return
     }
 
-    if (process.env.DEBUG !== "1") {
-      return
-    }
-
-    const heartbeatIntervalMs = this.options.heartbeatIntervalMs ?? 5000
+    const heartbeatIntervalMs =
+      this.options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS
     if (heartbeatIntervalMs <= 0) {
       return
     }

--- a/tests/shared/thread-worker-pool-timeout.test.ts
+++ b/tests/shared/thread-worker-pool-timeout.test.ts
@@ -215,9 +215,8 @@ test("thread worker pool emits heartbeat logs when DEBUG is not 1", async () => 
 
     await new Promise((resolve) => setTimeout(resolve, 80))
 
-    const detailedHeartbeat = logs.find(
-      (line) =>
-        line.includes("[worker-pool] heartbeat:"),
+    const detailedHeartbeat = logs.find((line) =>
+      line.includes("[worker-pool] heartbeat:"),
     )
 
     expect(detailedHeartbeat).toBeDefined()

--- a/tests/shared/thread-worker-pool-timeout.test.ts
+++ b/tests/shared/thread-worker-pool-timeout.test.ts
@@ -129,7 +129,7 @@ test("thread worker pool logs when a job times out", async () => {
   }
 })
 
-test("thread worker pool emits heartbeat logs only when DEBUG=1", async () => {
+test("thread worker pool emits heartbeat logs when DEBUG=1", async () => {
   const previousDebug = process.env.DEBUG
   process.env.DEBUG = "1"
 
@@ -181,7 +181,7 @@ test("thread worker pool emits heartbeat logs only when DEBUG=1", async () => {
   }
 })
 
-test("thread worker pool does not emit heartbeat logs when DEBUG is not 1", async () => {
+test("thread worker pool emits heartbeat logs when DEBUG is not 1", async () => {
   const previousDebug = process.env.DEBUG
   process.env.DEBUG = undefined
 
@@ -215,11 +215,12 @@ test("thread worker pool does not emit heartbeat logs when DEBUG is not 1", asyn
 
     await new Promise((resolve) => setTimeout(resolve, 80))
 
-    const detailedHeartbeat = logs.find((line) =>
-      line.includes("[worker-pool] heartbeat:"),
+    const detailedHeartbeat = logs.find(
+      (line) =>
+        line.includes("[worker-pool] heartbeat:"),
     )
 
-    expect(detailedHeartbeat).toBeUndefined()
+    expect(detailedHeartbeat).toBeDefined()
   } finally {
     await pool.terminate()
     if (previousDebug === undefined) {


### PR DESCRIPTION
### Motivation
- Heartbeat logs from the thread worker pool should be available whenever a consumer registers `onLog` instead of being gated by `DEBUG=1`.
- Increase the default heartbeat interval to reduce log noise and resource churn by moving from 5s to 30s.

### Description
- Removed the `process.env.DEBUG === "1"` guard in `ThreadWorkerPool.startHeartbeat()` so heartbeats are emitted whenever `onLog` is provided (file: `lib/shared/thread-worker-pool.ts`).
- Added a new constant `DEFAULT_HEARTBEAT_INTERVAL_MS = 30 * 1000` and used it as the fallback for `heartbeatIntervalMs` (file: `lib/shared/thread-worker-pool.ts`).
- Updated tests to reflect that heartbeat logging is enabled regardless of the `DEBUG` env var and adjusted expectations and test names accordingly (file: `tests/shared/thread-worker-pool-timeout.test.ts`).

### Testing
- Ran `bun test tests/shared/thread-worker-pool-timeout.test.ts`, which completed successfully with `4 pass` and `0 fail`.
- The updated heartbeat tests assert that heartbeat lines are present when `onLog` is provided both with and without `DEBUG` set to `1` (all assertions passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c8c34531fc8327842afc5dbaf1e90c)