### PR TITLE
Fix placement check reporting for placement DRC errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Overview
+
+This is the tscircuit CLI (`@tscircuit/cli`) - the command-line interface for developing, managing, and publishing tscircuit circuit designs. It's essentially "npm for tscircuit".
+
+## Common Commands
+
+```bash
+# Development
+bun run dev                    # Start dev server with examples/basic/index.circuit.tsx
+bun --hot ./cli/main.ts dev <file>  # Run dev server with specific file
+
+# Building
+bun run build                  # Build the CLI (runs scripts/bun-build.ts)
+
+# Testing
+bun test                       # Run all tests
+bun test tests/cli/build/build.test.ts  # Run a single test file
+bun test --match "build"       # Run tests matching pattern
+
+# Formatting
+bun run format                 # Format with Biome
+bun run format:check           # Check formatting
+
+# Local CLI usage
+bun ./cli/main.ts <command>    # Run CLI commands during development
+```
+
+## Architecture
+
+### Command Structure
+CLI commands use Commander.js with a modular registration pattern. Each command lives in `cli/<command>/register.ts` with a `register*` function that attaches to the program object. Main entry is `cli/main.ts`.
+
+### Key Directories
+- `cli/` - CLI commands, each in its own directory with `register.ts`
+- `lib/` - Shared utility functions and core logic
+- `tests/` - Bun test files, organized by feature
+- `examples/` - Example circuit files for development
+
+### Dev Server (`tsci dev`)
+The dev server uses `@tscircuit/file-server` and `@tscircuit/runframe`. It maintains bidirectional sync:
+- Filesystem → Server: Chokidar watches files, syncs via HTTP
+- Server → Filesystem: Events polled via `EventsWatcher`
+- Binary files (`.glb`, `.png`, `.step`) are base64-encoded
+- Dependencies are analyzed via TypeScript AST and uploaded to file server
+
+### Build System
+- Uses Bun plugins for static asset imports (`.gltf`, `.step`, `.kicad_mod`)
+- Worker pool for parallel builds (`--concurrency` option)
+- Outputs: circuit JSON, PNG previews, GLTF 3D models, KiCad projects, static HTML sites
+
+### Configuration
+- Project config: `tscircuit.config.json` (Zod validated with JSON schema)
+- CLI user config: `Conf` store (XDG-compliant paths)
+- Static assets import handling registered via `lib/shared/register-static-asset-loaders.ts`
+
+## Testing
+
+Tests use Bun's test runner with:
+- `tests/fixtures/get-cli-test-fixture.ts` - Creates isolated test environment with temp directory and mock registry server
+- `tests/fixtures/preload.ts` - Global cleanup handling via `globalThis.deferredCleanupFns`
+- `@tscircuit/fake-snippets` - Mock registry API for testing
+
+Test fixture provides:
+- `tmpDir` - Isolated temp directory
+- `runCommand(cmd)` - Execute CLI commands
+- `registryDb` - Direct database access for assertions
+- `registryApiUrl` - Test server URL
+
+## Code Style
+
+- Files must use kebab-case naming (enforced by Biome)
+- Semicolons: as-needed
+- Trailing commas: all
+- Path aliases available: `lib/*`, `cli/*`, `tests/*`
+
+## Runtime
+
+The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the TypeScript runner, preferring Bun when available. This allows hot-reload during development while maintaining Node.js compatibility.

--- a/cli/check/placement/register.ts
+++ b/cli/check/placement/register.ts
@@ -2,10 +2,146 @@ import {
   analyzeAllPlacements,
   analyzeComponentPlacement,
 } from "@tscircuit/circuit-json-placement-analysis"
+import {
+  categorizeErrorOrWarning,
+  type DrcCategory,
+} from "@tscircuit/circuit-json-util"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import type { Command } from "commander"
+import {
+  analyzeCircuitJson,
+  type CircuitJsonIssue,
+} from "lib/shared/circuit-json-diagnostics"
 import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
+
+type CircuitJsonRecord = Record<string, unknown>
+
+const normalizeCategory = (category: string): DrcCategory =>
+  category === "netlist" ||
+  category === "pin_specification" ||
+  category === "placement" ||
+  category === "routing"
+    ? category
+    : "unknown"
+
+const isPlacementDiagnostic = (issue: CircuitJsonIssue) =>
+  normalizeCategory(categorizeErrorOrWarning(issue)) === "placement"
+
+const getIssueType = (issue: CircuitJsonIssue) =>
+  issue.error_type ?? issue.warning_type ?? issue.type ?? "unknown_issue"
+
+const getScopedComponentIds = (
+  circuitJson: AnyCircuitElement[],
+  refdes: string,
+) => {
+  const sourceComponentIds = new Set<string>()
+  const pcbComponentIds = new Set<string>()
+
+  for (const item of circuitJson) {
+    const record = item as CircuitJsonRecord
+    if (
+      record.type === "source_component" &&
+      record.name === refdes &&
+      typeof record.source_component_id === "string"
+    ) {
+      sourceComponentIds.add(record.source_component_id)
+    }
+  }
+
+  for (const item of circuitJson) {
+    const record = item as CircuitJsonRecord
+    if (
+      record.type === "pcb_component" &&
+      typeof record.source_component_id === "string" &&
+      sourceComponentIds.has(record.source_component_id) &&
+      typeof record.pcb_component_id === "string"
+    ) {
+      pcbComponentIds.add(record.pcb_component_id)
+    }
+  }
+
+  return { sourceComponentIds, pcbComponentIds }
+}
+
+const isIssueRelatedToRefdes = (
+  issue: CircuitJsonIssue,
+  refdes: string,
+  scopedIds: ReturnType<typeof getScopedComponentIds>,
+) => {
+  if (
+    typeof issue.source_component_id === "string" &&
+    scopedIds.sourceComponentIds.has(issue.source_component_id)
+  ) {
+    return true
+  }
+
+  if (
+    typeof issue.pcb_component_id === "string" &&
+    scopedIds.pcbComponentIds.has(issue.pcb_component_id)
+  ) {
+    return true
+  }
+
+  if (
+    typeof issue.component_name === "string" &&
+    issue.component_name === refdes
+  ) {
+    return true
+  }
+
+  if (typeof issue.name === "string" && issue.name === refdes) {
+    return true
+  }
+
+  return typeof issue.message === "string" && issue.message.includes(refdes)
+}
+
+const getPlacementDiagnostics = (
+  circuitJson: AnyCircuitElement[],
+  refdes?: string,
+) => {
+  const diagnostics = analyzeCircuitJson(circuitJson)
+  let errors = diagnostics.errors.filter(isPlacementDiagnostic)
+  let warnings = diagnostics.warnings.filter(isPlacementDiagnostic)
+
+  if (refdes) {
+    const scopedIds = getScopedComponentIds(circuitJson, refdes)
+    errors = errors.filter((issue) =>
+      isIssueRelatedToRefdes(issue, refdes, scopedIds),
+    )
+    warnings = warnings.filter((issue) =>
+      isIssueRelatedToRefdes(issue, refdes, scopedIds),
+    )
+  }
+
+  return { errors, warnings }
+}
+
+const formatPlacementDiagnostics = ({
+  errors,
+  warnings,
+}: ReturnType<typeof getPlacementDiagnostics>) => {
+  const lines = [
+    "placement drc:",
+    `Errors: ${errors.length}`,
+    `Warnings: ${warnings.length}`,
+  ]
+
+  if (errors.length > 0) {
+    lines.push(
+      ...errors.map((issue) => `- ${getIssueType(issue)}: ${issue.message ?? ""}`),
+    )
+  }
+
+  if (warnings.length > 0) {
+    lines.push(
+      ...warnings.map((issue) => `- ${getIssueType(issue)}: ${issue.message ?? ""}`),
+    )
+  }
+
+  return lines.join("\n")
+}
 
 export const checkPlacement = async (file?: string, refdes?: string) => {
   const resolvedInputFilePath = await resolveCheckInputFilePath(file)
@@ -18,11 +154,14 @@ export const checkPlacement = async (file?: string, refdes?: string) => {
     allowPrebuiltCircuitJson: true,
   })) as AnyCircuitElement[]
 
-  if (refdes) {
-    return analyzeComponentPlacement(circuitJson, refdes).getString()
-  }
+  const analysisReport = refdes
+    ? analyzeComponentPlacement(circuitJson, refdes).getString()
+    : analyzeAllPlacements(circuitJson).getString()
+  const placementDiagnostics = getPlacementDiagnostics(circuitJson, refdes)
 
-  return analyzeAllPlacements(circuitJson).getString()
+  return `${analysisReport.trimEnd()}\n\n${formatPlacementDiagnostics(
+    placementDiagnostics,
+  )}`
 }
 
 export const registerCheckPlacement = (program: Command) => {

--- a/cli/check/placement/register.ts
+++ b/cli/check/placement/register.ts
@@ -130,13 +130,17 @@ const formatPlacementDiagnostics = ({
 
   if (errors.length > 0) {
     lines.push(
-      ...errors.map((issue) => `- ${getIssueType(issue)}: ${issue.message ?? ""}`),
+      ...errors.map(
+        (issue) => `- ${getIssueType(issue)}: ${issue.message ?? ""}`,
+      ),
     )
   }
 
   if (warnings.length > 0) {
     lines.push(
-      ...warnings.map((issue) => `- ${getIssueType(issue)}: ${issue.message ?? ""}`),
+      ...warnings.map(
+        (issue) => `- ${getIssueType(issue)}: ${issue.message ?? ""}`,
+      ),
     )
   }
 

--- a/lib/shared/circuit-json-diagnostics.ts
+++ b/lib/shared/circuit-json-diagnostics.ts
@@ -1,5 +1,7 @@
 export type CircuitJsonIssue = {
-  type: string
+  type?: string
+  error_type?: string
+  warning_type?: string
   message?: string
 } & Record<string, any>
 
@@ -14,12 +16,19 @@ export function analyzeCircuitJson(circuitJson: any[]): {
     if (!item || typeof item !== "object") continue
 
     const t = item.type
-    if (typeof t === "string") {
-      if (t.endsWith("_error")) errors.push(item)
-      else if (t.endsWith("_warning")) warnings.push(item)
+    const hasErrorType = typeof item.error_type === "string"
+    const hasWarningType = typeof item.warning_type === "string"
+    const isTypedError = typeof t === "string" && t.endsWith("_error")
+    const isTypedWarning = typeof t === "string" && t.endsWith("_warning")
+
+    if (hasErrorType || isTypedError) {
+      errors.push(item as CircuitJsonIssue)
+      continue
     }
-    if ("error_type" in item) errors.push(item)
-    if ("warning_type" in item) warnings.push(item as CircuitJsonIssue)
+
+    if (hasWarningType || isTypedWarning) {
+      warnings.push(item as CircuitJsonIssue)
+    }
   }
 
   return { errors, warnings }

--- a/tests/analyze-circuit-json.test.ts
+++ b/tests/analyze-circuit-json.test.ts
@@ -21,3 +21,21 @@ test("analyzeCircuitJson detects errors and warnings", () => {
   expect(errors.length).toBe(2)
   expect(warnings.length).toBe(2)
 })
+
+test("analyzeCircuitJson does not double-count items with both type and error metadata", () => {
+  const { errors, warnings } = analyzeCircuitJson([
+    {
+      type: "pcb_component_outside_board_error",
+      error_type: "pcb_component_outside_board_error",
+      message: "outside board",
+    },
+    {
+      type: "source_pin_missing_trace_warning",
+      warning_type: "source_pin_missing_trace_warning",
+      message: "missing trace",
+    },
+  ])
+
+  expect(errors).toHaveLength(1)
+  expect(warnings).toHaveLength(1)
+})

--- a/tests/cli/check/check-placement.test.ts
+++ b/tests/cli/check/check-placement.test.ts
@@ -91,7 +91,9 @@ test("check placement scopes placement DRC diagnostics to the requested refdes",
     expect(output).toContain("placement drc:")
     expect(output).toContain("Errors: 0")
     expect(output).toContain("Warnings: 0")
-    expect(output).not.toContain("Component R1 extends outside board boundaries")
+    expect(output).not.toContain(
+      "Component R1 extends outside board boundaries",
+    )
     expect(output).not.toContain("pcb_component_outside_board_error")
   } finally {
     await unlink(circuitPath)

--- a/tests/cli/check/check-placement.test.ts
+++ b/tests/cli/check/check-placement.test.ts
@@ -12,12 +12,21 @@ export default () => (
 )
 `
 
-const makeCircuitFile = async () => {
+const placementDrcCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm" routingDisabled>
+    <resistor resistance="1k" footprint="0402" name="R1" pcbX={5.2} pcbY={0} />
+    <capacitor capacitance="1000pF" footprint="0402" name="C1" pcbX={0} pcbY={0} />
+  </board>
+)
+`
+
+const makeCircuitFile = async (code = circuitCode) => {
   const circuitPath = path.join(
     process.cwd(),
     `tmp-check-placement-${Date.now()}-${Math.random().toString(36).slice(2)}.tsx`,
   )
-  await writeFile(circuitPath, circuitCode)
+  await writeFile(circuitPath, code)
   return circuitPath
 }
 
@@ -44,6 +53,46 @@ test("check placement analyzes all placements when refdes is missing", async () 
     expect(output).toContain("board-edge status:")
     expect(output).toContain("- R1:")
     expect(output).toContain("- C1:")
+    expect(output).toContain("placement drc:")
+    expect(output).toContain("Errors: 0")
+    expect(output).toContain("Warnings: 0")
+  } finally {
+    await unlink(circuitPath)
+  }
+}, 20_000)
+
+test("check placement includes placement DRC diagnostics from generated circuit json", async () => {
+  const circuitPath = await makeCircuitFile(placementDrcCircuitCode)
+
+  try {
+    const output = await checkPlacement(circuitPath)
+    expect(output).toContain("placement summary: 1 off-board")
+    expect(output).toContain("placement drc:")
+    expect(output).toContain("Errors: 1")
+    expect(output).toContain("Warnings: 0")
+    expect(output).toContain("pcb_component_outside_board_error")
+    expect(output).toContain("Component R1 extends outside board boundaries")
+    expect(output).not.toContain("source_pin_missing_trace_warning")
+
+    const matches =
+      output.match(/pcb_component_outside_board_error/g)?.length ?? 0
+    expect(matches).toBe(1)
+  } finally {
+    await unlink(circuitPath)
+  }
+}, 20_000)
+
+test("check placement scopes placement DRC diagnostics to the requested refdes", async () => {
+  const circuitPath = await makeCircuitFile(placementDrcCircuitCode)
+
+  try {
+    const output = await checkPlacement(circuitPath, "C1")
+    expect(output).toContain("C1")
+    expect(output).toContain("placement drc:")
+    expect(output).toContain("Errors: 0")
+    expect(output).toContain("Warnings: 0")
+    expect(output).not.toContain("Component R1 extends outside board boundaries")
+    expect(output).not.toContain("pcb_component_outside_board_error")
   } finally {
     await unlink(circuitPath)
   }


### PR DESCRIPTION
## Summary
- append placement-category circuit JSON diagnostics to `tsci check placement` output
- classify DRC issues with `categorizeErrorOrWarning` and scope refdes checks to related components only
- prevent `analyzeCircuitJson` from double-counting issues that include both `type` and `error_type` or `warning_type`
- add coverage for generated placement DRC output, refdes scoping, and duplicate-diagnostic handling

## Testing
- `bun test tests/cli/check/check-placement.test.ts tests/analyze-circuit-json.test.ts`