### PR TITLE
fix: support board files as entrypoint for tsci push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777953610
 # bump 1777996811
 # bump 1778040016
+# bump 1778083219

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777865642
 # bump 1777865729
 # bump 1777867212
+# bump 1777910421

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777910421
 # bump 1777953610
 # bump 1777996811
+# bump 1778040016

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,3 +89,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1778040016
 # bump 1778083219
 # bump 1778126416
+# bump 1778169612

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,4 @@ Test fixture provides:
 
 The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the TypeScript runner, preferring Bun when available. This allows hot-reload during development while maintaining Node.js compatibility.
 # bump 1777865642
+# bump 1777865729

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777996811
 # bump 1778040016
 # bump 1778083219
+# bump 1778126416

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1778083219
 # bump 1778126416
 # bump 1778169612
+# bump 1778212811

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777867212
 # bump 1777910421
 # bump 1777953610
+# bump 1777996811

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,4 @@ Test fixture provides:
 ## Runtime
 
 The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the TypeScript runner, preferring Bun when available. This allows hot-reload during development while maintaining Node.js compatibility.
+# bump 1777865642

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777865729
 # bump 1777867212
 # bump 1777910421
+# bump 1777953610

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,4 @@ Test fixture provides:
 The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the TypeScript runner, preferring Bun when available. This allows hot-reload during development while maintaining Node.js compatibility.
 # bump 1777865642
 # bump 1777865729
+# bump 1777867212

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -131,7 +131,6 @@ export const pushSnippet = async ({
     onError: () => {}, // Suppress error here, we'll handle fallback below
   })
 
-
   // If no entrypoint found, try finding board files (like `tsci dev` does)
   if (!snippetFilePath) {
     const boardFiles = findBoardFiles({
@@ -160,6 +159,7 @@ export const pushSnippet = async ({
   const projectDir = packageJsonPath
     ? path.dirname(packageJsonPath)
     : path.dirname(snippetFilePath)
+  if (!packageJsonPath) {
     onError(
       "No package.json found, try running 'tsci init' to bootstrap the project",
     )

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -6,6 +6,7 @@ import semver from "semver"
 import Debug from "debug"
 import kleur from "kleur"
 import { getEntrypoint } from "./get-entrypoint"
+import { findBoardFiles } from "./find-board-files"
 import prompts from "lib/utils/prompts"
 import { getUnscopedPackageName } from "lib/utils/get-unscoped-package-name"
 import { getPackageAuthor } from "lib/utils/get-package-author"
@@ -123,18 +124,42 @@ export const pushSnippet = async ({
     return onExit(1)
   }
 
-  const pushProject = await findPushProject({
+  // Detect the entrypoint file - first try standard entrypoints, then board files
+  let snippetFilePath = await getEntrypoint({
     filePath,
-    onError,
+    onSuccess: () => {},
+    onError: () => {}, // Suppress error here, we'll handle fallback below
   })
 
-  if (!pushProject) {
+
+  // If no entrypoint found, try finding board files (like `tsci dev` does)
+  if (!snippetFilePath) {
+    const boardFiles = findBoardFiles({
+      projectDir: filePath ? path.dirname(filePath) : process.cwd(),
+    })
+    if (boardFiles.length > 0) {
+      snippetFilePath = boardFiles[0]
+    }
+  }
+
+  // If still no entrypoint, show error
+  if (!snippetFilePath) {
+    onError(
+      kleur.red(
+        "No entrypoint found. Run 'tsci init' to bootstrap a basic project or specify a file with 'tsci push <file>'",
+      ),
+    )
     return onExit(1)
   }
 
-  const { snippetFilePath, packageJsonPath, projectDir } = pushProject
-
-  if (!packageJsonPath) {
+  // Determine projectDir and packageJsonPath from snippetFilePath
+  const packageJsonPath = [
+    path.resolve(path.join(path.dirname(snippetFilePath), "package.json")),
+    path.resolve(path.join(process.cwd(), "package.json")),
+  ].find((candidatePath) => fs.existsSync(candidatePath))
+  const projectDir = packageJsonPath
+    ? path.dirname(packageJsonPath)
+    : path.dirname(snippetFilePath)
     onError(
       "No package.json found, try running 'tsci init' to bootstrap the project",
     )

--- a/tests/cli/push/push1-no-entrypoint.test.ts
+++ b/tests/cli/push/push1-no-entrypoint.test.ts
@@ -3,13 +3,13 @@ import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 import * as fs from "node:fs"
 import * as path from "node:path"
 
-test("should fail if no package.json is found", async () => {
+test("should fail if no entrypoint and no package.json are found", async () => {
   const { runCommand } = await getCliTestFixture({ loggedIn: true })
   const { stderr, exitCode } = await runCommand("tsci push")
 
   expect(exitCode).toBe(1)
-  expect(stderr).toBe(
-    "No package.json found, try running 'tsci init' to bootstrap the project\n",
+  expect(stderr).toContain(
+    "No entrypoint found. Run 'tsci init' to bootstrap a basic project or specify a file with 'tsci push <file>",
   )
 })
 


### PR DESCRIPTION
Like tsci dev, tsci push should find board files (*.circuit.tsx, *.board.tsx, *.circuit.json) when no standard entrypoint exists.

Fixes #2797

## Changes
- Added findBoardFiles import to push-snippet.ts
- After failing to find a standard entrypoint, fall back to finding board files (same logic as tsci dev)
- Only show the No entrypoint found error if both searches fail