### PR TITLE
Add runtime tscircuit config loader support

### DIFF
--- a/cli/config/set/register.ts
+++ b/cli/config/set/register.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander"
 import { type CliConfig, cliConfig } from "lib/cli-config"
 import {
-  loadProjectConfig,
+  loadProjectConfigSync,
   saveProjectConfig,
   CONFIG_FILENAME,
   type TscircuitProjectConfig,
@@ -55,7 +55,7 @@ export const registerConfigSet = (program: Command) => {
           key === "prebuildCommand" ||
           key === "buildCommand"
         ) {
-          const projectConfig = loadProjectConfig(projectDir) ?? {}
+          const projectConfig = loadProjectConfigSync(projectDir) ?? {}
           projectConfig[key] = value
           if (saveProjectConfig(projectConfig, projectDir)) {
             console.log(

--- a/lib/project-config/index.ts
+++ b/lib/project-config/index.ts
@@ -1,5 +1,7 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
+import { pathToFileURL } from "node:url"
+import type { PlatformConfig } from "@tscircuit/props"
 import {
   projectConfigSchema,
   type TscircuitProjectConfig,
@@ -7,11 +9,20 @@ import {
 
 export type { TscircuitProjectConfig }
 
-export const defineConfig = (config: TscircuitProjectConfig) => {
+export type TscircuitRuntimeProjectConfig = TscircuitProjectConfig & {
+  platformConfig?: PlatformConfig
+}
+
+export const defineConfig = (config: TscircuitRuntimeProjectConfig) => {
   return config
 }
 
 export const CONFIG_FILENAME = "tscircuit.config.json"
+const CONFIG_MODULE_FILENAMES = [
+  "tscircuit.config.ts",
+  "tscircuit.config.js",
+] as const
+const ENV_FILENAMES = [".env", ".env.local"] as const
 export const CONFIG_SCHEMA_URL =
   "https://cdn.jsdelivr.net/npm/@tscircuit/cli/types/tscircuit.config.schema.json"
 
@@ -21,10 +32,74 @@ export const DEFAULT_BOARD_FILE_PATTERNS = [
   "**/*.circuit.json",
 ]
 
+const parseProjectConfigObject = (
+  config: unknown,
+): TscircuitRuntimeProjectConfig => {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new Error("tscircuit config must export an object")
+  }
+
+  const { platformConfig, ...serializableConfig } = config as Record<
+    string,
+    unknown
+  >
+
+  const parsedConfig = projectConfigSchema.parse(serializableConfig)
+
+  if (platformConfig === undefined) {
+    return parsedConfig
+  }
+
+  return {
+    ...parsedConfig,
+    platformConfig: platformConfig as PlatformConfig,
+  }
+}
+
+const stripWrappingQuotes = (value: string) => {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1)
+  }
+
+  return value
+}
+
+const loadProjectEnv = (projectDir: string) => {
+  const initialEnvKeys = new Set(Object.keys(process.env))
+
+  for (const envFileName of ENV_FILENAMES) {
+    const envPath = path.join(projectDir, envFileName)
+    if (!fs.existsSync(envPath)) continue
+
+    const envContent = fs.readFileSync(envPath, "utf8")
+    for (const rawLine of envContent.split(/\r?\n/)) {
+      const line = rawLine.trim()
+      if (!line || line.startsWith("#")) continue
+
+      const lineWithoutExport = line.startsWith("export ")
+        ? line.slice("export ".length)
+        : line
+      const separatorIndex = lineWithoutExport.indexOf("=")
+      if (separatorIndex <= 0) continue
+
+      const key = lineWithoutExport.slice(0, separatorIndex).trim()
+      if (!key || initialEnvKeys.has(key)) continue
+
+      const value = stripWrappingQuotes(
+        lineWithoutExport.slice(separatorIndex + 1).trim(),
+      )
+      process.env[key] = value
+    }
+  }
+}
+
 /**
  * Load the tscircuit project configuration from the file system
  */
-export const loadProjectConfig = (
+export const loadProjectConfigSync = (
   projectDir: string = process.cwd(),
 ): TscircuitProjectConfig | null => {
   const configPath = path.join(projectDir, CONFIG_FILENAME)
@@ -43,10 +118,60 @@ export const loadProjectConfig = (
   }
 }
 
+const loadProjectConfigModule = async (
+  projectDir: string,
+): Promise<TscircuitRuntimeProjectConfig | null> => {
+  loadProjectEnv(projectDir)
+
+  for (const configFileName of CONFIG_MODULE_FILENAMES) {
+    const configPath = path.join(projectDir, configFileName)
+    if (!fs.existsSync(configPath)) continue
+
+    try {
+      const moduleUrl = pathToFileURL(configPath)
+      const stat = fs.statSync(configPath)
+      moduleUrl.searchParams.set("tsci", String(stat.mtimeMs))
+      const importedModule = await import(moduleUrl.href)
+      const exportedConfig =
+        importedModule.default ?? importedModule.config ?? importedModule
+      return parseProjectConfigObject(exportedConfig)
+    } catch (error) {
+      console.error(`Error loading ${configFileName}: ${error}`)
+      return null
+    }
+  }
+
+  return null
+}
+
+export const loadProjectConfig = async (
+  projectDir: string = process.cwd(),
+): Promise<TscircuitRuntimeProjectConfig | null> => {
+  const jsonConfig = loadProjectConfigSync(projectDir)
+  const moduleConfig = await loadProjectConfigModule(projectDir)
+
+  if (!jsonConfig && !moduleConfig) {
+    return null
+  }
+
+  return {
+    ...(jsonConfig ?? {}),
+    ...(moduleConfig ?? {}),
+    build: {
+      ...jsonConfig?.build,
+      ...moduleConfig?.build,
+    },
+    pcbSnapshotSettings: {
+      ...jsonConfig?.pcbSnapshotSettings,
+      ...moduleConfig?.pcbSnapshotSettings,
+    },
+  }
+}
+
 export const getBoardFilePatterns = (
   projectDir: string = process.cwd(),
 ): string[] => {
-  const config = loadProjectConfig(projectDir)
+  const config = loadProjectConfigSync(projectDir)
   const patterns = config?.includeBoardFiles?.filter((pattern) =>
     pattern.trim(),
   )
@@ -64,7 +189,7 @@ export const getBoardFilePatterns = (
 export const getSnapshotsDir = (
   projectDir: string = process.cwd(),
 ): string | undefined => {
-  const config = loadProjectConfig(projectDir)
+  const config = loadProjectConfigSync(projectDir)
   return config?.snapshotsDir
 }
 

--- a/lib/project-config/index.ts
+++ b/lib/project-config/index.ts
@@ -144,7 +144,7 @@ const loadProjectConfigModule = async (
   return null
 }
 
-export const loadProjectConfig = async (
+export const loadRuntimeProjectConfig = async (
   projectDir: string = process.cwd(),
 ): Promise<TscircuitRuntimeProjectConfig | null> => {
   const jsonConfig = loadProjectConfigSync(projectDir)
@@ -166,6 +166,12 @@ export const loadProjectConfig = async (
       ...moduleConfig?.pcbSnapshotSettings,
     },
   }
+}
+
+export const loadProjectConfig = (
+  projectDir: string = process.cwd(),
+): TscircuitProjectConfig | null => {
+  return loadProjectConfigSync(projectDir)
 }
 
 export const getBoardFilePatterns = (

--- a/lib/shared/get-entrypoint.ts
+++ b/lib/shared/get-entrypoint.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { loadProjectConfig } from "lib/project-config"
+import { loadRuntimeProjectConfig } from "lib/project-config"
 import kleur from "kleur"
 
 type EntrypointOptions = {
@@ -128,7 +128,7 @@ export const getEntrypoint = async ({
       return null
     }
 
-    const projectConfig = await loadProjectConfig(validatedProjectDir)
+    const projectConfig = await loadRuntimeProjectConfig(validatedProjectDir)
     const configEntrypoint =
       projectConfig?.mainEntrypoint ?? projectConfig?.libraryEntrypoint
     if (configEntrypoint && typeof configEntrypoint === "string") {

--- a/lib/shared/get-entrypoint.ts
+++ b/lib/shared/get-entrypoint.ts
@@ -128,7 +128,7 @@ export const getEntrypoint = async ({
       return null
     }
 
-    const projectConfig = loadProjectConfig(validatedProjectDir)
+    const projectConfig = await loadProjectConfig(validatedProjectDir)
     const configEntrypoint =
       projectConfig?.mainEntrypoint ?? projectConfig?.libraryEntrypoint
     if (configEntrypoint && typeof configEntrypoint === "string") {
@@ -141,9 +141,7 @@ export const getEntrypoint = async ({
           validatedProjectDir,
           validatedConfigPath,
         )
-        onSuccess(
-          `Using entrypoint from tscircuit.config.json: '${relativePath}'`,
-        )
+        onSuccess(`Using entrypoint from tscircuit config: '${relativePath}'`)
         return validatedConfigPath
       }
     }

--- a/tests/lib/get-entrypoint-config-module.test.ts
+++ b/tests/lib/get-entrypoint-config-module.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import * as fs from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../fixtures/get-cli-test-fixture"
+import { getEntrypoint } from "../../lib/shared/get-entrypoint"
+
+test("getEntrypoint detects entrypoint from tscircuit.config.ts", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  await fs.mkdir(path.join(tmpDir, "src"), { recursive: true })
+  await fs.writeFile(
+    path.join(tmpDir, "src", "main.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "tscircuit.config.ts"),
+    [
+      "export default {",
+      '  mainEntrypoint: "src/main.circuit.tsx",',
+      "}",
+      "",
+    ].join("\n"),
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).toBe(path.join(tmpDir, "src", "main.circuit.tsx"))
+})

--- a/tests/lib/project-config.test.ts
+++ b/tests/lib/project-config.test.ts
@@ -2,7 +2,7 @@ import { afterEach, expect, test } from "bun:test"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { temporaryDirectory } from "tempy"
-import { loadProjectConfig } from "lib/project-config"
+import { loadRuntimeProjectConfig } from "lib/project-config"
 
 const tempDirs: string[] = []
 const ENV_KEYS = ["TEST_TI_PARTNER_TOKEN", "TEST_TI_FLAG"] as const
@@ -36,7 +36,7 @@ test("loadProjectConfig loads tscircuit.config.ts and project .env values", asyn
     ].join("\n"),
   )
 
-  const config = await loadProjectConfig(tmpDir)
+  const config = await loadRuntimeProjectConfig(tmpDir)
 
   expect(config?.mainEntrypoint).toBe("src/main.circuit.tsx")
   expect(config?.platformConfig?.partsEngineDisabled).toBeTrue()
@@ -71,7 +71,7 @@ test("loadProjectConfig merges json config with module config", async () => {
     ].join("\n"),
   )
 
-  const config = await loadProjectConfig(tmpDir)
+  const config = await loadRuntimeProjectConfig(tmpDir)
 
   expect(config?.mainEntrypoint).toBe("src/index.circuit.tsx")
   expect(config?.previewComponentPath).toBe("src/preview.tsx")

--- a/tests/lib/project-config.test.ts
+++ b/tests/lib/project-config.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, expect, test } from "bun:test"
+import { mkdir, rm, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { temporaryDirectory } from "tempy"
+import { loadProjectConfig } from "lib/project-config"
+
+const tempDirs: string[] = []
+const ENV_KEYS = ["TEST_TI_PARTNER_TOKEN", "TEST_TI_FLAG"] as const
+
+afterEach(async () => {
+  for (const envKey of ENV_KEYS) {
+    delete process.env[envKey]
+  }
+
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+test("loadProjectConfig loads tscircuit.config.ts and project .env values", async () => {
+  const tmpDir = temporaryDirectory()
+  tempDirs.push(tmpDir)
+
+  await mkdir(path.join(tmpDir, "src"), { recursive: true })
+  await writeFile(path.join(tmpDir, ".env"), "TEST_TI_PARTNER_TOKEN=from-env\n")
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.ts"),
+    [
+      "export default {",
+      '  mainEntrypoint: "src/main.circuit.tsx",',
+      "  platformConfig: {",
+      '    partsEngineDisabled: process.env.TEST_TI_PARTNER_TOKEN === "from-env",',
+      "  },",
+      "}",
+      "",
+    ].join("\n"),
+  )
+
+  const config = await loadProjectConfig(tmpDir)
+
+  expect(config?.mainEntrypoint).toBe("src/main.circuit.tsx")
+  expect(config?.platformConfig?.partsEngineDisabled).toBeTrue()
+  expect(process.env.TEST_TI_PARTNER_TOKEN).toBe("from-env")
+})
+
+test("loadProjectConfig merges json config with module config", async () => {
+  const tmpDir = temporaryDirectory()
+  tempDirs.push(tmpDir)
+
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.json"),
+    JSON.stringify({
+      previewComponentPath: "src/preview.tsx",
+      build: { kicadLibrary: true },
+      pcbSnapshotSettings: { showPcbNotes: true },
+    }),
+  )
+  await writeFile(
+    path.join(tmpDir, "tscircuit.config.ts"),
+    [
+      "export default {",
+      '  mainEntrypoint: "src/index.circuit.tsx",',
+      "  build: {",
+      "    previewImages: true,",
+      "  },",
+      "  pcbSnapshotSettings: {",
+      "    showCourtyards: true,",
+      "  },",
+      "}",
+      "",
+    ].join("\n"),
+  )
+
+  const config = await loadProjectConfig(tmpDir)
+
+  expect(config?.mainEntrypoint).toBe("src/index.circuit.tsx")
+  expect(config?.previewComponentPath).toBe("src/preview.tsx")
+  expect(config?.build).toEqual({
+    kicadLibrary: true,
+    previewImages: true,
+  })
+  expect(config?.pcbSnapshotSettings).toEqual({
+    showPcbNotes: true,
+    showCourtyards: true,
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds runtime config module support to the CLI so projects can define configuration in:

- `tscircuit.config.ts`
- `tscircuit.config.js`

The loader now also:

- keeps existing `tscircuit.config.json` support
- merges JSON config with module config when both exist
- loads `.env` and `.env.local` before importing the config module
- preserves `platformConfig` as a runtime-only field outside the JSON schema

This is the first, narrow step toward supporting custom parts/platform behavior through project configuration.

## Why

The current CLI config flow is centered around `tscircuit.config.json`, which only supports serializable JSON values.

For custom runtime behavior, that is not enough. A project may need to provide config that depends on:

- functions
- imported helpers
- environment variables such as `PARTNER_TOKEN`
