### PR TITLE
fix: fall back to node when bun and tsx are not installed

### DIFF
--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -1,59 +1,61 @@
-import fs from "node:fs"
-import path from "node:path"
-import { dirname } from "node:path"
-import { fileURLToPath } from "node:url"
-
-// __metaDir is Bun-only; __metaDirname is Node 21.2+
-const __metaDir: string =
-  (import.meta as unknown as { dir?: string }).dir ??
-  __metaDirname ??
-  dirname(fileURLToPath(import.meta.url))
-import type { PlatformConfig } from "@tscircuit/props"
-import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
-import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
-import type { DrcIgnoreOptions } from "./drc-diagnostic-filter"
-import type { BuildImageFormatSelection } from "./image-format-selection"
+import fs from "node:fs";
+import path from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { PlatformConfig } from "@tscircuit/props";
+import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema";
+import { ThreadWorkerPool } from "lib/shared/thread-worker-pool";
+import type { DrcIgnoreOptions } from "./drc-diagnostic-filter";
+import type { BuildImageFormatSelection } from "./image-format-selection";
 import type {
-  BuildCompletedMessage,
-  BuildFileMessage,
-  BuildJobResult,
-  WorkerOutputMessage,
-} from "./worker-types"
+	BuildCompletedMessage,
+	BuildFileMessage,
+	BuildJobResult,
+	WorkerOutputMessage,
+} from "./worker-types";
+
+// import.meta.dir is Bun-only; import.meta.dirname is Node >=21.2
+// Cast to include both so TypeScript doesn't complain about either property.
+type ImportMetaWithDir = { dir?: string; dirname?: string };
+const __metaDir: string =
+	(import.meta as unknown as ImportMetaWithDir).dir ??
+	(import.meta as unknown as ImportMetaWithDir).dirname ??
+	dirname(fileURLToPath(import.meta.url));
 
 type BuildJob = {
-  filePath: string
-  outputPath: string
-  glbOutputPath?: string
-  stepOutputPath?: string
-  previewOutputDir?: string
-  projectDir: string
-  options?: {
-    ignoreErrors?: boolean
-    ignoreWarnings?: boolean
-  } & DrcIgnoreOptions & {
-      platformConfig?: PlatformConfig
-      profile?: boolean
-      injectedProps?: Record<string, unknown>
-      generatePreviewAssets?: boolean
-      imageFormats?: BuildImageFormatSelection
-      pcbSnapshotSettings?: PcbSnapshotSettings
-    }
-}
+	filePath: string;
+	outputPath: string;
+	glbOutputPath?: string;
+	stepOutputPath?: string;
+	previewOutputDir?: string;
+	projectDir: string;
+	options?: {
+		ignoreErrors?: boolean;
+		ignoreWarnings?: boolean;
+	} & DrcIgnoreOptions & {
+			platformConfig?: PlatformConfig;
+			profile?: boolean;
+			injectedProps?: Record<string, unknown>;
+			generatePreviewAssets?: boolean;
+			imageFormats?: BuildImageFormatSelection;
+			pcbSnapshotSettings?: PcbSnapshotSettings;
+		};
+};
 
 const getWorkerEntrypointPath = (): string => {
-  // Check for .ts file first (development), then .js (published/dist)
-  const tsPath = path.join(__metaDir, "build.worker.ts")
-  if (fs.existsSync(tsPath)) {
-    return tsPath
-  }
-  // When bundled, main.js is in dist/ and worker is in dist/build/
-  const jsBundledPath = path.join(__metaDir, "build", "build.worker.js")
-  if (fs.existsSync(jsBundledPath)) {
-    return jsBundledPath
-  }
-  // Fallback: same directory
-  return path.join(__metaDir, "build.worker.js")
-}
+	// Check for .ts file first (development), then .js (published/dist)
+	const tsPath = path.join(__metaDir, "build.worker.ts");
+	if (fs.existsSync(tsPath)) {
+		return tsPath;
+	}
+	// When bundled, main.js is in dist/ and worker is in dist/build/
+	const jsBundledPath = path.join(__metaDir, "build", "build.worker.js");
+	if (fs.existsSync(jsBundledPath)) {
+		return jsBundledPath;
+	}
+	// Fallback: same directory
+	return path.join(__metaDir, "build.worker.js");
+};
 
 /**
  * Build multiple files in parallel using worker threads.
@@ -61,159 +63,159 @@ const getWorkerEntrypointPath = (): string => {
  * Circuit JSON is written to disk, not passed through IPC.
  */
 export async function buildFilesWithWorkerPool(options: {
-  files: Array<{
-    filePath: string
-    outputPath: string
-    glbOutputPath?: string
-    stepOutputPath?: string
-    previewOutputDir?: string
-    generatePreviewAssets?: boolean
-  }>
-  projectDir: string
-  concurrency: number
-  buildOptions?: {
-    ignoreErrors?: boolean
-    ignoreWarnings?: boolean
-  } & DrcIgnoreOptions & {
-      platformConfig?: PlatformConfig
-      profile?: boolean
-      injectedProps?: Record<string, unknown>
-      generatePreviewAssets?: boolean
-      imageFormats?: BuildImageFormatSelection
-      pcbSnapshotSettings?: PcbSnapshotSettings
-    }
-  onLog?: (lines: string[]) => void
-  onJobComplete?: (result: BuildJobResult) => void
-  stopOnFatal?: boolean
-  workerJobTimeoutMs?: number
+	files: Array<{
+		filePath: string;
+		outputPath: string;
+		glbOutputPath?: string;
+		stepOutputPath?: string;
+		previewOutputDir?: string;
+		generatePreviewAssets?: boolean;
+	}>;
+	projectDir: string;
+	concurrency: number;
+	buildOptions?: {
+		ignoreErrors?: boolean;
+		ignoreWarnings?: boolean;
+	} & DrcIgnoreOptions & {
+			platformConfig?: PlatformConfig;
+			profile?: boolean;
+			injectedProps?: Record<string, unknown>;
+			generatePreviewAssets?: boolean;
+			imageFormats?: BuildImageFormatSelection;
+			pcbSnapshotSettings?: PcbSnapshotSettings;
+		};
+	onLog?: (lines: string[]) => void;
+	onJobComplete?: (result: BuildJobResult) => void;
+	stopOnFatal?: boolean;
+	workerJobTimeoutMs?: number;
 }): Promise<BuildJobResult[]> {
-  const cancellationError = new Error("Build cancelled due fatal error")
-  const envWorkerTimeoutMs = Number.parseInt(
-    process.env.TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS || "",
-    10,
-  )
-  const workerJobTimeoutMs = Number.isFinite(envWorkerTimeoutMs)
-    ? envWorkerTimeoutMs
-    : (options.workerJobTimeoutMs ?? 300000)
-  const poolConcurrency = Math.max(
-    1,
-    Math.min(options.concurrency, options.files.length),
-  )
+	const cancellationError = new Error("Build cancelled due fatal error");
+	const envWorkerTimeoutMs = Number.parseInt(
+		process.env.TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS || "",
+		10,
+	);
+	const workerJobTimeoutMs = Number.isFinite(envWorkerTimeoutMs)
+		? envWorkerTimeoutMs
+		: (options.workerJobTimeoutMs ?? 300000);
+	const poolConcurrency = Math.max(
+		1,
+		Math.min(options.concurrency, options.files.length),
+	);
 
-  const pool = new ThreadWorkerPool<
-    BuildJob,
-    BuildFileMessage,
-    WorkerOutputMessage,
-    BuildJobResult
-  >({
-    concurrency: poolConcurrency,
-    workerEntrypointPath: getWorkerEntrypointPath(),
-    createMessage: (job) => ({
-      message_type: "build_file",
-      file_path: job.filePath,
-      output_path: job.outputPath,
-      glb_output_path: job.glbOutputPath,
-      step_output_path: job.stepOutputPath,
-      preview_output_dir: job.previewOutputDir,
-      project_dir: job.projectDir,
-      options: job.options,
-    }),
-    isLogMessage: (message) => message.message_type === "worker_log",
-    getLogLines: (message) =>
-      message.message_type === "worker_log" ? message.log_lines : [],
-    getStatusLine: (message) =>
-      message.message_type === "worker_log"
-        ? (message.status_line ?? null)
-        : null,
-    isCompletionMessage: (message) =>
-      message.message_type === "build_completed",
-    getResult: (message) => {
-      const completedMessage = message as BuildCompletedMessage
-      return {
-        filePath: completedMessage.file_path,
-        outputPath: completedMessage.output_path,
-        glbOutputPath: completedMessage.glb_output_path,
-        stepOutputPath: completedMessage.step_output_path,
-        previewOutputDir: completedMessage.preview_output_dir,
-        glbOk: completedMessage.glb_ok,
-        glbError: completedMessage.glb_error,
-        stepOk: completedMessage.step_ok,
-        stepError: completedMessage.step_error,
-        previewOk: completedMessage.preview_ok,
-        previewError: completedMessage.preview_error,
-        ok: completedMessage.ok,
-        hasErrors: completedMessage.hasErrors,
-        ignoredDrcCount: completedMessage.ignoredDrcCount,
-        ignoredDrcByCategory: completedMessage.ignoredDrcByCategory,
-        isFatalError: completedMessage.isFatalError,
-        errors: completedMessage.errors,
-        warnings: completedMessage.warnings,
-        durationMs: completedMessage.durationMs,
-      }
-    },
-    shouldStopOnMessage: (message) => {
-      if (!options.stopOnFatal || message.message_type !== "build_completed") {
-        return false
-      }
-      return Boolean((message as BuildCompletedMessage).isFatalError)
-    },
-    cancellationError,
-    jobTimeoutMs:
-      Number.isFinite(workerJobTimeoutMs) && workerJobTimeoutMs > 0
-        ? workerJobTimeoutMs
-        : undefined,
-    onLog: options.onLog,
-  })
+	const pool = new ThreadWorkerPool<
+		BuildJob,
+		BuildFileMessage,
+		WorkerOutputMessage,
+		BuildJobResult
+	>({
+		concurrency: poolConcurrency,
+		workerEntrypointPath: getWorkerEntrypointPath(),
+		createMessage: (job) => ({
+			message_type: "build_file",
+			file_path: job.filePath,
+			output_path: job.outputPath,
+			glb_output_path: job.glbOutputPath,
+			step_output_path: job.stepOutputPath,
+			preview_output_dir: job.previewOutputDir,
+			project_dir: job.projectDir,
+			options: job.options,
+		}),
+		isLogMessage: (message) => message.message_type === "worker_log",
+		getLogLines: (message) =>
+			message.message_type === "worker_log" ? message.log_lines : [],
+		getStatusLine: (message) =>
+			message.message_type === "worker_log"
+				? (message.status_line ?? null)
+				: null,
+		isCompletionMessage: (message) =>
+			message.message_type === "build_completed",
+		getResult: (message) => {
+			const completedMessage = message as BuildCompletedMessage;
+			return {
+				filePath: completedMessage.file_path,
+				outputPath: completedMessage.output_path,
+				glbOutputPath: completedMessage.glb_output_path,
+				stepOutputPath: completedMessage.step_output_path,
+				previewOutputDir: completedMessage.preview_output_dir,
+				glbOk: completedMessage.glb_ok,
+				glbError: completedMessage.glb_error,
+				stepOk: completedMessage.step_ok,
+				stepError: completedMessage.step_error,
+				previewOk: completedMessage.preview_ok,
+				previewError: completedMessage.preview_error,
+				ok: completedMessage.ok,
+				hasErrors: completedMessage.hasErrors,
+				ignoredDrcCount: completedMessage.ignoredDrcCount,
+				ignoredDrcByCategory: completedMessage.ignoredDrcByCategory,
+				isFatalError: completedMessage.isFatalError,
+				errors: completedMessage.errors,
+				warnings: completedMessage.warnings,
+				durationMs: completedMessage.durationMs,
+			};
+		},
+		shouldStopOnMessage: (message) => {
+			if (!options.stopOnFatal || message.message_type !== "build_completed") {
+				return false;
+			}
+			return Boolean((message as BuildCompletedMessage).isFatalError);
+		},
+		cancellationError,
+		jobTimeoutMs:
+			Number.isFinite(workerJobTimeoutMs) && workerJobTimeoutMs > 0
+				? workerJobTimeoutMs
+				: undefined,
+		onLog: options.onLog,
+	});
 
-  const results: BuildJobResult[] = []
-  const promises: Promise<BuildJobResult>[] = []
+	const results: BuildJobResult[] = [];
+	const promises: Promise<BuildJobResult>[] = [];
 
-  for (const file of options.files) {
-    const promise = pool
-      .queueJob({
-        filePath: file.filePath,
-        outputPath: file.outputPath,
-        glbOutputPath: file.glbOutputPath,
-        stepOutputPath: file.stepOutputPath,
-        previewOutputDir: file.previewOutputDir,
-        projectDir: options.projectDir,
-        options: {
-          ...options.buildOptions,
-          generatePreviewAssets:
-            file.generatePreviewAssets ??
-            options.buildOptions?.generatePreviewAssets,
-        },
-      })
-      .then(async (result) => {
-        results.push(result)
-        if (options.onJobComplete) {
-          await options.onJobComplete(result)
-        }
+	for (const file of options.files) {
+		const promise = pool
+			.queueJob({
+				filePath: file.filePath,
+				outputPath: file.outputPath,
+				glbOutputPath: file.glbOutputPath,
+				stepOutputPath: file.stepOutputPath,
+				previewOutputDir: file.previewOutputDir,
+				projectDir: options.projectDir,
+				options: {
+					...options.buildOptions,
+					generatePreviewAssets:
+						file.generatePreviewAssets ??
+						options.buildOptions?.generatePreviewAssets,
+				},
+			})
+			.then(async (result) => {
+				results.push(result);
+				if (options.onJobComplete) {
+					await options.onJobComplete(result);
+				}
 
-        return result
-      })
+				return result;
+			});
 
-    promises.push(promise)
-  }
+		promises.push(promise);
+	}
 
-  const settledResults = await Promise.allSettled(promises)
+	const settledResults = await Promise.allSettled(promises);
 
-  for (const settledResult of settledResults) {
-    if (
-      settledResult.status === "rejected" &&
-      settledResult.reason !== cancellationError
-    ) {
-      throw settledResult.reason
-    }
-  }
+	for (const settledResult of settledResults) {
+		if (
+			settledResult.status === "rejected" &&
+			settledResult.reason !== cancellationError
+		) {
+			throw settledResult.reason;
+		}
+	}
 
-  // NOTE: In some Bun runtimes, terminating worker threads here can cause the
-  // parent process to exit before post-build steps (site/preview/transpile)
-  // run. The CLI exits explicitly at the end of the build command, so on Bun
-  // we let process shutdown clean up workers.
-  if (typeof Bun === "undefined") {
-    await pool.terminate()
-  }
+	// NOTE: In some Bun runtimes, terminating worker threads here can cause the
+	// parent process to exit before post-build steps (site/preview/transpile)
+	// run. The CLI exits explicitly at the end of the build command, so on Bun
+	// we let process shutdown clean up workers.
+	if (typeof Bun === "undefined") {
+		await pool.terminate();
+	}
 
-  return results
+	return results;
 }

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -1,5 +1,13 @@
 import fs from "node:fs"
 import path from "node:path"
+import { dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+// __metaDir is Bun-only; __metaDirname is Node 21.2+
+const __metaDir: string =
+  (import.meta as unknown as { dir?: string }).dir ??
+  __metaDirname ??
+  dirname(fileURLToPath(import.meta.url))
 import type { PlatformConfig } from "@tscircuit/props"
 import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
 import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
@@ -34,17 +42,17 @@ type BuildJob = {
 
 const getWorkerEntrypointPath = (): string => {
   // Check for .ts file first (development), then .js (published/dist)
-  const tsPath = path.join(import.meta.dir, "build.worker.ts")
+  const tsPath = path.join(__metaDir, "build.worker.ts")
   if (fs.existsSync(tsPath)) {
     return tsPath
   }
   // When bundled, main.js is in dist/ and worker is in dist/build/
-  const jsBundledPath = path.join(import.meta.dir, "build", "build.worker.js")
+  const jsBundledPath = path.join(__metaDir, "build", "build.worker.js")
   if (fs.existsSync(jsBundledPath)) {
     return jsBundledPath
   }
   // Fallback: same directory
-  return path.join(import.meta.dir, "build.worker.js")
+  return path.join(__metaDir, "build.worker.js")
 }
 
 /**

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -1,61 +1,61 @@
-import fs from "node:fs";
-import path from "node:path";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import type { PlatformConfig } from "@tscircuit/props";
-import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema";
-import { ThreadWorkerPool } from "lib/shared/thread-worker-pool";
-import type { DrcIgnoreOptions } from "./drc-diagnostic-filter";
-import type { BuildImageFormatSelection } from "./image-format-selection";
+import fs from "node:fs"
+import path from "node:path"
+import { dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { PlatformConfig } from "@tscircuit/props"
+import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
+import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
+import type { DrcIgnoreOptions } from "./drc-diagnostic-filter"
+import type { BuildImageFormatSelection } from "./image-format-selection"
 import type {
-	BuildCompletedMessage,
-	BuildFileMessage,
-	BuildJobResult,
-	WorkerOutputMessage,
-} from "./worker-types";
-
-// import.meta.dir is Bun-only; import.meta.dirname is Node >=21.2
-// Cast to include both so TypeScript doesn't complain about either property.
-type ImportMetaWithDir = { dir?: string; dirname?: string };
-const __metaDir: string =
-	(import.meta as unknown as ImportMetaWithDir).dir ??
-	(import.meta as unknown as ImportMetaWithDir).dirname ??
-	dirname(fileURLToPath(import.meta.url));
+  BuildCompletedMessage,
+  BuildFileMessage,
+  BuildJobResult,
+  WorkerOutputMessage,
+} from "./worker-types"
 
 type BuildJob = {
-	filePath: string;
-	outputPath: string;
-	glbOutputPath?: string;
-	stepOutputPath?: string;
-	previewOutputDir?: string;
-	projectDir: string;
-	options?: {
-		ignoreErrors?: boolean;
-		ignoreWarnings?: boolean;
-	} & DrcIgnoreOptions & {
-			platformConfig?: PlatformConfig;
-			profile?: boolean;
-			injectedProps?: Record<string, unknown>;
-			generatePreviewAssets?: boolean;
-			imageFormats?: BuildImageFormatSelection;
-			pcbSnapshotSettings?: PcbSnapshotSettings;
-		};
-};
+  filePath: string
+  outputPath: string
+  glbOutputPath?: string
+  stepOutputPath?: string
+  previewOutputDir?: string
+  projectDir: string
+  options?: {
+    ignoreErrors?: boolean
+    ignoreWarnings?: boolean
+  } & DrcIgnoreOptions & {
+      platformConfig?: PlatformConfig
+      profile?: boolean
+      injectedProps?: Record<string, unknown>
+      generatePreviewAssets?: boolean
+      imageFormats?: BuildImageFormatSelection
+      pcbSnapshotSettings?: PcbSnapshotSettings
+    }
+}
+
+// import.meta.dir is Bun-only; import.meta.dirname is Node >=21.2
+// Cast to include both so TypeScript does not complain about either.
+type ImportMetaWithDir = { dir?: string; dirname?: string }
+const __metaDir: string =
+  (import.meta as unknown as ImportMetaWithDir).dir ??
+  (import.meta as unknown as ImportMetaWithDir).dirname ??
+  dirname(fileURLToPath(import.meta.url))
 
 const getWorkerEntrypointPath = (): string => {
-	// Check for .ts file first (development), then .js (published/dist)
-	const tsPath = path.join(__metaDir, "build.worker.ts");
-	if (fs.existsSync(tsPath)) {
-		return tsPath;
-	}
-	// When bundled, main.js is in dist/ and worker is in dist/build/
-	const jsBundledPath = path.join(__metaDir, "build", "build.worker.js");
-	if (fs.existsSync(jsBundledPath)) {
-		return jsBundledPath;
-	}
-	// Fallback: same directory
-	return path.join(__metaDir, "build.worker.js");
-};
+  // Check for .ts file first (development), then .js (published/dist)
+  const tsPath = path.join(__metaDir, "build.worker.ts")
+  if (fs.existsSync(tsPath)) {
+    return tsPath
+  }
+  // When bundled, main.js is in dist/ and worker is in dist/build/
+  const jsBundledPath = path.join(__metaDir, "build", "build.worker.js")
+  if (fs.existsSync(jsBundledPath)) {
+    return jsBundledPath
+  }
+  // Fallback: same directory
+  return path.join(__metaDir, "build.worker.js")
+}
 
 /**
  * Build multiple files in parallel using worker threads.
@@ -63,159 +63,159 @@ const getWorkerEntrypointPath = (): string => {
  * Circuit JSON is written to disk, not passed through IPC.
  */
 export async function buildFilesWithWorkerPool(options: {
-	files: Array<{
-		filePath: string;
-		outputPath: string;
-		glbOutputPath?: string;
-		stepOutputPath?: string;
-		previewOutputDir?: string;
-		generatePreviewAssets?: boolean;
-	}>;
-	projectDir: string;
-	concurrency: number;
-	buildOptions?: {
-		ignoreErrors?: boolean;
-		ignoreWarnings?: boolean;
-	} & DrcIgnoreOptions & {
-			platformConfig?: PlatformConfig;
-			profile?: boolean;
-			injectedProps?: Record<string, unknown>;
-			generatePreviewAssets?: boolean;
-			imageFormats?: BuildImageFormatSelection;
-			pcbSnapshotSettings?: PcbSnapshotSettings;
-		};
-	onLog?: (lines: string[]) => void;
-	onJobComplete?: (result: BuildJobResult) => void;
-	stopOnFatal?: boolean;
-	workerJobTimeoutMs?: number;
+  files: Array<{
+    filePath: string
+    outputPath: string
+    glbOutputPath?: string
+    stepOutputPath?: string
+    previewOutputDir?: string
+    generatePreviewAssets?: boolean
+  }>
+  projectDir: string
+  concurrency: number
+  buildOptions?: {
+    ignoreErrors?: boolean
+    ignoreWarnings?: boolean
+  } & DrcIgnoreOptions & {
+      platformConfig?: PlatformConfig
+      profile?: boolean
+      injectedProps?: Record<string, unknown>
+      generatePreviewAssets?: boolean
+      imageFormats?: BuildImageFormatSelection
+      pcbSnapshotSettings?: PcbSnapshotSettings
+    }
+  onLog?: (lines: string[]) => void
+  onJobComplete?: (result: BuildJobResult) => void
+  stopOnFatal?: boolean
+  workerJobTimeoutMs?: number
 }): Promise<BuildJobResult[]> {
-	const cancellationError = new Error("Build cancelled due fatal error");
-	const envWorkerTimeoutMs = Number.parseInt(
-		process.env.TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS || "",
-		10,
-	);
-	const workerJobTimeoutMs = Number.isFinite(envWorkerTimeoutMs)
-		? envWorkerTimeoutMs
-		: (options.workerJobTimeoutMs ?? 300000);
-	const poolConcurrency = Math.max(
-		1,
-		Math.min(options.concurrency, options.files.length),
-	);
+  const cancellationError = new Error("Build cancelled due fatal error")
+  const envWorkerTimeoutMs = Number.parseInt(
+    process.env.TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS || "",
+    10,
+  )
+  const workerJobTimeoutMs = Number.isFinite(envWorkerTimeoutMs)
+    ? envWorkerTimeoutMs
+    : (options.workerJobTimeoutMs ?? 300000)
+  const poolConcurrency = Math.max(
+    1,
+    Math.min(options.concurrency, options.files.length),
+  )
 
-	const pool = new ThreadWorkerPool<
-		BuildJob,
-		BuildFileMessage,
-		WorkerOutputMessage,
-		BuildJobResult
-	>({
-		concurrency: poolConcurrency,
-		workerEntrypointPath: getWorkerEntrypointPath(),
-		createMessage: (job) => ({
-			message_type: "build_file",
-			file_path: job.filePath,
-			output_path: job.outputPath,
-			glb_output_path: job.glbOutputPath,
-			step_output_path: job.stepOutputPath,
-			preview_output_dir: job.previewOutputDir,
-			project_dir: job.projectDir,
-			options: job.options,
-		}),
-		isLogMessage: (message) => message.message_type === "worker_log",
-		getLogLines: (message) =>
-			message.message_type === "worker_log" ? message.log_lines : [],
-		getStatusLine: (message) =>
-			message.message_type === "worker_log"
-				? (message.status_line ?? null)
-				: null,
-		isCompletionMessage: (message) =>
-			message.message_type === "build_completed",
-		getResult: (message) => {
-			const completedMessage = message as BuildCompletedMessage;
-			return {
-				filePath: completedMessage.file_path,
-				outputPath: completedMessage.output_path,
-				glbOutputPath: completedMessage.glb_output_path,
-				stepOutputPath: completedMessage.step_output_path,
-				previewOutputDir: completedMessage.preview_output_dir,
-				glbOk: completedMessage.glb_ok,
-				glbError: completedMessage.glb_error,
-				stepOk: completedMessage.step_ok,
-				stepError: completedMessage.step_error,
-				previewOk: completedMessage.preview_ok,
-				previewError: completedMessage.preview_error,
-				ok: completedMessage.ok,
-				hasErrors: completedMessage.hasErrors,
-				ignoredDrcCount: completedMessage.ignoredDrcCount,
-				ignoredDrcByCategory: completedMessage.ignoredDrcByCategory,
-				isFatalError: completedMessage.isFatalError,
-				errors: completedMessage.errors,
-				warnings: completedMessage.warnings,
-				durationMs: completedMessage.durationMs,
-			};
-		},
-		shouldStopOnMessage: (message) => {
-			if (!options.stopOnFatal || message.message_type !== "build_completed") {
-				return false;
-			}
-			return Boolean((message as BuildCompletedMessage).isFatalError);
-		},
-		cancellationError,
-		jobTimeoutMs:
-			Number.isFinite(workerJobTimeoutMs) && workerJobTimeoutMs > 0
-				? workerJobTimeoutMs
-				: undefined,
-		onLog: options.onLog,
-	});
+  const pool = new ThreadWorkerPool<
+    BuildJob,
+    BuildFileMessage,
+    WorkerOutputMessage,
+    BuildJobResult
+  >({
+    concurrency: poolConcurrency,
+    workerEntrypointPath: getWorkerEntrypointPath(),
+    createMessage: (job) => ({
+      message_type: "build_file",
+      file_path: job.filePath,
+      output_path: job.outputPath,
+      glb_output_path: job.glbOutputPath,
+      step_output_path: job.stepOutputPath,
+      preview_output_dir: job.previewOutputDir,
+      project_dir: job.projectDir,
+      options: job.options,
+    }),
+    isLogMessage: (message) => message.message_type === "worker_log",
+    getLogLines: (message) =>
+      message.message_type === "worker_log" ? message.log_lines : [],
+    getStatusLine: (message) =>
+      message.message_type === "worker_log"
+        ? (message.status_line ?? null)
+        : null,
+    isCompletionMessage: (message) =>
+      message.message_type === "build_completed",
+    getResult: (message) => {
+      const completedMessage = message as BuildCompletedMessage
+      return {
+        filePath: completedMessage.file_path,
+        outputPath: completedMessage.output_path,
+        glbOutputPath: completedMessage.glb_output_path,
+        stepOutputPath: completedMessage.step_output_path,
+        previewOutputDir: completedMessage.preview_output_dir,
+        glbOk: completedMessage.glb_ok,
+        glbError: completedMessage.glb_error,
+        stepOk: completedMessage.step_ok,
+        stepError: completedMessage.step_error,
+        previewOk: completedMessage.preview_ok,
+        previewError: completedMessage.preview_error,
+        ok: completedMessage.ok,
+        hasErrors: completedMessage.hasErrors,
+        ignoredDrcCount: completedMessage.ignoredDrcCount,
+        ignoredDrcByCategory: completedMessage.ignoredDrcByCategory,
+        isFatalError: completedMessage.isFatalError,
+        errors: completedMessage.errors,
+        warnings: completedMessage.warnings,
+        durationMs: completedMessage.durationMs,
+      }
+    },
+    shouldStopOnMessage: (message) => {
+      if (!options.stopOnFatal || message.message_type !== "build_completed") {
+        return false
+      }
+      return Boolean((message as BuildCompletedMessage).isFatalError)
+    },
+    cancellationError,
+    jobTimeoutMs:
+      Number.isFinite(workerJobTimeoutMs) && workerJobTimeoutMs > 0
+        ? workerJobTimeoutMs
+        : undefined,
+    onLog: options.onLog,
+  })
 
-	const results: BuildJobResult[] = [];
-	const promises: Promise<BuildJobResult>[] = [];
+  const results: BuildJobResult[] = []
+  const promises: Promise<BuildJobResult>[] = []
 
-	for (const file of options.files) {
-		const promise = pool
-			.queueJob({
-				filePath: file.filePath,
-				outputPath: file.outputPath,
-				glbOutputPath: file.glbOutputPath,
-				stepOutputPath: file.stepOutputPath,
-				previewOutputDir: file.previewOutputDir,
-				projectDir: options.projectDir,
-				options: {
-					...options.buildOptions,
-					generatePreviewAssets:
-						file.generatePreviewAssets ??
-						options.buildOptions?.generatePreviewAssets,
-				},
-			})
-			.then(async (result) => {
-				results.push(result);
-				if (options.onJobComplete) {
-					await options.onJobComplete(result);
-				}
+  for (const file of options.files) {
+    const promise = pool
+      .queueJob({
+        filePath: file.filePath,
+        outputPath: file.outputPath,
+        glbOutputPath: file.glbOutputPath,
+        stepOutputPath: file.stepOutputPath,
+        previewOutputDir: file.previewOutputDir,
+        projectDir: options.projectDir,
+        options: {
+          ...options.buildOptions,
+          generatePreviewAssets:
+            file.generatePreviewAssets ??
+            options.buildOptions?.generatePreviewAssets,
+        },
+      })
+      .then(async (result) => {
+        results.push(result)
+        if (options.onJobComplete) {
+          await options.onJobComplete(result)
+        }
 
-				return result;
-			});
+        return result
+      })
 
-		promises.push(promise);
-	}
+    promises.push(promise)
+  }
 
-	const settledResults = await Promise.allSettled(promises);
+  const settledResults = await Promise.allSettled(promises)
 
-	for (const settledResult of settledResults) {
-		if (
-			settledResult.status === "rejected" &&
-			settledResult.reason !== cancellationError
-		) {
-			throw settledResult.reason;
-		}
-	}
+  for (const settledResult of settledResults) {
+    if (
+      settledResult.status === "rejected" &&
+      settledResult.reason !== cancellationError
+    ) {
+      throw settledResult.reason
+    }
+  }
 
-	// NOTE: In some Bun runtimes, terminating worker threads here can cause the
-	// parent process to exit before post-build steps (site/preview/transpile)
-	// run. The CLI exits explicitly at the end of the build command, so on Bun
-	// we let process shutdown clean up workers.
-	if (typeof Bun === "undefined") {
-		await pool.terminate();
-	}
+  // NOTE: In some Bun runtimes, terminating worker threads here can cause the
+  // parent process to exit before post-build steps (site/preview/transpile)
+  // run. The CLI exits explicitly at the end of the build command, so on Bun
+  // we let process shutdown clean up workers.
+  if (typeof Bun === "undefined") {
+    await pool.terminate()
+  }
 
-	return results;
+  return results
 }

--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -14,7 +14,7 @@ function commandExists(cmd) {
   }
 }
 
-const runner = commandExists("bun") ? "bun" : "tsx"
+const runner = commandExists("bun") ? "bun" : commandExists("tsx") ? "tsx" : process.execPath
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const packageRoot = join(__dirname, "..")

--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -1,53 +1,57 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process"
-import { existsSync } from "node:fs"
-import { createRequire } from "node:module"
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 function commandExists(cmd) {
-  try {
-    const res = spawnSync(cmd, ["--version"], { stdio: "ignore" })
-    return res.status === 0
-  } catch {
-    return false
-  }
+	try {
+		const res = spawnSync(cmd, ["--version"], { stdio: "ignore" });
+		return res.status === 0;
+	} catch {
+		return false;
+	}
 }
 
-const runner = commandExists("bun") ? "bun" : commandExists("tsx") ? "tsx" : process.execPath
+const runner = commandExists("bun")
+	? "bun"
+	: commandExists("tsx")
+		? "tsx"
+		: process.execPath;
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const packageRoot = join(__dirname, "..")
-const require = createRequire(import.meta.url)
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(__dirname, "..");
+const require = createRequire(import.meta.url);
 
-const globalPackageJson = require("../package.json")
+const globalPackageJson = require("../package.json");
 
-const useGlobal = process.argv.includes("--use-global")
-const args = process.argv.slice(2).filter((arg) => arg !== "--use-global")
+const useGlobal = process.argv.includes("--use-global");
+const args = process.argv.slice(2).filter((arg) => arg !== "--use-global");
 
-let mainPath = join(packageRoot, "dist/cli/main.js")
+let mainPath = join(packageRoot, "dist/cli/main.js");
 
 if (!useGlobal) {
-  try {
-    const localRequire = createRequire(join(process.cwd(), "package.json"))
-    const localPackageJsonPath = localRequire.resolve(
-      "@tscircuit/cli/package.json",
-    )
-    const localPackageJson = localRequire(localPackageJsonPath)
-    const localPackageRoot = dirname(localPackageJsonPath)
-    const localMainPath = join(localPackageRoot, "dist/cli/main.js")
+	try {
+		const localRequire = createRequire(join(process.cwd(), "package.json"));
+		const localPackageJsonPath = localRequire.resolve(
+			"@tscircuit/cli/package.json",
+		);
+		const localPackageJson = localRequire(localPackageJsonPath);
+		const localPackageRoot = dirname(localPackageJsonPath);
+		const localMainPath = join(localPackageRoot, "dist/cli/main.js");
 
-    if (localPackageRoot !== packageRoot && existsSync(localMainPath)) {
-      console.warn(
-        `Using local @tscircuit/cli v${localPackageJson.version} instead of global v${globalPackageJson.version}`,
-      )
-      mainPath = localMainPath
-    }
-  } catch {}
+		if (localPackageRoot !== packageRoot && existsSync(localMainPath)) {
+			console.warn(
+				`Using local @tscircuit/cli v${localPackageJson.version} instead of global v${globalPackageJson.version}`,
+			);
+			mainPath = localMainPath;
+		}
+	} catch {}
 }
 
 const { status } = spawnSync(runner, [mainPath, ...args], {
-  stdio: "inherit",
-})
+	stdio: "inherit",
+});
 
-process.exit(status ?? 0)
+process.exit(status ?? 0);

--- a/cli/entrypoint.js
+++ b/cli/entrypoint.js
@@ -1,57 +1,57 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 
 function commandExists(cmd) {
-	try {
-		const res = spawnSync(cmd, ["--version"], { stdio: "ignore" });
-		return res.status === 0;
-	} catch {
-		return false;
-	}
+  try {
+    const res = spawnSync(cmd, ["--version"], { stdio: "ignore" })
+    return res.status === 0
+  } catch {
+    return false
+  }
 }
 
 const runner = commandExists("bun")
-	? "bun"
-	: commandExists("tsx")
-		? "tsx"
-		: process.execPath;
+  ? "bun"
+  : commandExists("tsx")
+    ? "tsx"
+    : process.execPath
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const packageRoot = join(__dirname, "..");
-const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const packageRoot = join(__dirname, "..")
+const require = createRequire(import.meta.url)
 
-const globalPackageJson = require("../package.json");
+const globalPackageJson = require("../package.json")
 
-const useGlobal = process.argv.includes("--use-global");
-const args = process.argv.slice(2).filter((arg) => arg !== "--use-global");
+const useGlobal = process.argv.includes("--use-global")
+const args = process.argv.slice(2).filter((arg) => arg !== "--use-global")
 
-let mainPath = join(packageRoot, "dist/cli/main.js");
+let mainPath = join(packageRoot, "dist/cli/main.js")
 
 if (!useGlobal) {
-	try {
-		const localRequire = createRequire(join(process.cwd(), "package.json"));
-		const localPackageJsonPath = localRequire.resolve(
-			"@tscircuit/cli/package.json",
-		);
-		const localPackageJson = localRequire(localPackageJsonPath);
-		const localPackageRoot = dirname(localPackageJsonPath);
-		const localMainPath = join(localPackageRoot, "dist/cli/main.js");
+  try {
+    const localRequire = createRequire(join(process.cwd(), "package.json"))
+    const localPackageJsonPath = localRequire.resolve(
+      "@tscircuit/cli/package.json",
+    )
+    const localPackageJson = localRequire(localPackageJsonPath)
+    const localPackageRoot = dirname(localPackageJsonPath)
+    const localMainPath = join(localPackageRoot, "dist/cli/main.js")
 
-		if (localPackageRoot !== packageRoot && existsSync(localMainPath)) {
-			console.warn(
-				`Using local @tscircuit/cli v${localPackageJson.version} instead of global v${globalPackageJson.version}`,
-			);
-			mainPath = localMainPath;
-		}
-	} catch {}
+    if (localPackageRoot !== packageRoot && existsSync(localMainPath)) {
+      console.warn(
+        `Using local @tscircuit/cli v${localPackageJson.version} instead of global v${globalPackageJson.version}`,
+      )
+      mainPath = localMainPath
+    }
+  } catch {}
 }
 
 const { status } = spawnSync(runner, [mainPath, ...args], {
-	stdio: "inherit",
-});
+  stdio: "inherit",
+})
 
-process.exit(status ?? 0);
+process.exit(status ?? 0)

--- a/cli/snapshot/worker-pool.ts
+++ b/cli/snapshot/worker-pool.ts
@@ -1,149 +1,147 @@
-import fs from "node:fs"
-import path from "node:path"
-import { dirname } from "node:path"
-import { fileURLToPath } from "node:url"
-
-// __metaDir is Bun-only; __metaDirname is Node 21.2+
-const __metaDir: string =
-  (import.meta as unknown as { dir?: string }).dir ??
-  __metaDirname ??
-  dirname(fileURLToPath(import.meta.url))
-import type { ProcessSnapshotFileOptions } from "lib/shared/process-snapshot-file"
-import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
+import fs from "node:fs";
+import path from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ProcessSnapshotFileOptions } from "lib/shared/process-snapshot-file";
+import { ThreadWorkerPool } from "lib/shared/thread-worker-pool";
 import type {
-  SnapshotCompletedMessage,
-  SnapshotFileMessage,
-  SnapshotJobResult,
-  WorkerOutputMessage,
-} from "./worker-types"
+	SnapshotCompletedMessage,
+	SnapshotFileMessage,
+	SnapshotJobResult,
+	WorkerOutputMessage,
+} from "./worker-types";
+
+// import.meta.dir is Bun-only; import.meta.dirname is Node >=21.2
+// Cast to include both so TypeScript doesn't complain about either property.
+type ImportMetaWithDir = { dir?: string; dirname?: string };
+const __metaDir: string =
+	(import.meta as unknown as ImportMetaWithDir).dir ??
+	(import.meta as unknown as ImportMetaWithDir).dirname ??
+	dirname(fileURLToPath(import.meta.url));
 
 type SnapshotJob = {
-  filePath: string
-  projectDir: string
-  snapshotsDirName?: string
-  options: Omit<
-    ProcessSnapshotFileOptions,
-    "file" | "projectDir" | "snapshotsDirName"
-  >
-}
+	filePath: string;
+	projectDir: string;
+	snapshotsDirName?: string;
+	options: Omit<
+		ProcessSnapshotFileOptions,
+		"file" | "projectDir" | "snapshotsDirName"
+	>;
+};
 
 const getWorkerEntrypointPath = (): string => {
-  const tsPath = path.join(__metaDir, "snapshot.worker.ts")
-  if (fs.existsSync(tsPath)) {
-    return tsPath
-  }
+	const tsPath = path.join(__metaDir, "snapshot.worker.ts");
+	if (fs.existsSync(tsPath)) {
+		return tsPath;
+	}
 
-  const jsBundledPath = path.join(
-    __metaDir,
-    "snapshot",
-    "snapshot.worker.js",
-  )
-  if (fs.existsSync(jsBundledPath)) {
-    return jsBundledPath
-  }
+	const jsBundledPath = path.join(__metaDir, "snapshot", "snapshot.worker.js");
+	if (fs.existsSync(jsBundledPath)) {
+		return jsBundledPath;
+	}
 
-  return path.join(__metaDir, "snapshot.worker.js")
-}
+	return path.join(__metaDir, "snapshot.worker.js");
+};
 
 export const snapshotFilesWithWorkerPool = async (options: {
-  files: string[]
-  projectDir: string
-  snapshotsDirName?: string
-  concurrency: number
-  snapshotOptions: Omit<
-    ProcessSnapshotFileOptions,
-    "file" | "projectDir" | "snapshotsDirName"
-  >
-  onLog?: (lines: string[]) => void
-  onJobComplete?: (result: SnapshotJobResult) => void | Promise<void>
-  stopOnFailure?: boolean
+	files: string[];
+	projectDir: string;
+	snapshotsDirName?: string;
+	concurrency: number;
+	snapshotOptions: Omit<
+		ProcessSnapshotFileOptions,
+		"file" | "projectDir" | "snapshotsDirName"
+	>;
+	onLog?: (lines: string[]) => void;
+	onJobComplete?: (result: SnapshotJobResult) => void | Promise<void>;
+	stopOnFailure?: boolean;
 }): Promise<SnapshotJobResult[]> => {
-  const cancellationError = new Error("Snapshot cancelled due to file failure")
-  const poolConcurrency = Math.max(
-    1,
-    Math.min(options.concurrency, options.files.length),
-  )
+	const cancellationError = new Error("Snapshot cancelled due to file failure");
+	const poolConcurrency = Math.max(
+		1,
+		Math.min(options.concurrency, options.files.length),
+	);
 
-  const pool = new ThreadWorkerPool<
-    SnapshotJob,
-    SnapshotFileMessage,
-    WorkerOutputMessage,
-    SnapshotJobResult
-  >({
-    concurrency: poolConcurrency,
-    workerEntrypointPath: getWorkerEntrypointPath(),
-    createMessage: (job) => ({
-      message_type: "snapshot_file",
-      file_path: job.filePath,
-      project_dir: job.projectDir,
-      snapshots_dir_name: job.snapshotsDirName,
-      options: {
-        update: job.options.update,
-        threeD: job.options.threeD,
-        pcbOnly: job.options.pcbOnly,
-        schematicOnly: job.options.schematicOnly,
-        forceUpdate: job.options.forceUpdate,
-        platformConfig: job.options.platformConfig,
-        pcbSnapshotSettings: job.options.pcbSnapshotSettings,
-        createDiff: job.options.createDiff,
-        cameraPreset: job.options.cameraPreset,
-      },
-    }),
-    isLogMessage: (message) => message.message_type === "worker_log",
-    getLogLines: (message) =>
-      message.message_type === "worker_log" ? message.log_lines : [],
-    isCompletionMessage: (message) =>
-      message.message_type === "snapshot_completed",
-    getResult: (message) => {
-      const completedMessage = message as SnapshotCompletedMessage
-      return {
-        filePath: completedMessage.file_path,
-        result: completedMessage.result,
-      }
-    },
-    shouldStopOnMessage: (message) => {
-      if (
-        !options.stopOnFailure ||
-        message.message_type !== "snapshot_completed"
-      ) {
-        return false
-      }
-      return !(message as SnapshotCompletedMessage).result.ok
-    },
-    cancellationError,
-    onLog: options.onLog,
-  })
+	const pool = new ThreadWorkerPool<
+		SnapshotJob,
+		SnapshotFileMessage,
+		WorkerOutputMessage,
+		SnapshotJobResult
+	>({
+		concurrency: poolConcurrency,
+		workerEntrypointPath: getWorkerEntrypointPath(),
+		createMessage: (job) => ({
+			message_type: "snapshot_file",
+			file_path: job.filePath,
+			project_dir: job.projectDir,
+			snapshots_dir_name: job.snapshotsDirName,
+			options: {
+				update: job.options.update,
+				threeD: job.options.threeD,
+				pcbOnly: job.options.pcbOnly,
+				schematicOnly: job.options.schematicOnly,
+				forceUpdate: job.options.forceUpdate,
+				platformConfig: job.options.platformConfig,
+				pcbSnapshotSettings: job.options.pcbSnapshotSettings,
+				createDiff: job.options.createDiff,
+				cameraPreset: job.options.cameraPreset,
+			},
+		}),
+		isLogMessage: (message) => message.message_type === "worker_log",
+		getLogLines: (message) =>
+			message.message_type === "worker_log" ? message.log_lines : [],
+		isCompletionMessage: (message) =>
+			message.message_type === "snapshot_completed",
+		getResult: (message) => {
+			const completedMessage = message as SnapshotCompletedMessage;
+			return {
+				filePath: completedMessage.file_path,
+				result: completedMessage.result,
+			};
+		},
+		shouldStopOnMessage: (message) => {
+			if (
+				!options.stopOnFailure ||
+				message.message_type !== "snapshot_completed"
+			) {
+				return false;
+			}
+			return !(message as SnapshotCompletedMessage).result.ok;
+		},
+		cancellationError,
+		onLog: options.onLog,
+	});
 
-  const results: SnapshotJobResult[] = []
-  const jobs = options.files.map((filePath) =>
-    pool
-      .queueJob({
-        filePath,
-        projectDir: options.projectDir,
-        snapshotsDirName: options.snapshotsDirName,
-        options: options.snapshotOptions,
-      })
-      .then(async (result) => {
-        results.push(result)
-        await options.onJobComplete?.(result)
-        return result
-      }),
-  )
+	const results: SnapshotJobResult[] = [];
+	const jobs = options.files.map((filePath) =>
+		pool
+			.queueJob({
+				filePath,
+				projectDir: options.projectDir,
+				snapshotsDirName: options.snapshotsDirName,
+				options: options.snapshotOptions,
+			})
+			.then(async (result) => {
+				results.push(result);
+				await options.onJobComplete?.(result);
+				return result;
+			}),
+	);
 
-  const settledResults = await Promise.allSettled(jobs)
+	const settledResults = await Promise.allSettled(jobs);
 
-  for (const settledResult of settledResults) {
-    if (
-      settledResult.status === "rejected" &&
-      settledResult.reason !== cancellationError
-    ) {
-      throw settledResult.reason
-    }
-  }
+	for (const settledResult of settledResults) {
+		if (
+			settledResult.status === "rejected" &&
+			settledResult.reason !== cancellationError
+		) {
+			throw settledResult.reason;
+		}
+	}
 
-  if (typeof Bun === "undefined") {
-    await pool.terminate()
-  }
+	if (typeof Bun === "undefined") {
+		await pool.terminate();
+	}
 
-  return results
-}
+	return results;
+};

--- a/cli/snapshot/worker-pool.ts
+++ b/cli/snapshot/worker-pool.ts
@@ -35,11 +35,7 @@ const getWorkerEntrypointPath = (): string => {
     return tsPath
   }
 
-  const jsBundledPath = path.join(
-    __metaDir,
-    "snapshot",
-    "snapshot.worker.js",
-  )
+  const jsBundledPath = path.join(__metaDir, "snapshot", "snapshot.worker.js")
   if (fs.existsSync(jsBundledPath)) {
     return jsBundledPath
   }

--- a/cli/snapshot/worker-pool.ts
+++ b/cli/snapshot/worker-pool.ts
@@ -1,5 +1,13 @@
 import fs from "node:fs"
 import path from "node:path"
+import { dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+// __metaDir is Bun-only; __metaDirname is Node 21.2+
+const __metaDir: string =
+  (import.meta as unknown as { dir?: string }).dir ??
+  __metaDirname ??
+  dirname(fileURLToPath(import.meta.url))
 import type { ProcessSnapshotFileOptions } from "lib/shared/process-snapshot-file"
 import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
 import type {
@@ -20,13 +28,13 @@ type SnapshotJob = {
 }
 
 const getWorkerEntrypointPath = (): string => {
-  const tsPath = path.join(import.meta.dir, "snapshot.worker.ts")
+  const tsPath = path.join(__metaDir, "snapshot.worker.ts")
   if (fs.existsSync(tsPath)) {
     return tsPath
   }
 
   const jsBundledPath = path.join(
-    import.meta.dir,
+    __metaDir,
     "snapshot",
     "snapshot.worker.js",
   )
@@ -34,7 +42,7 @@ const getWorkerEntrypointPath = (): string => {
     return jsBundledPath
   }
 
-  return path.join(import.meta.dir, "snapshot.worker.js")
+  return path.join(__metaDir, "snapshot.worker.js")
 }
 
 export const snapshotFilesWithWorkerPool = async (options: {

--- a/cli/snapshot/worker-pool.ts
+++ b/cli/snapshot/worker-pool.ts
@@ -1,147 +1,151 @@
-import fs from "node:fs";
-import path from "node:path";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import type { ProcessSnapshotFileOptions } from "lib/shared/process-snapshot-file";
-import { ThreadWorkerPool } from "lib/shared/thread-worker-pool";
+import fs from "node:fs"
+import path from "node:path"
+import { dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { ProcessSnapshotFileOptions } from "lib/shared/process-snapshot-file"
+import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
 import type {
-	SnapshotCompletedMessage,
-	SnapshotFileMessage,
-	SnapshotJobResult,
-	WorkerOutputMessage,
-} from "./worker-types";
-
-// import.meta.dir is Bun-only; import.meta.dirname is Node >=21.2
-// Cast to include both so TypeScript doesn't complain about either property.
-type ImportMetaWithDir = { dir?: string; dirname?: string };
-const __metaDir: string =
-	(import.meta as unknown as ImportMetaWithDir).dir ??
-	(import.meta as unknown as ImportMetaWithDir).dirname ??
-	dirname(fileURLToPath(import.meta.url));
+  SnapshotCompletedMessage,
+  SnapshotFileMessage,
+  SnapshotJobResult,
+  WorkerOutputMessage,
+} from "./worker-types"
 
 type SnapshotJob = {
-	filePath: string;
-	projectDir: string;
-	snapshotsDirName?: string;
-	options: Omit<
-		ProcessSnapshotFileOptions,
-		"file" | "projectDir" | "snapshotsDirName"
-	>;
-};
+  filePath: string
+  projectDir: string
+  snapshotsDirName?: string
+  options: Omit<
+    ProcessSnapshotFileOptions,
+    "file" | "projectDir" | "snapshotsDirName"
+  >
+}
+
+// import.meta.dir is Bun-only; import.meta.dirname is Node >=21.2
+// Cast to include both so TypeScript does not complain about either.
+type ImportMetaWithDir = { dir?: string; dirname?: string }
+const __metaDir: string =
+  (import.meta as unknown as ImportMetaWithDir).dir ??
+  (import.meta as unknown as ImportMetaWithDir).dirname ??
+  dirname(fileURLToPath(import.meta.url))
 
 const getWorkerEntrypointPath = (): string => {
-	const tsPath = path.join(__metaDir, "snapshot.worker.ts");
-	if (fs.existsSync(tsPath)) {
-		return tsPath;
-	}
+  const tsPath = path.join(__metaDir, "snapshot.worker.ts")
+  if (fs.existsSync(tsPath)) {
+    return tsPath
+  }
 
-	const jsBundledPath = path.join(__metaDir, "snapshot", "snapshot.worker.js");
-	if (fs.existsSync(jsBundledPath)) {
-		return jsBundledPath;
-	}
+  const jsBundledPath = path.join(
+    __metaDir,
+    "snapshot",
+    "snapshot.worker.js",
+  )
+  if (fs.existsSync(jsBundledPath)) {
+    return jsBundledPath
+  }
 
-	return path.join(__metaDir, "snapshot.worker.js");
-};
+  return path.join(__metaDir, "snapshot.worker.js")
+}
 
 export const snapshotFilesWithWorkerPool = async (options: {
-	files: string[];
-	projectDir: string;
-	snapshotsDirName?: string;
-	concurrency: number;
-	snapshotOptions: Omit<
-		ProcessSnapshotFileOptions,
-		"file" | "projectDir" | "snapshotsDirName"
-	>;
-	onLog?: (lines: string[]) => void;
-	onJobComplete?: (result: SnapshotJobResult) => void | Promise<void>;
-	stopOnFailure?: boolean;
+  files: string[]
+  projectDir: string
+  snapshotsDirName?: string
+  concurrency: number
+  snapshotOptions: Omit<
+    ProcessSnapshotFileOptions,
+    "file" | "projectDir" | "snapshotsDirName"
+  >
+  onLog?: (lines: string[]) => void
+  onJobComplete?: (result: SnapshotJobResult) => void | Promise<void>
+  stopOnFailure?: boolean
 }): Promise<SnapshotJobResult[]> => {
-	const cancellationError = new Error("Snapshot cancelled due to file failure");
-	const poolConcurrency = Math.max(
-		1,
-		Math.min(options.concurrency, options.files.length),
-	);
+  const cancellationError = new Error("Snapshot cancelled due to file failure")
+  const poolConcurrency = Math.max(
+    1,
+    Math.min(options.concurrency, options.files.length),
+  )
 
-	const pool = new ThreadWorkerPool<
-		SnapshotJob,
-		SnapshotFileMessage,
-		WorkerOutputMessage,
-		SnapshotJobResult
-	>({
-		concurrency: poolConcurrency,
-		workerEntrypointPath: getWorkerEntrypointPath(),
-		createMessage: (job) => ({
-			message_type: "snapshot_file",
-			file_path: job.filePath,
-			project_dir: job.projectDir,
-			snapshots_dir_name: job.snapshotsDirName,
-			options: {
-				update: job.options.update,
-				threeD: job.options.threeD,
-				pcbOnly: job.options.pcbOnly,
-				schematicOnly: job.options.schematicOnly,
-				forceUpdate: job.options.forceUpdate,
-				platformConfig: job.options.platformConfig,
-				pcbSnapshotSettings: job.options.pcbSnapshotSettings,
-				createDiff: job.options.createDiff,
-				cameraPreset: job.options.cameraPreset,
-			},
-		}),
-		isLogMessage: (message) => message.message_type === "worker_log",
-		getLogLines: (message) =>
-			message.message_type === "worker_log" ? message.log_lines : [],
-		isCompletionMessage: (message) =>
-			message.message_type === "snapshot_completed",
-		getResult: (message) => {
-			const completedMessage = message as SnapshotCompletedMessage;
-			return {
-				filePath: completedMessage.file_path,
-				result: completedMessage.result,
-			};
-		},
-		shouldStopOnMessage: (message) => {
-			if (
-				!options.stopOnFailure ||
-				message.message_type !== "snapshot_completed"
-			) {
-				return false;
-			}
-			return !(message as SnapshotCompletedMessage).result.ok;
-		},
-		cancellationError,
-		onLog: options.onLog,
-	});
+  const pool = new ThreadWorkerPool<
+    SnapshotJob,
+    SnapshotFileMessage,
+    WorkerOutputMessage,
+    SnapshotJobResult
+  >({
+    concurrency: poolConcurrency,
+    workerEntrypointPath: getWorkerEntrypointPath(),
+    createMessage: (job) => ({
+      message_type: "snapshot_file",
+      file_path: job.filePath,
+      project_dir: job.projectDir,
+      snapshots_dir_name: job.snapshotsDirName,
+      options: {
+        update: job.options.update,
+        threeD: job.options.threeD,
+        pcbOnly: job.options.pcbOnly,
+        schematicOnly: job.options.schematicOnly,
+        forceUpdate: job.options.forceUpdate,
+        platformConfig: job.options.platformConfig,
+        pcbSnapshotSettings: job.options.pcbSnapshotSettings,
+        createDiff: job.options.createDiff,
+        cameraPreset: job.options.cameraPreset,
+      },
+    }),
+    isLogMessage: (message) => message.message_type === "worker_log",
+    getLogLines: (message) =>
+      message.message_type === "worker_log" ? message.log_lines : [],
+    isCompletionMessage: (message) =>
+      message.message_type === "snapshot_completed",
+    getResult: (message) => {
+      const completedMessage = message as SnapshotCompletedMessage
+      return {
+        filePath: completedMessage.file_path,
+        result: completedMessage.result,
+      }
+    },
+    shouldStopOnMessage: (message) => {
+      if (
+        !options.stopOnFailure ||
+        message.message_type !== "snapshot_completed"
+      ) {
+        return false
+      }
+      return !(message as SnapshotCompletedMessage).result.ok
+    },
+    cancellationError,
+    onLog: options.onLog,
+  })
 
-	const results: SnapshotJobResult[] = [];
-	const jobs = options.files.map((filePath) =>
-		pool
-			.queueJob({
-				filePath,
-				projectDir: options.projectDir,
-				snapshotsDirName: options.snapshotsDirName,
-				options: options.snapshotOptions,
-			})
-			.then(async (result) => {
-				results.push(result);
-				await options.onJobComplete?.(result);
-				return result;
-			}),
-	);
+  const results: SnapshotJobResult[] = []
+  const jobs = options.files.map((filePath) =>
+    pool
+      .queueJob({
+        filePath,
+        projectDir: options.projectDir,
+        snapshotsDirName: options.snapshotsDirName,
+        options: options.snapshotOptions,
+      })
+      .then(async (result) => {
+        results.push(result)
+        await options.onJobComplete?.(result)
+        return result
+      }),
+  )
 
-	const settledResults = await Promise.allSettled(jobs);
+  const settledResults = await Promise.allSettled(jobs)
 
-	for (const settledResult of settledResults) {
-		if (
-			settledResult.status === "rejected" &&
-			settledResult.reason !== cancellationError
-		) {
-			throw settledResult.reason;
-		}
-	}
+  for (const settledResult of settledResults) {
+    if (
+      settledResult.status === "rejected" &&
+      settledResult.reason !== cancellationError
+    ) {
+      throw settledResult.reason
+    }
+  }
 
-	if (typeof Bun === "undefined") {
-		await pool.terminate();
-	}
+  if (typeof Bun === "undefined") {
+    await pool.terminate()
+  }
 
-	return results;
-};
+  return results
+}


### PR DESCRIPTION
## Problem

Three separate issues cause `tsci dev` (and `build`/`snapshot`) to fail hard on Node-only systems:

### 1. `cli/entrypoint.js` — no fallback beyond `tsx`

```js
const runner = commandExists("bun") ? "bun" : "tsx"
```

If neither `bun` nor `tsx` is installed the spawned process fails. `tsx` isn't a guaranteed dependency on every dev machine, and it shouldn't be a hard requirement just to run compiled JS.

### 2 & 3. `cli/build/worker-pool.ts` and `cli/snapshot/worker-pool.ts` — `import.meta.dir` is Bun-only

```ts
path.join(import.meta.dir, "build.worker.ts")
```

`import.meta.dir` is a Bun extension; it is `undefined` in Node, causing `path.join` to throw once the worker entrypoint path is resolved.

## Fix

**`entrypoint.js`:** chain a final `process.execPath` fallback so the current Node binary is always available:
```js
const runner = commandExists("bun") ? "bun" : commandExists("tsx") ? "tsx" : process.execPath
```

**`worker-pool.ts` (both):** add a one-time cross-runtime `__metaDir` shim at the top of each file, then replace all `import.meta.dir` usages:
```ts
const __metaDir: string =
  (import.meta as unknown as { dir?: string }).dir ?? // Bun
  import.meta.dirname ??                              // Node >=21.2
  dirname(fileURLToPath(import.meta.url))             // Node <21.2
```

## Tested

Verified `tsci dev` starts and serves the preview on a system with Node 24 and **no Bun installed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)