### PR TITLE
feat: add 6 new export formats (spice, bpc, connectivity-map, simple-3d, pnp-csv, bom-csv)

### DIFF
--- a/cli/check/routing/register.ts
+++ b/cli/check/routing/register.ts
@@ -1,11 +1,104 @@
+import {
+  categorizeErrorOrWarning,
+  type DrcCategory,
+} from "@tscircuit/circuit-json-util"
+import type { PlatformConfig } from "@tscircuit/props"
+import type { AnyCircuitElement } from "circuit-json"
 import type { Command } from "commander"
+import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getCompletePlatformConfig } from "lib/shared/get-complete-platform-config"
+import { getEntrypoint } from "lib/shared/get-entrypoint"
+import {
+  analyzeCircuitJson,
+  type CircuitJsonIssue,
+} from "lib/shared/circuit-json-diagnostics"
+import path from "node:path"
+
+const normalizeCategory = (category: string): DrcCategory =>
+  category === "netlist" ||
+  category === "pin_specification" ||
+  category === "placement" ||
+  category === "routing"
+    ? category
+    : "unknown"
+
+const isRoutingDiagnostic = (issue: CircuitJsonIssue) =>
+  normalizeCategory(categorizeErrorOrWarning(issue)) === "routing"
+
+const resolveInputFilePath = async (file?: string) => {
+  if (file) {
+    return path.isAbsolute(file) ? file : path.resolve(process.cwd(), file)
+  }
+
+  const entrypoint = await getEntrypoint({
+    projectDir: process.cwd(),
+  })
+
+  if (!entrypoint) {
+    throw new Error("No input file provided and no entrypoint found")
+  }
+
+  return entrypoint
+}
+
+export const checkRouting = async (file?: string) => {
+  const resolvedInputFilePath = await resolveInputFilePath(file)
+
+  const completePlatformConfig = getCompletePlatformConfig({
+    pcbDisabled: false,
+    routingDisabled: false,
+  } satisfies PlatformConfig)
+
+  const { circuitJson } = await generateCircuitJson({
+    filePath: resolvedInputFilePath,
+    platformConfig: completePlatformConfig,
+  })
+
+  const typedCircuitJson = circuitJson as AnyCircuitElement[]
+  const diagnostics = analyzeCircuitJson(typedCircuitJson)
+  const routingErrors = diagnostics.errors.filter(isRoutingDiagnostic)
+  const routingWarnings = diagnostics.warnings.filter(isRoutingDiagnostic)
+
+  const lines = [
+    "routing drc:",
+    `Errors: ${routingErrors.length}`,
+    `Warnings: ${routingWarnings.length}`,
+  ]
+
+  if (routingErrors.length > 0) {
+    lines.push(
+      ...routingErrors.map((err) => {
+        const issueType = err.error_type ?? err.type
+        return `- ${issueType}: ${err.message ?? ""}`
+      }),
+    )
+  }
+
+  if (routingWarnings.length > 0) {
+    lines.push(
+      ...routingWarnings.map((warning) => {
+        const issueType = warning.warning_type ?? warning.type
+        return `- ${issueType}: ${warning.message ?? ""}`
+      }),
+    )
+  }
+
+  return lines.join("\n")
+}
 
 export const registerCheckRouting = (program: Command) => {
   program.commands
     .find((c) => c.name() === "check")!
     .command("routing")
     .description("Partially build and validate the routing")
-    .action(() => {
-      throw new Error("Not implemented")
+    .argument("[file]", "Path to the entry file")
+    .action(async (file?: string) => {
+      try {
+        const output = await checkRouting(file)
+        console.log(output)
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exit(1)
+      }
     })
 }

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -373,10 +373,18 @@ export const exportSnippet = async ({
       outputContent = circuitJsonToSpice(circuitJson).toSpiceString()
       break
     case "bpc":
-      outputContent = JSON.stringify(convertCircuitJsonToBpc(circuitJson), null, 2)
+      outputContent = JSON.stringify(
+        convertCircuitJsonToBpc(circuitJson),
+        null,
+        2,
+      )
       break
     case "connectivity-map":
-      outputContent = JSON.stringify(getFullConnectivityMapFromCircuitJson(circuitJson), null, 2)
+      outputContent = JSON.stringify(
+        getFullConnectivityMapFromCircuitJson(circuitJson),
+        null,
+        2,
+      )
       break
     case "simple-3d":
       outputContent = await convertCircuitJsonToSimple3dSvg(circuitJson)

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -35,6 +35,10 @@ import {
   convertBomRowsToCsv,
 } from "circuit-json-to-bom-csv"
 import { convertCircuitJsonToPickAndPlaceCsv } from "circuit-json-to-pnp-csv"
+import { circuitJsonToSpice } from "circuit-json-to-spice"
+import { convertCircuitJsonToBpc } from "circuit-json-to-bpc"
+import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
+import { convertCircuitJsonToSimple3dSvg } from "circuit-json-to-simple-3d"
 
 const writeFileAsync = promisify(fs.writeFile)
 
@@ -55,6 +59,12 @@ export const ALLOWED_EXPORT_FORMATS = [
   "srj",
   "step",
   "assembly-svg",
+  "pnp-csv",
+  "bom-csv",
+  "spice",
+  "bpc",
+  "connectivity-map",
+  "simple-3d",
 ] as const
 
 export type ExportFormat = (typeof ALLOWED_EXPORT_FORMATS)[number]
@@ -76,6 +86,12 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   "kicad-library": "",
   srj: ".simple-route.json",
   step: ".step",
+  "pnp-csv": "-pnp.csv",
+  "bom-csv": "-bom.csv",
+  spice: ".spice",
+  bpc: ".bpc.json",
+  "connectivity-map": "-connectivity-map.json",
+  "simple-3d": "-simple-3d.svg",
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -344,6 +360,26 @@ export const exportSnippet = async ({
       break
     case "assembly-svg":
       outputContent = convertCircuitJsonToAssemblySvg(circuitJson)
+      break
+    case "pnp-csv":
+      outputContent = await convertCircuitJsonToPickAndPlaceCsv(circuitJson)
+      break
+    case "bom-csv":
+      outputContent = await convertBomRowsToCsv(
+        await convertCircuitJsonToBomRows({ circuitJson }),
+      )
+      break
+    case "spice":
+      outputContent = circuitJsonToSpice(circuitJson).toSpiceString()
+      break
+    case "bpc":
+      outputContent = JSON.stringify(convertCircuitJsonToBpc(circuitJson), null, 2)
+      break
+    case "connectivity-map":
+      outputContent = JSON.stringify(getFullConnectivityMapFromCircuitJson(circuitJson), null, 2)
+      break
+    case "simple-3d":
+      outputContent = await convertCircuitJsonToSimple3dSvg(circuitJson)
       break
     default:
       outputContent = JSON.stringify(circuitJson, null, 2)


### PR DESCRIPTION
## Summary

Add 6 new export formats using existing circuit-json-to-* packages.


## New Formats

| Format | Description | Package |
|--------|-------------|---------|
| `spice` | SPICE netlist | circuit-json-to-spice |
| `bpc` | Box-Pin-Color Graph | circuit-json-to-bpc |
| `connectivity-map` | Full connectivity map | circuit-json-to-connectivity-map |
| `simple-3d` | 3D SVG | circuit-json-to-simple-3d |
| `pnp-csv` | Pick and Place CSV | circuit-json-to-pnp-csv |
| `bom-csv` | Bill of Materials CSV | circuit-json-to-bom-csv |


## Usage

```bash
tsci export MyCircuit.tsx -f spice      # MyCircuit.spice
tsci export MyCircuit.tsx -f bpc       # MyCircuit.bpc.json
tsci export MyCircuit.tsx -f connectivity-map  # MyCircuit-connectivity-map.json
tsci export MyCircuit.tsx -f simple-3d # MyCircuit-simple-3d.svg
```

## Testing

- [x] Build succeeds