### PR TITLE
feat: add bpc export format

### DIFF
--- a/cli/check/routing/register.ts
+++ b/cli/check/routing/register.ts
@@ -1,11 +1,83 @@
+import {
+  categorizeErrorOrWarning,
+  type DrcCategory,
+} from "@tscircuit/circuit-json-util"
+import type { PlatformConfig } from "@tscircuit/props"
 import type { Command } from "commander"
+import {
+  analyzeCircuitJson,
+  type CircuitJsonIssue,
+} from "lib/shared/circuit-json-diagnostics"
+import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
+
+const normalizeCategory = (category: string): DrcCategory =>
+  category === "netlist" ||
+  category === "pin_specification" ||
+  category === "placement" ||
+  category === "routing"
+    ? category
+    : "unknown"
+
+const isRoutingDiagnostic = (issue: CircuitJsonIssue) =>
+  normalizeCategory(categorizeErrorOrWarning(issue)) === "routing"
+
+const getIssueType = (issue: CircuitJsonIssue) =>
+  issue.error_type ?? issue.warning_type ?? issue.type ?? "unknown_issue"
+
+export const checkRouting = async (file?: string) => {
+  const resolvedInputFilePath = await resolveCheckInputFilePath(file)
+
+  const circuitJson = await getCircuitJsonForCheck({
+    filePath: resolvedInputFilePath,
+    platformConfig: {
+      pcbDisabled: false,
+      routingDisabled: false,
+    } satisfies PlatformConfig,
+    allowPrebuiltCircuitJson: true,
+  })
+
+  const diagnostics = analyzeCircuitJson(circuitJson)
+  const routingErrors = diagnostics.errors.filter(isRoutingDiagnostic)
+  const routingWarnings = diagnostics.warnings.filter(isRoutingDiagnostic)
+
+  const lines = [
+    "routing drc:",
+    `Errors: ${routingErrors.length}`,
+    `Warnings: ${routingWarnings.length}`,
+  ]
+
+  if (routingErrors.length > 0) {
+    lines.push(
+      ...routingErrors.map(
+        (err) => `- ${getIssueType(err)}: ${err.message ?? ""}`,
+      ),
+    )
+  }
+
+  if (routingWarnings.length > 0) {
+    lines.push(
+      ...routingWarnings.map(
+        (warning) => `- ${getIssueType(warning)}: ${warning.message ?? ""}`,
+      ),
+    )
+  }
+
+  return lines.join("\n")
+}
 
 export const registerCheckRouting = (program: Command) => {
   program.commands
     .find((c) => c.name() === "check")!
     .command("routing")
-    .description("Partially build and validate the routing")
-    .action(() => {
-      throw new Error("Not implemented")
+    .description("Run the autorouter and validate the routing")
+    .argument("[file]", "Path to the entry file")
+    .action(async (file?: string) => {
+      try {
+        const output = await checkRouting(file)
+        console.log(output)
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exit(1)
+      }
     })
 }

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -56,6 +56,7 @@ export const ALLOWED_EXPORT_FORMATS = [
   "step",
   "assembly-svg",
   "pnp-csv",
+  "bom-csv",
 ] as const
 
 export type ExportFormat = (typeof ALLOWED_EXPORT_FORMATS)[number]
@@ -78,6 +79,7 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   srj: ".simple-route.json",
   step: ".step",
   "pnp-csv": "-pnp.csv",
+  "bom-csv": "-bom.csv",
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -349,6 +351,11 @@ export const exportSnippet = async ({
       break
     case "pnp-csv":
       outputContent = await convertCircuitJsonToPickAndPlaceCsv(circuitJson)
+      break
+    case "bom-csv":
+      outputContent = await convertBomRowsToCsv(
+        await convertCircuitJsonToBomRows({ circuitJson }),
+      )
       break
     default:
       outputContent = JSON.stringify(circuitJson, null, 2)

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -35,6 +35,7 @@ import {
   convertBomRowsToCsv,
 } from "circuit-json-to-bom-csv"
 import { convertCircuitJsonToPickAndPlaceCsv } from "circuit-json-to-pnp-csv"
+import { circuitJsonToSpice } from "circuit-json-to-spice"
 
 const writeFileAsync = promisify(fs.writeFile)
 
@@ -57,6 +58,7 @@ export const ALLOWED_EXPORT_FORMATS = [
   "assembly-svg",
   "pnp-csv",
   "bom-csv",
+  "spice",
 ] as const
 
 export type ExportFormat = (typeof ALLOWED_EXPORT_FORMATS)[number]
@@ -80,6 +82,7 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   step: ".step",
   "pnp-csv": "-pnp.csv",
   "bom-csv": "-bom.csv",
+  spice: ".spice",
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -356,6 +359,9 @@ export const exportSnippet = async ({
       outputContent = await convertBomRowsToCsv(
         await convertCircuitJsonToBomRows({ circuitJson }),
       )
+      break
+    case "spice":
+      outputContent = circuitJsonToSpice(circuitJson).toSpiceString()
       break
     default:
       outputContent = JSON.stringify(circuitJson, null, 2)

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -36,6 +36,7 @@ import {
 } from "circuit-json-to-bom-csv"
 import { convertCircuitJsonToPickAndPlaceCsv } from "circuit-json-to-pnp-csv"
 import { circuitJsonToSpice } from "circuit-json-to-spice"
+import { convertCircuitJsonToBpc } from "circuit-json-to-bpc"
 
 const writeFileAsync = promisify(fs.writeFile)
 
@@ -59,6 +60,7 @@ export const ALLOWED_EXPORT_FORMATS = [
   "pnp-csv",
   "bom-csv",
   "spice",
+  "bpc",
 ] as const
 
 export type ExportFormat = (typeof ALLOWED_EXPORT_FORMATS)[number]
@@ -83,6 +85,7 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   "pnp-csv": "-pnp.csv",
   "bom-csv": "-bom.csv",
   spice: ".spice",
+  bpc: ".bpc.json",
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -362,6 +365,9 @@ export const exportSnippet = async ({
       break
     case "spice":
       outputContent = circuitJsonToSpice(circuitJson).toSpiceString()
+      break
+    case "bpc":
+      outputContent = JSON.stringify(convertCircuitJsonToBpc(circuitJson), null, 2)
       break
     default:
       outputContent = JSON.stringify(circuitJson, null, 2)

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -367,7 +367,11 @@ export const exportSnippet = async ({
       outputContent = circuitJsonToSpice(circuitJson).toSpiceString()
       break
     case "bpc":
-      outputContent = JSON.stringify(convertCircuitJsonToBpc(circuitJson), null, 2)
+      outputContent = JSON.stringify(
+        convertCircuitJsonToBpc(circuitJson),
+        null,
+        2,
+      )
       break
     default:
       outputContent = JSON.stringify(circuitJson, null, 2)

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -55,6 +55,7 @@ export const ALLOWED_EXPORT_FORMATS = [
   "srj",
   "step",
   "assembly-svg",
+  "pnp-csv",
 ] as const
 
 export type ExportFormat = (typeof ALLOWED_EXPORT_FORMATS)[number]
@@ -76,6 +77,7 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   "kicad-library": "",
   srj: ".simple-route.json",
   step: ".step",
+  "pnp-csv": "-pnp.csv",
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -344,6 +346,9 @@ export const exportSnippet = async ({
       break
     case "assembly-svg":
       outputContent = convertCircuitJsonToAssemblySvg(circuitJson)
+      break
+    case "pnp-csv":
+      outputContent = await convertCircuitJsonToPickAndPlaceCsv(circuitJson)
       break
     default:
       outputContent = JSON.stringify(circuitJson, null, 2)

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -75,11 +75,26 @@ export const pushSnippet = async ({
   }
 
   // Detect the entrypoint file
-  const snippetFilePath = await getEntrypoint({
+  let snippetFilePath = await getEntrypoint({
     filePath,
     onSuccess: () => {},
     onError,
   })
+
+  // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
+  if (!snippetFilePath) {
+    const { globbySync } = await import("globby")
+    const projectDir = process.cwd()
+    const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
+      cwd: projectDir,
+      ignore: ["node_modules/**", "**/.*"]
+    }).filter(f => fs.existsSync(f))
+
+    if (validFiles.length > 0) {
+      snippetFilePath = path.resolve(projectDir, validFiles[0])
+      onSuccess(`Using fallback file: '${validFiles[0]}'`)
+    }
+  }
 
   if (!snippetFilePath) {
     return onExit(1)

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -84,12 +84,16 @@ export const pushSnippet = async ({
 
   // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
   if (!snippetFilePath) {
-    
     const projectDir = process.cwd()
-    const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
-      cwd: projectDir,
-      ignore: ["node_modules/**", "**/.*"]
-    }).filter((relativePath) => fs.existsSync(path.join(projectDir, relativePath)))
+    const validFiles = globbySync(
+      ["**/*.tsx", "**/*.ts", "**/*.circuit.json"],
+      {
+        cwd: projectDir,
+        ignore: ["node_modules/**", "**/.*"],
+      },
+    ).filter((relativePath) =>
+      fs.existsSync(path.join(projectDir, relativePath)),
+    )
 
     if (validFiles.length > 0) {
       snippetFilePath = path.resolve(projectDir, validFiles[0])

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -6,6 +6,7 @@ import semver from "semver"
 import Debug from "debug"
 import kleur from "kleur"
 import { getEntrypoint } from "./get-entrypoint"
+import { globbySync } from "globby"
 import prompts from "lib/utils/prompts"
 import { getUnscopedPackageName } from "lib/utils/get-unscoped-package-name"
 import { getPackageAuthor } from "lib/utils/get-package-author"
@@ -83,12 +84,12 @@ export const pushSnippet = async ({
 
   // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
   if (!snippetFilePath) {
-    const { globbySync } = await import("globby")
+    
     const projectDir = process.cwd()
     const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
       cwd: projectDir,
       ignore: ["node_modules/**", "**/.*"]
-    }).filter(f => fs.existsSync(f))
+    }).filter((relativePath) => fs.existsSync(path.join(projectDir, relativePath)))
 
     if (validFiles.length > 0) {
       snippetFilePath = path.resolve(projectDir, validFiles[0])


### PR DESCRIPTION
## Summary

Add `bpc` (Box-Pin-Color Graph) export format.

## Changes

- Added `convertCircuitJsonToBpc` import
- Added `bpc` to `ALLOWED_EXPORT_FORMATS`
- Added `bpc: ".bpc.json"` to `OUTPUT_EXTENSIONS`
- Added case handler

## Usage

```bash
tsci export MyCircuit.tsx -f bpc
# Outputs: MyCircuit.bpc.json
```