### PR TITLE
Add STEP 3D model generation to build pipeline (CLI + config + tests)

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -26,6 +26,7 @@ export interface BuildCommandOptions {
   kicadPcm?: boolean
   previewGltf?: boolean
   glbs?: boolean
+  step?: boolean
   profile?: boolean
   useCdnJavascript?: boolean
   concurrency?: string

--- a/cli/build/build-step-files.ts
+++ b/cli/build/build-step-files.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs"
+import path from "node:path"
+import type { AnyCircuitElement } from "circuit-json"
+import { circuitJsonToStep } from "circuit-json-to-step"
+import type { BuildFileResult } from "./build-preview-images"
+
+export const buildStepFiles = async ({
+  builtFiles,
+  distDir,
+}: {
+  builtFiles: BuildFileResult[]
+  distDir: string
+}) => {
+  const successfulBuilds = builtFiles.filter((file) => file.ok)
+
+  if (successfulBuilds.length === 0) {
+    console.warn("No successful build output available for STEP generation.")
+    return
+  }
+
+  for (const build of successfulBuilds) {
+    const outputDir = path.dirname(build.outputPath)
+    const prefixRelative = path.relative(distDir, outputDir) || "."
+    const prefix = prefixRelative === "." ? "" : `[${prefixRelative}] `
+
+    let circuitJson: AnyCircuitElement[]
+    try {
+      const circuitJsonRaw = fs.readFileSync(build.outputPath, "utf-8")
+      circuitJson = JSON.parse(circuitJsonRaw)
+    } catch (error) {
+      console.error(`${prefix}Failed to read circuit JSON:`, error)
+      continue
+    }
+
+    try {
+      console.log(`${prefix}Converting circuit to STEP...`)
+      const stepContent = await circuitJsonToStep(circuitJson)
+      fs.writeFileSync(path.join(outputDir, "3d.step"), stepContent)
+      console.log(`${prefix}Written 3d.step`)
+    } catch (error) {
+      console.error(`${prefix}Failed to generate STEP:`, error)
+    }
+  }
+}

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -18,6 +18,7 @@ import { type BuildCommandOptions, applyCiBuildOptions } from "./build-ci"
 import { buildFile } from "./build-file"
 import { buildGlbs } from "./build-glbs"
 import { buildKicadPcm } from "./build-kicad-pcm"
+import { buildStepFiles } from "./build-step-files"
 import { buildPreviewGltf } from "./build-preview-gltf"
 import type { BuildFileResult } from "./build-preview-images"
 import { buildPreviewImages } from "./build-preview-images"
@@ -176,6 +177,7 @@ export const registerBuild = (program: Command) => {
     )
     .option("--show-courtyards", "Show courtyard outlines in PCB SVG outputs")
     .option("--glbs", "Generate GLB 3D model files for every successful build")
+    .option("--step", "Generate STEP 3D model files for every successful build")
     .option(
       "--profile",
       "Log per-circuit circuit.json generation time during build",
@@ -704,6 +706,14 @@ export const registerBuild = (program: Command) => {
           })
         }
 
+        if (resolvedOptions?.step) {
+          console.log("Generating STEP models for all builds...")
+          await buildStepFiles({
+            builtFiles,
+            distDir,
+          })
+        }
+
         if (resolvedOptions?.transpile) {
           const includeBoardPatterns =
             projectConfig?.includeBoardFiles?.filter((pattern) =>
@@ -902,6 +912,7 @@ export const registerBuild = (program: Command) => {
           resolvedOptions?.pcbOnly && "pcb-only",
           resolvedOptions?.schematicOnly && "schematic-only",
           resolvedOptions?.glbs && "glbs",
+          resolvedOptions?.step && "step",
           resolvedOptions?.kicadProject && "kicad-project",
           resolvedOptions?.kicadLibrary && "kicad-library",
           resolvedOptions?.kicadPcm && "kicad-pcm",

--- a/cli/build/resolve-build-options.ts
+++ b/cli/build/resolve-build-options.ts
@@ -36,6 +36,9 @@ export const resolveBuildOptions = ({
   if (!cliOptions?.glbs && configBuild?.glbs) {
     configAppliedOpts.push("glbs")
   }
+  if (!cliOptions?.step && configBuild?.step) {
+    configAppliedOpts.push("step")
+  }
   if (
     cliOptions?.routingDisabled === undefined &&
     configBuild?.routingDisabled
@@ -55,6 +58,7 @@ export const resolveBuildOptions = ({
     kicadPcm: cliOptions?.kicadPcm ?? configBuild?.kicadPcm,
     previewImages: cliOptions?.previewImages ?? configBuild?.previewImages,
     glbs: cliOptions?.glbs ?? configBuild?.glbs,
+    step: cliOptions?.step ?? configBuild?.step,
     routingDisabled:
       cliOptions?.routingDisabled ?? configBuild?.routingDisabled,
     transpile: cliOptions?.transpile ?? configBuild?.typescriptLibrary,

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -31,6 +31,7 @@ export const projectConfigSchema = z.object({
       kicadPcm: z.boolean().optional(),
       previewImages: z.boolean().optional(),
       glbs: z.boolean().optional(),
+      step: z.boolean().optional(),
       workerTimeoutMs: z.number().int().positive().optional(),
       routingDisabled: z.boolean().optional(),
       typescriptLibrary: z.boolean().optional(),

--- a/tests/cli/build/build-step-config.test.ts
+++ b/tests/cli/build/build-step-config.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const circuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)
+`
+
+test("build uses config build.step setting", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "step-output.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({
+      build: {
+        step: true,
+      },
+    }),
+  )
+
+  const { stderr, stdout } = await runCommand(`tsci build ${circuitPath}`)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("Generating STEP models")
+  expect(stdout).toContain("step")
+
+  const stepContent = await readFile(
+    path.join(tmpDir, "dist", "step-output", "3d.step"),
+    "utf-8",
+  )
+
+  expect(stepContent).toContain("ISO-10303-21")
+  expect(stepContent).toContain("FILE_DESCRIPTION")
+}, 60_000)

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -115,6 +115,10 @@
           "type": "boolean",
           "description": "Enable GLB 3D model outputs for each circuit in build."
         },
+        "step": {
+          "type": "boolean",
+          "description": "Enable STEP 3D model outputs for each circuit in build."
+        },
         "workerTimeoutMs": {
           "type": "number",
           "minimum": 1,


### PR DESCRIPTION
### Motivation
- Provide STEP 3D model outputs for built circuits so consumers can obtain CAD-friendly STEP files alongside GLB/PNG outputs.
- Allow enabling STEP generation via the CLI and project configuration to make the feature selectable per-project or per-run.

### Description
- Add a new generator `build-step-files.ts` that reads generated `circuit.json`, converts it via `circuit-json-to-step`, and writes `3d.step` next to each build output.
- Wire the feature into the CLI by adding a `--step` option in `register.ts`, adding `step` to the `BuildCommandOptions` type, and including `step` in the enabled options summary.
- Extend project configuration support by adding `step` to `project-config-schema.ts` and to the JSON schema in `types/tscircuit.config.schema.json`, and apply the config default in `resolve-build-options.ts`.
- Add an automated test `tests/cli/build/build-step-config.test.ts` that exercises enabling `build.step` via `tscircuit.config.json`, runs `tsci build`, and asserts the resulting `3d.step` contains STEP file markers.

### Testing
- Ran the automated unit test suite including `tests/cli/build/build-step-config.test.ts`, and the tests completed successfully.
- Executed the CLI build path (`tsci build <file>`) with `build.step` enabled and confirmed a `dist/.../3d.step` file was produced containing `ISO-10303-21` and `FILE_DESCRIPTION` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0248c01024832e8767d30a23b264c8)