### PR TITLE
feat(build): make worker timeout configurable in tscircuit config

### DIFF
--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -583,6 +583,7 @@ export const registerBuild = (program: Command) => {
             projectDir,
             concurrency: concurrencyValue,
             buildOptions,
+            workerJobTimeoutMs: projectConfig?.build?.workerTimeoutMs,
             stopOnFatal: true,
             onLog: (lines) => {
               for (const line of lines) {

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -75,12 +75,16 @@ export async function buildFilesWithWorkerPool(options: {
   onLog?: (lines: string[]) => void
   onJobComplete?: (result: BuildJobResult) => void
   stopOnFatal?: boolean
+  workerJobTimeoutMs?: number
 }): Promise<BuildJobResult[]> {
   const cancellationError = new Error("Build cancelled due fatal error")
-  const workerJobTimeoutMs = Number.parseInt(
-    process.env.TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS || "180000",
+  const envWorkerTimeoutMs = Number.parseInt(
+    process.env.TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS || "",
     10,
   )
+  const workerJobTimeoutMs = Number.isFinite(envWorkerTimeoutMs)
+    ? envWorkerTimeoutMs
+    : (options.workerJobTimeoutMs ?? 300000)
   const poolConcurrency = Math.max(
     1,
     Math.min(options.concurrency, options.files.length),

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -31,6 +31,7 @@ export const projectConfigSchema = z.object({
       kicadPcm: z.boolean().optional(),
       previewImages: z.boolean().optional(),
       glbs: z.boolean().optional(),
+      workerTimeoutMs: z.number().int().positive().optional(),
       routingDisabled: z.boolean().optional(),
       typescriptLibrary: z.boolean().optional(),
     })

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -115,6 +115,12 @@
           "type": "boolean",
           "description": "Enable GLB 3D model outputs for each circuit in build."
         },
+        "workerTimeoutMs": {
+          "type": "number",
+          "minimum": 1,
+          "multipleOf": 1,
+          "description": "Timeout in milliseconds for each build worker job."
+        },
         "routingDisabled": {
           "type": "boolean",
           "description": "Disable routing during circuit generation in build."


### PR DESCRIPTION
### Motivation

- Increase the default per-worker job timeout from 3 minutes to 5 minutes to reduce spurious timeouts for longer build tasks.
- Allow projects to override the timeout from their `tscircuit.config.json` so teams can tune worker timeouts per-project.
- Preserve the existing `TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS` env var behavior with highest precedence for CI/ops overrides.

### Description

- Added `build.workerTimeoutMs` to the project config Zod schema as an optional positive integer and to the published JSON schema with `minimum: 1` and `multipleOf: 1` constraints.
- Exposed a new `workerJobTimeoutMs` option on `buildFilesWithWorkerPool` and wired `projectConfig?.build?.workerTimeoutMs` into the call site in `cli/build/register.ts`.
- Changed worker timeout resolution to prefer `TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS` when set, otherwise use `projectConfig.build.workerTimeoutMs` if present, and fall back to a new default of `300000` ms (5 minutes).
- Kept heartbeat and heartbeat logging unchanged while only adjusting how `jobTimeoutMs` is computed and passed into the thread worker pool.

### Testing

- Ran code formatting check with `bunx @biomejs/biome format lib/project-config/project-config-schema.ts cli/build/worker-pool.ts cli/build/register.ts types/tscircuit.config.schema.json` and it succeeded.
- Ran unit tests `bun test tests/cli/build/resolve-build-options.test.ts` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd2748a6d48327802de9cc196da519)