### PR TITLE
Install codex skill to .agents/skills

### DIFF
--- a/lib/shared/setup-tscircuit-skill.ts
+++ b/lib/shared/setup-tscircuit-skill.ts
@@ -14,7 +14,7 @@ const SKILL_REPO_API_URL =
   "https://api.github.com/repos/tscircuit/skill/contents"
 const SKILL_INSTALL_PATHS = [
   ".claude/skills/tscircuit",
-  ".codex/skills/tscircuit",
+  ".agents/skills/tscircuit",
 ]
 
 async function fetchGitHubContents(apiUrl: string): Promise<GitHubContent[]> {

--- a/tests/cli/init/init-no-install.test.ts
+++ b/tests/cli/init/init-no-install.test.ts
@@ -38,7 +38,7 @@ test("init installs tscircuit skills for both Claude and Codex", async () => {
     join(tmpDir, projectDir, ".claude/skills/tscircuit/SKILL.md"),
   ).exists()
   const codexSkillExists = await Bun.file(
-    join(tmpDir, projectDir, ".codex/skills/tscircuit/SKILL.md"),
+    join(tmpDir, projectDir, ".agents/skills/tscircuit/SKILL.md"),
   ).exists()
 
   expect(claudeSkillExists).toBeTrue()


### PR DESCRIPTION
Codex uses the `.agents` convention, so install the tscircuit skill to `.agents/skills/tscircuit` instead of `.codex/skills/tscircuit`. The `.claude/skills/tscircuit` path is unchanged.