### PR TITLE
fix: pass pcbSnapshotSettings to build preview image generation

### DIFF
--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -7,6 +7,7 @@ import {
   convertCircuitJsonToSchematicSvg,
 } from "circuit-to-svg"
 import { getCircuitJsonToGltfOptions } from "lib/shared/get-circuit-json-to-gltf-options"
+import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
 import { renderGLTFToPNGBufferFromGLBBuffer } from "poppygl"
 import { convertModelUrlsToFileUrls } from "./convert-model-urls-to-file-urls"
 import type { BuildImageFormatSelection } from "./image-format-selection"
@@ -71,11 +72,13 @@ const generatePreviewAssets = async ({
   outputDir,
   distDir,
   imageFormats,
+  pcbSnapshotSettings,
 }: {
   build: BuildFileResult
   outputDir: string
   distDir: string
   imageFormats: BuildImageFormatSelection
+  pcbSnapshotSettings?: PcbSnapshotSettings
 }) => {
   const prefixRelative = path.relative(distDir, outputDir) || "."
   const prefix = prefixRelative === "." ? "" : `[${prefixRelative}] `
@@ -94,7 +97,10 @@ const generatePreviewAssets = async ({
   if (imageFormats.pcbSvgs) {
     try {
       console.log(`${prefix}Generating PCB SVG...`)
-      const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+      const pcbSvg = convertCircuitJsonToPcbSvg(
+        circuitJson,
+        pcbSnapshotSettings,
+      )
       fs.writeFileSync(path.join(outputDir, "pcb.svg"), pcbSvg, "utf-8")
       console.log(`${prefix}Written pcb.svg`)
     } catch (error) {
@@ -105,7 +111,10 @@ const generatePreviewAssets = async ({
   if (imageFormats.pcbPngs) {
     try {
       console.log(`${prefix}Generating PCB PNG...`)
-      const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+      const pcbSvg = convertCircuitJsonToPcbSvg(
+        circuitJson,
+        pcbSnapshotSettings,
+      )
       fs.writeFileSync(
         path.join(outputDir, "pcb.png"),
         await convertSvgToPngBuffer(pcbSvg),
@@ -160,6 +169,7 @@ export const buildPreviewImages = async ({
   previewComponentPath,
   allImages,
   imageFormats,
+  pcbSnapshotSettings,
 }: {
   builtFiles: BuildFileResult[]
   distDir: string
@@ -167,6 +177,7 @@ export const buildPreviewImages = async ({
   previewComponentPath?: string
   allImages?: boolean
   imageFormats: BuildImageFormatSelection
+  pcbSnapshotSettings?: PcbSnapshotSettings
 }) => {
   const successfulBuilds = builtFiles.filter((file) => file.ok)
   // previewComponentPath takes precedence over mainEntrypoint for preview images
@@ -190,6 +201,7 @@ export const buildPreviewImages = async ({
         outputDir,
         distDir,
         imageFormats,
+        pcbSnapshotSettings,
       })
     }
     return
@@ -215,6 +227,7 @@ export const buildPreviewImages = async ({
   await generatePreviewAssets({
     build: previewBuild,
     outputDir: path.dirname(previewBuild.outputPath),
+    pcbSnapshotSettings,
     distDir,
     imageFormats,
   })

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -356,6 +356,7 @@ export const registerBuild = (program: Command) => {
           injectedProps,
           generatePreviewAssets: false,
           imageFormats: imageFormatSelection,
+          pcbSnapshotSettings: projectConfig?.pcbSnapshotSettings,
         }
 
         const shouldGeneratePreviewImages = Boolean(
@@ -671,6 +672,7 @@ export const registerBuild = (program: Command) => {
               previewComponentPath,
               allImages: shouldGenerateAllPreviewImages,
               imageFormats: imageFormatSelection,
+              pcbSnapshotSettings: projectConfig?.pcbSnapshotSettings,
             })
           }
         }

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -125,6 +125,7 @@ export const handleBuildFile = async (
         await writeImageAssetsFromCircuitJson(circuitJson, {
           outputDir: resolvedPreviewOutputDir,
           imageFormats: options?.imageFormats ?? DEFAULT_IMAGE_FORMAT_SELECTION,
+          pcbSnapshotSettings: options?.pcbSnapshotSettings,
         })
         previewOk = true
       } catch (err) {

--- a/cli/build/worker-output-generators.ts
+++ b/cli/build/worker-output-generators.ts
@@ -8,6 +8,7 @@ import {
 } from "circuit-to-svg"
 import { renderGLTFToPNGBufferFromGLBBuffer } from "poppygl"
 import { getCircuitJsonToGltfOptions } from "../../lib/shared/get-circuit-json-to-gltf-options"
+import type { PcbSnapshotSettings } from "../../lib/project-config/project-config-schema"
 import { convertModelUrlsToFileUrls } from "./convert-model-urls-to-file-urls"
 import {
   normalizeToArrayBuffer,
@@ -36,18 +37,19 @@ export const writeImageAssetsFromCircuitJson = async (
   options: {
     outputDir: string
     imageFormats: BuildImageFormatSelection
+    pcbSnapshotSettings?: PcbSnapshotSettings
   },
 ) => {
-  const { outputDir, imageFormats } = options
+  const { outputDir, imageFormats, pcbSnapshotSettings } = options
   fs.mkdirSync(outputDir, { recursive: true })
 
   if (imageFormats.pcbSvgs) {
-    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson, pcbSnapshotSettings)
     fs.writeFileSync(path.join(outputDir, "pcb.svg"), pcbSvg, "utf-8")
   }
 
   if (imageFormats.pcbPngs) {
-    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson, pcbSnapshotSettings)
     fs.writeFileSync(
       path.join(outputDir, "pcb.png"),
       await convertSvgToPngBuffer(pcbSvg),

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -2,6 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
+import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
 import type { DrcIgnoreOptions } from "./drc-diagnostic-filter"
 import type { BuildImageFormatSelection } from "./image-format-selection"
 import type {
@@ -26,6 +27,7 @@ type BuildJob = {
       injectedProps?: Record<string, unknown>
       generatePreviewAssets?: boolean
       imageFormats?: BuildImageFormatSelection
+      pcbSnapshotSettings?: PcbSnapshotSettings
     }
 }
 
@@ -68,6 +70,7 @@ export async function buildFilesWithWorkerPool(options: {
       injectedProps?: Record<string, unknown>
       generatePreviewAssets?: boolean
       imageFormats?: BuildImageFormatSelection
+      pcbSnapshotSettings?: PcbSnapshotSettings
     }
   onLog?: (lines: string[]) => void
   onJobComplete?: (result: BuildJobResult) => void

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -1,4 +1,5 @@
 import type { PlatformConfig } from "@tscircuit/props"
+import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
 import type { DrcIgnoreCounts, DrcIgnoreOptions } from "./drc-diagnostic-filter"
 import type { BuildImageFormatSelection } from "./image-format-selection"
 
@@ -21,6 +22,7 @@ export type BuildFileMessage = {
       injectedProps?: Record<string, unknown>
       generatePreviewAssets?: boolean
       imageFormats?: BuildImageFormatSelection
+      pcbSnapshotSettings?: PcbSnapshotSettings
     }
 }
 

--- a/tests/cli/build/build-pcb-svgs-courtyards-enabled.test.ts
+++ b/tests/cli/build/build-pcb-svgs-courtyards-enabled.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("build --pcb-svgs includes courtyards when pcbSnapshotSettings.showCourtyards is true", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(
+    circuitPath,
+    `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)`,
+  )
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ pcbSnapshotSettings: { showCourtyards: true } }),
+  )
+
+  await runCommand(`tsci build --pcb-svgs ${circuitPath}`)
+
+  const svg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
+  expect(svg).toContain("pcb-courtyard-")
+}, 30_000)

--- a/tests/cli/build/build-preview-images-courtyards-enabled.test.ts
+++ b/tests/cli/build/build-preview-images-courtyards-enabled.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("build --preview-images includes courtyards when pcbSnapshotSettings.showCourtyards is true", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(
+    circuitPath,
+    `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)`,
+  )
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ pcbSnapshotSettings: { showCourtyards: true } }),
+  )
+
+  await runCommand(`tsci build --preview-images ${circuitPath}`)
+
+  const svg = await readFile(
+    path.join(tmpDir, "dist", "preview", "pcb.svg"),
+    "utf-8",
+  )
+  expect(svg).toContain("pcb-courtyard-")
+}, 60_000)

--- a/tests/cli/build/worker-output-courtyards-enabled.test.ts
+++ b/tests/cli/build/worker-output-courtyards-enabled.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { temporaryDirectory } from "tempy"
+import { writeImageAssetsFromCircuitJson } from "cli/build/worker-output-generators"
+
+test("writeImageAssetsFromCircuitJson includes courtyards when showCourtyards is true", async () => {
+  const outputDir = temporaryDirectory()
+
+  const circuitJson = [
+    {
+      type: "pcb_courtyard_rect",
+      pcb_courtyard_rect_id: "courtyard_test",
+      layer: "top",
+      center: { x: 0, y: 0 },
+      width: 2,
+      height: 2,
+    },
+  ]
+
+  await writeImageAssetsFromCircuitJson(circuitJson as any, {
+    outputDir,
+    imageFormats: {
+      pcbSvgs: true,
+      pcbPngs: false,
+      schematicSvgs: false,
+      threeDPngs: false,
+    },
+    pcbSnapshotSettings: { showCourtyards: true },
+  })
+
+  const svg = await readFile(path.join(outputDir, "pcb.svg"), "utf-8")
+  expect(svg).toContain("pcb-courtyard-")
+})


### PR DESCRIPTION
`pcbSnapshotSettings` from `tscircuit.config.json` (including showCourtyards) was being read correctly for `tsci snapshot` but silently ignored during `tsci build`. This was because both the sequential (buildPreviewImages) and worker (writeImageAssetsFromCircuitJson) image generation paths called `convertCircuitJsonToPcbSvg` without forwarding the config.

Threads `pcbSnapshotSettings` through the full build pipeline for the `--pcb-svgs`, `--pcb-png`, and `--preview-images` flags:
 - Sequential path: `register.ts` → `buildPreviewImages` → `generatePreviewAssets`
 - Worker path (--ci --concurrency >1): `buildOptions` → `BuildFileMessage` → `worker-build-handlers` → `writeImageAssetsFromCircuitJson`