### PR TITLE
Fix Rollup transpilation for .obj file imports

### DIFF
--- a/cli/build/transpile/static-asset-plugin.ts
+++ b/cli/build/transpile/static-asset-plugin.ts
@@ -14,6 +14,7 @@ function normalizePathSeparators(filePath: string): string {
 export const STATIC_ASSET_EXTENSIONS = new Set([
   ".glb",
   ".gltf",
+  ".obj",
   ".png",
   ".jpg",
   ".jpeg",

--- a/tests/cli/transpile/transpile-obj-static-asset.test.ts
+++ b/tests/cli/transpile/transpile-obj-static-asset.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { readdir, readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const objCircuitCode = `
+import modelUrl from "./part.obj"
+
+export default () => (
+  <board width="20mm" height="20mm">
+    <chip
+      name="U1"
+      footprint="soic8"
+      cadModel={<cadmodel modelUrl={modelUrl} />}
+    />
+  </board>
+)
+`
+
+test("transpile supports .obj static asset imports", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "obj-test.tsx")
+  const objPath = path.join(tmpDir, "part.obj")
+
+  const objFileContent = `
+o cube
+v 0 0 0
+v 1 0 0
+v 1 1 0
+f 1 2 3
+`.trim()
+
+  await writeFile(circuitPath, objCircuitCode)
+  await writeFile(objPath, objFileContent)
+  await writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({
+      type: "module",
+      dependencies: {
+        react: "^19.1.0",
+      },
+    }),
+  )
+
+  await runCommand("tsci install")
+  const { stderr } = await runCommand(`tsci transpile ${circuitPath}`)
+  expect(stderr).not.toContain("Transpilation failed")
+
+  const assetFiles = await readdir(path.join(tmpDir, "dist", "assets"))
+  const copiedObj = assetFiles.find((file) => file.endsWith(".obj"))
+  expect(copiedObj).toBeDefined()
+
+  const transpiledOutput = await readFile(
+    path.join(tmpDir, "dist", "index.js"),
+    "utf-8",
+  )
+
+  expect(transpiledOutput).toContain("./assets/part-")
+  expect(transpiledOutput).toContain(".obj")
+}, 60_000)


### PR DESCRIPTION
### Motivation
- Rollup was attempting to parse `.obj` imports as JavaScript which caused transpilation to fail with errors like "Note that you need plugins to import files that are not JavaScript". 
- The static asset handling needed to treat `.obj` as a static asset so imports are resolved/copied and replaced with relative `dist/assets` URLs.

### Description
- Added `.obj` to the static asset extension allowlist in `cli/build/transpile/static-asset-plugin.ts` so the Rollup plugin treats `.obj` files as external static assets. 
- Added a regression test `tests/cli/transpile/transpile-obj-static-asset.test.ts` that creates a small project importing `./part.obj`, runs `tsci transpile`, and asserts the `.obj` is copied into `dist/assets` and referenced from the transpiled output.

### Testing
- Ran `bun test tests/cli/transpile/transpile-obj-static-asset.test.ts` and the test passed with no transpilation failures. 
- Ran `bun test tests/cli/transpile/transpile-static-assets.test.ts` to verify existing static asset behavior and it also passed. 
- The tests exercise `tsci install` and `tsci transpile` in temporary projects and confirm the `.obj` asset is copied and referenced from `dist/assets` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd026eb5ac8327a0d00ef93aa7e992)