### PR TITLE
Fix tsci push to work without an entrypoint

### DIFF
--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -30,6 +30,55 @@ type PushOptions = {
 
 const debug = Debug("tsci:push-snippet")
 
+const findPushProject = async ({
+  filePath,
+  onError,
+}: {
+  filePath?: string
+  onError: (message: string) => void
+}): Promise<{
+  snippetFilePath?: string
+  packageJsonPath?: string
+  projectDir: string
+} | null> => {
+  if (filePath) {
+    const snippetFilePath = await getEntrypoint({
+      filePath,
+      onSuccess: () => {},
+      onError,
+    })
+
+    if (!snippetFilePath) {
+      return null
+    }
+
+    const packageJsonPath = [
+      path.resolve(path.join(path.dirname(snippetFilePath), "package.json")),
+      path.resolve(path.join(process.cwd(), "package.json")),
+    ].find((candidatePath) => fs.existsSync(candidatePath))
+    const projectDir = packageJsonPath
+      ? path.dirname(packageJsonPath)
+      : path.dirname(snippetFilePath)
+
+    return { snippetFilePath, packageJsonPath, projectDir }
+  }
+
+  const projectDir = process.cwd()
+  const packageJsonPath = path.resolve(path.join(projectDir, "package.json"))
+  if (!fs.existsSync(packageJsonPath)) {
+    return { projectDir }
+  }
+
+  const snippetFilePath =
+    (await getEntrypoint({
+      projectDir,
+      onSuccess: () => {},
+      onError: () => {},
+    })) ?? undefined
+
+  return { snippetFilePath, packageJsonPath, projectDir }
+}
+
 const getArchivePayload = async (
   filePaths: string[],
   projectDir: string,
@@ -74,24 +123,16 @@ export const pushSnippet = async ({
     return onExit(1)
   }
 
-  // Detect the entrypoint file
-  const snippetFilePath = await getEntrypoint({
+  const pushProject = await findPushProject({
     filePath,
-    onSuccess: () => {},
     onError,
   })
 
-  if (!snippetFilePath) {
+  if (!pushProject) {
     return onExit(1)
   }
 
-  const packageJsonPath = [
-    path.resolve(path.join(path.dirname(snippetFilePath), "package.json")),
-    path.resolve(path.join(process.cwd(), "package.json")),
-  ].find((path) => fs.existsSync(path))
-  const projectDir = packageJsonPath
-    ? path.dirname(packageJsonPath)
-    : path.dirname(snippetFilePath)
+  const { snippetFilePath, packageJsonPath, projectDir } = pushProject
 
   if (!packageJsonPath) {
     onError(
@@ -110,7 +151,7 @@ export const pushSnippet = async ({
     }
   }
 
-  if (!fs.existsSync(snippetFilePath)) {
+  if (snippetFilePath && !fs.existsSync(snippetFilePath)) {
     onError(`File not found: ${snippetFilePath}`)
     return onExit(1)
   }

--- a/tests/cli/push/push1-no-entrypoint.test.ts
+++ b/tests/cli/push/push1-no-entrypoint.test.ts
@@ -1,17 +1,42 @@
 import { test, expect } from "bun:test"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import * as fs from "node:fs"
+import * as path from "node:path"
 
-test("should fail if no entrypoint file is found", async () => {
-  const { runCommand } = await getCliTestFixture()
-  try {
-    await runCommand("tsci push")
-  } catch (e) {
-    if (e instanceof Error) {
-      expect(e.message).toContain(
-        "No entrypoint found. Run 'tsci init' to bootstrap a basic project.",
-      )
-    } else {
-      throw e
-    }
-  }
+test("should fail if no package.json is found", async () => {
+  const { runCommand } = await getCliTestFixture({ loggedIn: true })
+  const { stderr, exitCode } = await runCommand("tsci push")
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toBe(
+    "No package.json found, try running 'tsci init' to bootstrap the project\n",
+  )
 })
+
+test("should push a package without an entrypoint", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture({
+    loggedIn: true,
+  })
+
+  fs.writeFileSync(
+    path.resolve(tmpDir, "package.json"),
+    JSON.stringify({ name: "@tsci/test-user.test-package", version: "1.0.0" }),
+  )
+  fs.writeFileSync(
+    path.resolve(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({ includeBoardFiles: ["**/*.circuit.json"] }),
+  )
+  fs.writeFileSync(
+    path.resolve(tmpDir, "prebuilt.circuit.json"),
+    JSON.stringify([{ type: "source_component", name: "U1" }]),
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand("tsci push")
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("⬆︎ package.json")
+  expect(stdout).toContain("⬆︎ prebuilt.circuit.json")
+  expect(stdout).toContain("⬆︎ tscircuit.config.json")
+  expect(stdout).toContain('"@tsci/test-user.test-package@1.0.0" published!')
+}, 30_000)


### PR DESCRIPTION
## Summary
- Make `tsci push` resolve the package root without requiring an entrypoint when no file is passed.
- Keep explicit file pushes using entrypoint validation, but avoid failing the no-arg flow when only `package.json` and project files are present.
- Update push coverage to verify the no-entrypoint case and preserve the existing package.json-missing failure.

## Testing
- Added/updated Bun tests for push with no entrypoint and for the existing default-entrypoint path.
- Ran focused `bun test` coverage for the push command, plus formatting and type-check validation.