### PR TITLE
Fix search both JLC and tscircuit registry by default

### DIFF
--- a/cli/import/register.ts
+++ b/cli/import/register.ts
@@ -32,7 +32,7 @@ export const registerImport = (program: Command) => {
         const query = getQueryFromParts(queryParts)
         const hasFilters = opts.jlcpcb || opts.lcsc || opts.tscircuit
         const searchJlc = opts.jlcpcb || opts.lcsc || !hasFilters
-        const searchTscircuit = opts.tscircuit
+        const searchTscircuit = opts.tscircuit || !hasFilters
         const ky = getRegistryApiKy()
         const spinner = ora({
           text: "Searching...",

--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -35,7 +35,7 @@ export const registerSearch = (program: Command) => {
           opts.kicad || opts.jlcpcb || opts.lcsc || opts.tscircuit
         const searchKicad = opts.kicad
         const searchJlc = opts.jlcpcb || opts.lcsc || !hasFilters
-        const searchTscircuit = opts.tscircuit
+        const searchTscircuit = opts.tscircuit || !hasFilters
 
         let results: {
           packages: Array<{

--- a/tests/cli/search/search.test.ts
+++ b/tests/cli/search/search.test.ts
@@ -7,5 +7,5 @@ test("search command returns jlc results by default", async () => {
   // Should not output prompts in test mode
   expect(stderr).toBe("")
   expect(stdout).toContain("JLC search")
-  expect(stdout).not.toContain("tscircuit registry")
+  expect(stdout).toContain("tscircuit registry")
 })


### PR DESCRIPTION
Issue: Running tsci search with no flags was silently skipping the tscircuit registry and only hitting JLC. Now it searches both JLC and tscircuit. 

Explicit flags still work as before, No flags means search everything

so AI agents picking components automatically no longer miss half the available parts.