### PR TITLE
feat(search): add jlcpcb-prefixed identifiers to JLC search results

### DIFF
--- a/cli/search/format-jlcpcb-search-result.ts
+++ b/cli/search/format-jlcpcb-search-result.ts
@@ -1,0 +1,53 @@
+export type JlcpcbSearchResult = {
+  lcsc: number | string
+  mfr?: string | null
+  package?: string | null
+  description?: string | null
+  stock?: number | null
+  price?: number | null
+}
+
+const normalizeDisplayText = (value?: string | null) => value?.trim() ?? ""
+
+const hasSameDisplayText = (left?: string | null, right?: string | null) =>
+  normalizeDisplayText(left).toLocaleLowerCase() ===
+  normalizeDisplayText(right).toLocaleLowerCase()
+
+const getJlcpcbDisplayDetails = (comp: JlcpcbSearchResult) => {
+  const manufacturer = normalizeDisplayText(comp.mfr)
+  const description = normalizeDisplayText(comp.description)
+
+  if (
+    manufacturer &&
+    description &&
+    hasSameDisplayText(manufacturer, description)
+  ) {
+    return [manufacturer]
+  }
+
+  return [manufacturer, description].filter(Boolean)
+}
+
+const normalizeJlcpcbPartNumber = (lcsc: number | string) => {
+  const rawPartNumber = String(lcsc).trim()
+
+  return rawPartNumber.replace(/^jlcpcb:/i, "").replace(/^c/i, "")
+}
+
+export const getJlcpcbSearchResultIdentifier = (lcsc: number | string) =>
+  `jlcpcb:C${normalizeJlcpcbPartNumber(lcsc)}`
+
+export const formatJlcpcbSearchResult = (
+  comp: JlcpcbSearchResult,
+  idx: number,
+) => {
+  const detailParts = getJlcpcbDisplayDetails(comp)
+  const stockSuffix =
+    typeof comp.stock === "number"
+      ? ` (stock: ${comp.stock.toLocaleString("en-US")})`
+      : ""
+
+  return `${idx + 1}. ${getJlcpcbSearchResultIdentifier(comp.lcsc)}${
+    detailParts.length ? ` - ${detailParts.join(" - ")}` : ""
+  }${stockSuffix}`
+}

--- a/cli/search/register.ts
+++ b/cli/search/register.ts
@@ -1,8 +1,12 @@
+import { getQueryFromParts } from "cli/utils/get-query-from-parts"
 import type { Command } from "commander"
-import { getRegistryApiKy } from "lib/registry-api/get-ky"
 import Fuse from "fuse.js"
 import kleur from "kleur"
-import { getQueryFromParts } from "cli/utils/get-query-from-parts"
+import { getRegistryApiKy } from "lib/registry-api/get-ky"
+import {
+  type JlcpcbSearchResult,
+  formatJlcpcbSearchResult,
+} from "./format-jlcpcb-search-result"
 
 export const registerSearch = (program: Command) => {
   program
@@ -46,14 +50,7 @@ export const registerSearch = (program: Command) => {
           }>
         } = { packages: [] }
 
-        let jlcResults: Array<{
-          lcsc: number
-          mfr: string
-          package: string
-          description: string
-          stock: number
-          price: number
-        }> = []
+        let jlcResults: JlcpcbSearchResult[] = []
 
         let kicadResults: string[] = []
 
@@ -68,9 +65,7 @@ export const registerSearch = (program: Command) => {
           }
 
           if (searchJlc) {
-            const jlcSearchUrl =
-              "https://jlcsearch.tscircuit.com/api/search?limit=10&q=" +
-              encodeURIComponent(query)
+            const jlcSearchUrl = `https://jlcsearch.tscircuit.com/api/search?limit=10&q=${encodeURIComponent(query)}`
             const jlcResponse = await fetch(jlcSearchUrl).then((r) => r.json())
             jlcResults = jlcResponse?.components ?? []
           }
@@ -189,9 +184,7 @@ export const registerSearch = (program: Command) => {
           )
 
           jlcResults.forEach((comp, idx) => {
-            console.log(
-              `${idx + 1}. ${comp.mfr} (C${comp.lcsc}) - ${comp.description} (stock: ${comp.stock.toLocaleString("en-US")})`,
-            )
+            console.log(formatJlcpcbSearchResult(comp, idx))
           })
         }
         console.log("\n")

--- a/tests/cli/search/search-jlcpcb-command.test.ts
+++ b/tests/cli/search/search-jlcpcb-command.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, expect, test } from "bun:test"
+import type { JlcpcbSearchResult } from "cli/search/format-jlcpcb-search-result"
+import { registerSearch } from "cli/search/register"
+import { Command } from "commander"
+
+const originalFetch = globalThis.fetch
+const originalConsoleLog = console.log
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  console.log = originalConsoleLog
+})
+
+test("search --jlcpcb prints prefixed JLCPCB identifiers", async () => {
+  const output: string[] = []
+
+  console.log = (...args: unknown[]) => {
+    output.push(args.join(" "))
+  }
+
+  const components: JlcpcbSearchResult[] = [
+    {
+      lcsc: 2040,
+      mfr: "RP2040",
+      description: "RP2040",
+      stock: 123456,
+      package: "QFN-56",
+      price: 0.75,
+    },
+  ]
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input)
+
+    expect(url).toContain("https://jlcsearch.tscircuit.com/api/search")
+    expect(url).toContain("q=RP2040")
+
+    return new Response(JSON.stringify({ components }), {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+  }) as typeof fetch
+
+  const program = new Command()
+  registerSearch(program)
+
+  await program.parseAsync(["search", "--jlcpcb", "RP2040"], {
+    from: "user",
+  })
+
+  expect(output).toContain("Found 1 component(s) in JLC search:")
+  expect(output).toContain("1. jlcpcb:C2040 - RP2040 (stock: 123,456)")
+})

--- a/tests/cli/search/search-jlcpcb-format.test.ts
+++ b/tests/cli/search/search-jlcpcb-format.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import {
+  formatJlcpcbSearchResult,
+  getJlcpcbSearchResultIdentifier,
+} from "cli/search/format-jlcpcb-search-result"
+
+test("formatJlcpcbSearchResult prefixes JLCPCB identifiers", () => {
+  const output = formatJlcpcbSearchResult(
+    {
+      lcsc: 2040,
+      mfr: "RP2040",
+      package: "QFN-56",
+      description: "RP2040",
+      stock: 123456,
+      price: 0.75,
+    },
+    0,
+  )
+
+  expect(output).toBe("1. jlcpcb:C2040 - RP2040 (stock: 123,456)")
+})
+
+test("getJlcpcbSearchResultIdentifier normalizes existing prefixes", () => {
+  expect(getJlcpcbSearchResultIdentifier("2040")).toBe("jlcpcb:C2040")
+  expect(getJlcpcbSearchResultIdentifier("C2040")).toBe("jlcpcb:C2040")
+  expect(getJlcpcbSearchResultIdentifier("jlcpcb:C2040")).toBe("jlcpcb:C2040")
+})
+
+test("formatJlcpcbSearchResult keeps distinct descriptions after the identifier", () => {
+  const output = formatJlcpcbSearchResult(
+    {
+      lcsc: 5555,
+      mfr: "SN74LVC1G00",
+      package: "SOT-23-5",
+      description: "Single 2-input NAND gate",
+      stock: 42,
+      price: 0.03,
+    },
+    1,
+  )
+
+  expect(output).toBe(
+    "2. jlcpcb:C5555 - SN74LVC1G00 - Single 2-input NAND gate (stock: 42)",
+  )
+})
+
+test("formatJlcpcbSearchResult compares repeated labels case-insensitively", () => {
+  const output = formatJlcpcbSearchResult(
+    {
+      lcsc: "C2040",
+      mfr: " RP2040 ",
+      description: "rp2040",
+      stock: undefined,
+    },
+    0,
+  )
+
+  expect(output).toBe("1. jlcpcb:C2040 - RP2040")
+})


### PR DESCRIPTION
## Summary

This change makes JLCPCB search output use an explicit provider-prefixed identifier, similar to the existing KiCad search output.

Before:

```bash
$ tsci search --jlcpcb RP2040
1. RP2040 (C2040) - RP2040
```

After:

```bash
$ tsci search --jlcpcb RP2040
1. jlcpcb:C2040 - RP2040
```

## Why

KiCad search results already return namespaced identifiers such as `kicad:Resistor_SMD/R_0402_1005Metric`, but JLCPCB results only exposed the LCSC part number inside descriptive text. That made the output less consistent and harder to copy directly into workflows that expect provider-prefixed component references.

## What changed

- updated human-readable JLCPCB search output to print `jlcpcb:C...` first
- extracted JLCPCB identifier/label formatting into a dedicated helper for clearer behavior
- normalized existing `C...` or `jlcpcb:C...` values to a single output shape
- avoided repeating the same label twice when manufacturer and description are effectively identical
- added focused tests for both the formatter and the `search --jlcpcb` command output

## User impact

- `tsci search resistor` still defaults to JLCPCB search
- `tsci search --kicad resistor` is unchanged
- `tsci search --jlcpcb RP2040` now prints a copy-paste-friendly `jlcpcb:` identifier
- search behavior and JSON output are unchanged; this only affects the displayed CLI formatting

## Validation

- `bun test tests/cli/search/search-jlcpcb-format.test.ts tests/cli/search/search-jlcpcb-command.test.ts`
- `bunx @biomejs/biome check cli/search/register.ts cli/search/format-jlcpcb-search-result.ts tests/cli/search/search-jlcpcb-command.test.ts tests/cli/search/search-jlcpcb-format.test.ts`