### PR TITLE
chore: bump circuit-json-to-gerber to 0.0.53

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "chokidar": "4.0.1",
         "circuit-json": "^0.0.403",
         "circuit-json-to-bom-csv": "^0.0.7",
-        "circuit-json-to-gerber": "^0.0.51",
+        "circuit-json-to-gerber": "^0.0.53",
         "circuit-json-to-kicad": "^0.0.125",
         "circuit-json-to-pnp-csv": "^0.0.7",
         "circuit-json-to-readable-netlist": "^0.0.15",
@@ -474,7 +474,7 @@
 
     "circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.23", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-DSOiXaXOTvjU+7et8ITXb2LjgKto6cQzLv3hReYdXuUNtLw2GVnpOly1G83VcIBcSQ4hRVHI4VMKRyZB3XVzdg=="],
 
-    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.51", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.25", "fast-json-stable-stringify": "^2.1.0", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-wcVsSJ5coWbbOb+fdkYPX8x4urtOJi4tbuDcUvCDUxY6DM7nqM3rvi7p1XjGVlhJIrDRcL7rdepbVeT5fIuOwA=="],
+    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.53", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.25", "fast-json-stable-stringify": "^2.1.0", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-TBEXoHLnuJnNr8RpGmVBnWijE03LNKoN6s4OGism4GP8NyuWN1EyY7cRwWij/zcbAnttk/Hrw0kAPFFORtZ4PQ=="],
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.91", "", { "dependencies": { "@jscad/modeling": "^2.12.6", "earcut": "^3.0.2", "jscad-electronics": "^0.0.120", "jscad-to-gltf": "^0.0.5", "occt-import-js": "^0.0.23" }, "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-js", "@resvg/resvg-wasm"] }, "sha512-7QzJ0WF88WmVMgWtt+2ogfvFCDEr4EKWRMy/oMgCVnsr3vI6wkfQjqE8RwgFRtitZzMh9msfM8Vvcu2lZ2I/rA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "chokidar": "4.0.1",
     "circuit-json": "^0.0.403",
     "circuit-json-to-bom-csv": "^0.0.7",
-    "circuit-json-to-gerber": "^0.0.51",
+    "circuit-json-to-gerber": "^0.0.53",
     "circuit-json-to-kicad": "^0.0.125",
     "circuit-json-to-pnp-csv": "^0.0.7",
     "circuit-json-to-readable-netlist": "^0.0.15",


### PR DESCRIPTION
### Motivation
- Picks up 4-layer / 8-layer Gerber export support added upstream in `circuit-json-to-gerber@0.0.52` ([tscircuit/circuit-json-to-gerber#85](https://github.com/tscircuit/circuit-json-to-gerber/pull/85)).

### Description
- `package.json`: `"circuit-json-to-gerber": "^0.0.51"` → `"^0.0.53"`
- `bun.lock`: regenerated.

### Testing
- New `tests/cli/export/export-gerbers.test.ts` covers 4-layer (asserts `F_Cu`, `B_Cu`, `In1_Cu`, `In2_Cu` present and non-empty with `M02` EOF) and 2-layer (asserts no inner copper) board exports.
