### PR TITLE
fix: tsci push should find fallback file when no entrypoint

### DIFF
--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -75,11 +75,26 @@ export const pushSnippet = async ({
   }
 
   // Detect the entrypoint file
-  const snippetFilePath = await getEntrypoint({
+  let snippetFilePath = await getEntrypoint({
     filePath,
     onSuccess: () => {},
     onError,
   })
+
+  // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
+  if (!snippetFilePath) {
+    const { globbySync } = await import("globby")
+    const projectDir = process.cwd()
+    const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
+      cwd: projectDir,
+      ignore: ["node_modules/**", "**/.*"]
+    }).filter(f => fs.existsSync(f))
+
+    if (validFiles.length > 0) {
+      snippetFilePath = path.resolve(projectDir, validFiles[0])
+      onSuccess(`Using fallback file: '${validFiles[0]}'`)
+    }
+  }
 
   if (!snippetFilePath) {
     return onExit(1)

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -84,12 +84,16 @@ export const pushSnippet = async ({
 
   // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
   if (!snippetFilePath) {
-    
     const projectDir = process.cwd()
-    const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
-      cwd: projectDir,
-      ignore: ["node_modules/**", "**/.*"]
-    }).filter((relativePath) => fs.existsSync(path.join(projectDir, relativePath)))
+    const validFiles = globbySync(
+      ["**/*.tsx", "**/*.ts", "**/*.circuit.json"],
+      {
+        cwd: projectDir,
+        ignore: ["node_modules/**", "**/.*"],
+      },
+    ).filter((relativePath) =>
+      fs.existsSync(path.join(projectDir, relativePath)),
+    )
 
     if (validFiles.length > 0) {
       snippetFilePath = path.resolve(projectDir, validFiles[0])

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -6,6 +6,7 @@ import semver from "semver"
 import Debug from "debug"
 import kleur from "kleur"
 import { getEntrypoint } from "./get-entrypoint"
+import { globbySync } from "globby"
 import prompts from "lib/utils/prompts"
 import { getUnscopedPackageName } from "lib/utils/get-unscoped-package-name"
 import { getPackageAuthor } from "lib/utils/get-package-author"
@@ -83,12 +84,12 @@ export const pushSnippet = async ({
 
   // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
   if (!snippetFilePath) {
-    const { globbySync } = await import("globby")
+    
     const projectDir = process.cwd()
     const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
       cwd: projectDir,
       ignore: ["node_modules/**", "**/.*"]
-    }).filter(f => fs.existsSync(f))
+    }).filter((relativePath) => fs.existsSync(path.join(projectDir, relativePath)))
 
     if (validFiles.length > 0) {
       snippetFilePath = path.resolve(projectDir, validFiles[0])


### PR DESCRIPTION
## Summary
Fix Issue #2797 - `tsci push` fails when no `index.circuit.tsx` file and no `mainEntrypoint`

**Problem:** `tsci push` would fail with "No entrypoint found" error, while `tsci dev` would find a fallback file.


**Solution:** When no entrypoint is found, `tsci push` now searches for any `.tsx`, `.ts`, or `.circuit.json` file as a fallback (similar to how `tsci dev` works).

## Testing
```bash
bun test tests/cli/push/
```

Closes #2797