### PR TITLE
 Make tsci push fall back to selectable project files when no entrypoint is configured

### DIFF
--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -15,6 +15,9 @@ import { checkOrgAccess } from "lib/utils/check-org-access"
 import { isBinaryFile } from "./is-binary-file"
 import { hasBinaryContent } from "./has-binary-content"
 import JSZip from "jszip"
+import { findBoardFiles } from "./find-board-files"
+import { globbySync } from "globby"
+import { DEFAULT_IGNORED_PATTERNS } from "./should-ignore-path"
 
 type PushOptions = {
   filePath?: string
@@ -29,6 +32,26 @@ type PushOptions = {
 }
 
 const debug = Debug("tsci:push-snippet")
+
+const findSelectableFiles = (projectDir: string): string[] => {
+  const boardFiles = findBoardFiles({ projectDir })
+    .filter((file) => fs.existsSync(file))
+    .sort()
+
+  if (boardFiles.length > 0) {
+    return boardFiles
+  }
+
+  const files = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
+    cwd: projectDir,
+    ignore: DEFAULT_IGNORED_PATTERNS,
+  })
+
+  return files
+    .map((file) => path.resolve(projectDir, file))
+    .filter((file) => fs.existsSync(file))
+    .sort()
+}
 
 const findPushProject = async ({
   filePath,
@@ -74,7 +97,9 @@ const findPushProject = async ({
       projectDir,
       onSuccess: () => {},
       onError: () => {},
-    })) ?? undefined
+    })) ??
+    findSelectableFiles(projectDir)[0] ??
+    undefined
 
   return { snippetFilePath, packageJsonPath, projectDir }
 }
@@ -180,13 +205,12 @@ export const pushSnippet = async ({
   const packageJsonHasName = Boolean(packageJson.name)
   if (!packageJsonHasName) {
     console.log(kleur.gray("No package name found in package.json"))
-    let inputName: string
-    ;({ unscopedPackageName: inputName } = await prompts({
+    const { unscopedPackageName: inputName } = await prompts({
       type: "text",
       name: "unscopedPackageName",
       message: `Enter the unscoped package name:`,
       instructions: `Your package will be published as "@tsci/${currentUsername}.<unscoped package name>"`,
-    }))
+    })
 
     if (!inputName) {
       onError("Package name is required")

--- a/tests/cli/push/push1-no-entrypoint.test.ts
+++ b/tests/cli/push/push1-no-entrypoint.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test"
-import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { expect, test } from "bun:test"
 import * as fs from "node:fs"
 import * as path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
 test("should fail if no package.json is found", async () => {
   const { runCommand } = await getCliTestFixture({ loggedIn: true })
@@ -39,4 +39,28 @@ test("should push a package without an entrypoint", async () => {
   expect(stdout).toContain("⬆︎ prebuilt.circuit.json")
   expect(stdout).toContain("⬆︎ tscircuit.config.json")
   expect(stdout).toContain('"@tsci/test-user.test-package@1.0.0" published!')
+}, 30_000)
+
+test("should push a package by falling back to a selectable file when no entrypoint is found", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture({
+    loggedIn: true,
+  })
+
+  fs.writeFileSync(
+    path.resolve(tmpDir, "package.json"),
+    JSON.stringify({ name: "@tsci/test-user.test-package", version: "1.0.0" }),
+  )
+  fs.writeFileSync(
+    path.resolve(tmpDir, "board.tsx"),
+    "export const Board = () => null\n",
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand("tsci push")
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("⬆︎ board.tsx")
+  expect(stdout).toContain("⬆︎ package.json")
+  expect(stdout).toContain('"@tsci/test-user.test-package@1.0.0" published!')
+  expect(stdout).not.toContain("No entrypoint found")
 }, 30_000)


### PR DESCRIPTION
  tsci push previously failed with a "No entrypoint found" error when a project had no index.circuit.tsx and no mainEntrypoint, even though tsci dev already handled that case by falling back to the first
  selectable project file.

  This PR aligns push with dev by reusing the same fallback behavior:

  - try the configured or detected entrypoint first
  - if none exists, fall back to board files
  - then fall back to selectable .tsx, .ts, or .circuit.json files

  It also adds a regression test covering a project with no conventional entrypoint, verifying that tsci push succeeds and does not print the entrypoint error.

  Why this should score well against the guide:

  - it is a real bug fix, not a vague cleanup
  - it includes a reproduction test and the fix in the same PR
  - it is a meaningful CLI UX improvement
  
  /fixes #2797