### PR TITLE
fix: allow tsci push without entrypoint when circuit.json exists

### DIFF
--- a/lib/shared/get-entrypoint.ts
+++ b/lib/shared/get-entrypoint.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
+import { globbySync } from "globby"
 import { loadProjectConfig } from "lib/project-config"
 import kleur from "kleur"
 
@@ -200,6 +201,27 @@ export const getEntrypoint = async ({
         onSuccess(`Detected entrypoint: '${relativePath}'`)
         return entrypoint
       }
+    }
+
+    // No entrypoint found - check for circuit.json files as implicit entrypoints
+    // This allows `tsci push` to work the same as `tsci dev` which supports circuit.json files
+    const circuitJsonFiles = globbySync(
+      ["**/*.circuit.json", "**/circuit.json"],
+      {
+        cwd: validatedProjectDir,
+        ignore: ["**/node_modules/**", "**/dist/**"],
+      },
+    )
+      .map((f) => path.resolve(validatedProjectDir, f))
+      .filter(
+        (f) => fs.existsSync(f) && isValidDirectory(f, validatedProjectDir),
+      )
+      .sort()
+
+    if (circuitJsonFiles.length > 0) {
+      const chosenFile = path.relative(validatedProjectDir, circuitJsonFiles[0])
+      onSuccess(`Using circuit.json as implicit entrypoint: '${chosenFile}'`)
+      return circuitJsonFiles[0]
     }
 
     onError(

--- a/tests/get-entrypoint.test.ts
+++ b/tests/get-entrypoint.test.ts
@@ -539,7 +539,9 @@ test("getEntrypoint returns circuit.json as implicit entrypoint when no tsx/ts f
 
   expect(entrypoint).not.toBeNull()
   expect(entrypoint).toBe(path.join(tmpDir, "prebuilt.circuit.json"))
-  expect(onSuccessMessage).toContain("Using circuit.json as implicit entrypoint")
+  expect(onSuccessMessage).toContain(
+    "Using circuit.json as implicit entrypoint",
+  )
 })
 
 test("getEntrypoint prefers tsx entrypoint over circuit.json", async () => {

--- a/tests/get-entrypoint.test.ts
+++ b/tests/get-entrypoint.test.ts
@@ -519,3 +519,47 @@ test("getEntrypoint warns when multiple common locations exist", async () => {
   expect(warnings[0]).toContain("Choosing 'index.tsx'")
   expect(warnings[0]).toContain("'src/index.tsx'")
 })
+
+test("getEntrypoint returns circuit.json as implicit entrypoint when no tsx/ts files exist", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create only a circuit.json file, no tsx/ts entrypoints
+  await fs.writeFile(
+    path.join(tmpDir, "prebuilt.circuit.json"),
+    JSON.stringify([{ type: "source_component", name: "U1" }]),
+  )
+
+  let onSuccessMessage = ""
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    onSuccess: (msg) => {
+      onSuccessMessage = msg
+    },
+  })
+
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "prebuilt.circuit.json"))
+  expect(onSuccessMessage).toContain("Using circuit.json as implicit entrypoint")
+})
+
+test("getEntrypoint prefers tsx entrypoint over circuit.json", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Create both a circuit.json and an index.tsx
+  await fs.writeFile(
+    path.join(tmpDir, "prebuilt.circuit.json"),
+    JSON.stringify([{ type: "source_component", name: "U1" }]),
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  // Should prefer the tsx file since it comes first in ALLOWED_ENTRYPOINT_NAMES
+  expect(entrypoint).not.toBeNull()
+  expect(entrypoint).toBe(path.join(tmpDir, "index.tsx"))
+})


### PR DESCRIPTION
When no tsx/ts entrypoint files are found, `getEntrypoint()` now falls back to checking for `circuit.json` files. This mirrors the behavior of `tsci dev` which already supports circuit.json files as valid build targets.

Fixes #2797