### PR TITLE
feat: add pnp-csv as standalone export format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,4 @@ Test fixture provides:
 The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the TypeScript runner, preferring Bun when available. This allows hot-reload during development while maintaining Node.js compatibility.
 # bump 1777865639
 # bump 1777865726
+# bump 1777867209

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,4 @@ Test fixture provides:
 
 The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the TypeScript runner, preferring Bun when available. This allows hot-reload during development while maintaining Node.js compatibility.
 # bump 1777865639
+# bump 1777865726

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777996807
 # bump 1778040013
 # bump 1778083216
+# bump 1778126413

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777910411
 # bump 1777953607
 # bump 1777996807
+# bump 1778040013

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777865726
 # bump 1777867209
 # bump 1777910411
+# bump 1777953607

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777867209
 # bump 1777910411
 # bump 1777953607
+# bump 1777996807

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777865639
 # bump 1777865726
 # bump 1777867209
+# bump 1777910411

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,4 @@ Test fixture provides:
 ## Runtime
 
 The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the TypeScript runner, preferring Bun when available. This allows hot-reload during development while maintaining Node.js compatibility.
+# bump 1777865639

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,4 @@ The CLI entrypoint (`cli/entrypoint.js`) selects between Bun and tsx as the Type
 # bump 1777953607
 # bump 1777996807
 # bump 1778040013
+# bump 1778083216

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -55,6 +55,7 @@ export const ALLOWED_EXPORT_FORMATS = [
   "srj",
   "step",
   "assembly-svg",
+  "pnp-csv",
 ] as const
 
 export type ExportFormat = (typeof ALLOWED_EXPORT_FORMATS)[number]
@@ -76,6 +77,7 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   "kicad-library": "",
   srj: ".simple-route.json",
   step: ".step",
+  "pnp-csv": "-pnp.csv",
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -344,6 +346,9 @@ export const exportSnippet = async ({
       break
     case "assembly-svg":
       outputContent = convertCircuitJsonToAssemblySvg(circuitJson)
+      break
+    case "pnp-csv":
+      outputContent = await convertCircuitJsonToPickAndPlaceCsv(circuitJson)
       break
     default:
       outputContent = JSON.stringify(circuitJson, null, 2)

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -75,11 +75,26 @@ export const pushSnippet = async ({
   }
 
   // Detect the entrypoint file
-  const snippetFilePath = await getEntrypoint({
+  let snippetFilePath = await getEntrypoint({
     filePath,
     onSuccess: () => {},
     onError,
   })
+
+  // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
+  if (!snippetFilePath) {
+    const { globbySync } = await import("globby")
+    const projectDir = process.cwd()
+    const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
+      cwd: projectDir,
+      ignore: ["node_modules/**", "**/.*"]
+    }).filter(f => fs.existsSync(f))
+
+    if (validFiles.length > 0) {
+      snippetFilePath = path.resolve(projectDir, validFiles[0])
+      onSuccess(`Using fallback file: '${validFiles[0]}'`)
+    }
+  }
 
   if (!snippetFilePath) {
     return onExit(1)

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -84,12 +84,16 @@ export const pushSnippet = async ({
 
   // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
   if (!snippetFilePath) {
-    
     const projectDir = process.cwd()
-    const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
-      cwd: projectDir,
-      ignore: ["node_modules/**", "**/.*"]
-    }).filter((relativePath) => fs.existsSync(path.join(projectDir, relativePath)))
+    const validFiles = globbySync(
+      ["**/*.tsx", "**/*.ts", "**/*.circuit.json"],
+      {
+        cwd: projectDir,
+        ignore: ["node_modules/**", "**/.*"],
+      },
+    ).filter((relativePath) =>
+      fs.existsSync(path.join(projectDir, relativePath)),
+    )
 
     if (validFiles.length > 0) {
       snippetFilePath = path.resolve(projectDir, validFiles[0])

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -6,6 +6,7 @@ import semver from "semver"
 import Debug from "debug"
 import kleur from "kleur"
 import { getEntrypoint } from "./get-entrypoint"
+import { globbySync } from "globby"
 import prompts from "lib/utils/prompts"
 import { getUnscopedPackageName } from "lib/utils/get-unscoped-package-name"
 import { getPackageAuthor } from "lib/utils/get-package-author"
@@ -83,12 +84,12 @@ export const pushSnippet = async ({
 
   // If no entrypoint found, try to find any valid circuit file (like tsci dev does)
   if (!snippetFilePath) {
-    const { globbySync } = await import("globby")
+    
     const projectDir = process.cwd()
     const validFiles = globbySync(["**/*.tsx", "**/*.ts", "**/*.circuit.json"], {
       cwd: projectDir,
       ignore: ["node_modules/**", "**/.*"]
-    }).filter(f => fs.existsSync(f))
+    }).filter((relativePath) => fs.existsSync(path.join(projectDir, relativePath)))
 
     if (validFiles.length > 0) {
       snippetFilePath = path.resolve(projectDir, validFiles[0])


### PR DESCRIPTION
## Summary

Add `pnp-csv` export format to `ALLOWED_EXPORT_FORMATS`, enabling standalone pick-and-place CSV export.

## Changes

- Added `pnp-csv` to `ALLOWED_EXPORT_FORMATS` array
- Added `pnp-csv: "-pnp.csv"` to `OUTPUT_EXTENSIONS`
- Added case handler that uses the already-imported `convertCircuitJsonToPickAndPlaceCsv`

Also includes the `tsci push` fallback fix from #2914 (globbySync for finding circuit files when no entrypoint).