### PR TITLE
Update build camera and lazy-load trace analysis

### DIFF
--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs"
 import path from "node:path"
 import type { AnyCircuitElement } from "circuit-json"
-import { convertCircuitJsonToGltf } from "circuit-json-to-gltf"
+import {
+  convertCircuitJsonToGltf,
+  getBestCameraPosition,
+} from "circuit-json-to-gltf"
 import {
   convertCircuitJsonToPcbSvg,
   convertCircuitJsonToSchematicSvg,
@@ -150,7 +153,10 @@ const generatePreviewAssets = async ({
       )
       console.log(`${prefix}Rendering GLB to PNG buffer...`)
       const glbArrayBuffer = await normalizeToArrayBuffer(glbBuffer)
-      const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(glbArrayBuffer)
+      const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(
+        glbArrayBuffer,
+        getBestCameraPosition(circuitJson),
+      )
       fs.writeFileSync(
         path.join(outputDir, "3d.png"),
         Buffer.from(normalizeToUint8Array(pngBuffer)),

--- a/cli/build/worker-output-generators.ts
+++ b/cli/build/worker-output-generators.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs"
 import path from "node:path"
 import type { AnyCircuitElement } from "circuit-json"
-import { convertCircuitJsonToGltf } from "circuit-json-to-gltf"
+import {
+  convertCircuitJsonToGltf,
+  getBestCameraPosition,
+} from "circuit-json-to-gltf"
 import {
   convertCircuitJsonToPcbSvg,
   convertCircuitJsonToSchematicSvg,
@@ -72,7 +75,10 @@ export const writeImageAssetsFromCircuitJson = async (
       getCircuitJsonToGltfOptions({ format: "glb" }),
     )
     const glbArrayBuffer = await normalizeToArrayBuffer(glbBuffer)
-    const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(glbArrayBuffer)
+    const pngBuffer = await renderGLTFToPNGBufferFromGLBBuffer(
+      glbArrayBuffer,
+      getBestCameraPosition(circuitJson),
+    )
 
     fs.writeFileSync(
       path.join(outputDir, "3d.png"),

--- a/cli/check/trace-length/register.ts
+++ b/cli/check/trace-length/register.ts
@@ -1,7 +1,22 @@
-import { analyzeCircuitJsonTraceLength } from "circuit-json-trace-length-analysis"
 import type { PlatformConfig } from "@tscircuit/props"
+import type { AnyCircuitElement } from "circuit-json"
 import type { Command } from "commander"
 import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
+
+type TraceLengthAnalyzer = (
+  circuitJson: readonly AnyCircuitElement[],
+  options: { targetPinOrNet: string },
+) => { toString(): string }
+
+const loadTraceLengthAnalyzer = async (): Promise<TraceLengthAnalyzer> => {
+  const mod = (await import(
+    "circuit-json-trace-length-analysis"
+  )) as unknown as {
+    analyzeCircuitJsonTraceLength: TraceLengthAnalyzer
+  }
+
+  return mod.analyzeCircuitJsonTraceLength
+}
 
 export const checkTraceLength = async (pinOrNetRef: string, file?: string) => {
   const resolvedInputFilePath = await resolveCheckInputFilePath(file)
@@ -14,6 +29,7 @@ export const checkTraceLength = async (pinOrNetRef: string, file?: string) => {
     allowPrebuiltCircuitJson: true,
   })
 
+  const analyzeCircuitJsonTraceLength = await loadTraceLengthAnalyzer()
   const analysis = analyzeCircuitJsonTraceLength(circuitJson, {
     targetPinOrNet: pinOrNetRef,
   })


### PR DESCRIPTION
## Summary
- Use `getBestCameraPosition` when rendering 3D build previews so `tsci build --3d` matches snapshot camera framing.
- Apply the same camera path in worker-generated preview images for consistency.
- Lazy-load the trace-length analyzer to avoid paying the import cost unless the check runs.

## Testing
- Ran the build output flag test suite covering preview image generation.
- Re-rendered a real cloned board locally to confirm the 3D build preview now uses the intended angled camera.