### PR TITLE
Fix: Show Cli Version Instead of tscircuit Version

### DIFF
--- a/lib/getVersion.ts
+++ b/lib/getVersion.ts
@@ -43,7 +43,7 @@ export const getVersion = ({ verbose = false }: { verbose?: boolean } = {}) => {
   const versions = getVersionInfo()
 
   if (!verbose) {
-    return versions.tscircuitVersion ?? versions.cliVersion
+    return versions.cliVersion ?? versions.tscircuitVersion
   }
 
   return [


### PR DESCRIPTION
this is confusing for the user which cli version is installed this helps tracking based on cli version but not on tscircuit version.


<img width="433" height="100" alt="image" src="https://github.com/user-attachments/assets/85846ad4-b098-440b-bdc2-d870417d23a4" />



<img width="412" height="104" alt="image" src="https://github.com/user-attachments/assets/a5e00c23-fdbb-429b-bb20-da674968776c" />
