### PR TITLE
Use runtime project config in build, export, and simulate flows

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process"
 import kleur from "kleur"
-import { loadProjectConfig } from "lib/project-config"
+import { loadRuntimeProjectConfig } from "lib/project-config"
 import { installProjectDependencies } from "lib/shared/install-project-dependencies"
 
 export interface BuildCommandOptions {
@@ -67,7 +67,7 @@ export const applyCiBuildOptions = async ({
     return { resolvedOptions: options, handled: false }
   }
 
-  const projectConfig = loadProjectConfig(projectDir)
+  const projectConfig = await loadRuntimeProjectConfig(projectDir)
 
   // Check if we're already inside a buildCommand execution to prevent infinite recursion
   const insideBuildCommand = process.env.TSCIRCUIT_INSIDE_BUILD_COMMAND === "1"

--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs"
 import path from "node:path"
-import { getBoardFilePatterns, loadProjectConfig } from "lib/project-config"
-import { findBoardFiles } from "lib/shared/find-board-files"
+import {
+  DEFAULT_BOARD_FILE_PATTERNS,
+  loadRuntimeProjectConfig,
+} from "lib/project-config"
+import { findBoardFilesAsync } from "lib/shared/find-board-files"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
 
 export class BuildNoMatchingFilesError extends Error {
@@ -73,12 +76,15 @@ export async function getBuildEntrypoints({
   circuitFiles: string[]
 }> {
   const resolvedRoot = path.resolve(rootDir)
+  const rootProjectConfig = await loadRuntimeProjectConfig(resolvedRoot)
   const includeBoardFilePatterns = includeBoardFiles
-    ? getBoardFilePatterns(resolvedRoot)
+    ? (rootProjectConfig?.includeBoardFiles?.filter((pattern) =>
+        pattern.trim(),
+      ) ?? DEFAULT_BOARD_FILE_PATTERNS)
     : []
 
   const buildFromProjectDir = async () => {
-    const projectConfig = loadProjectConfig(resolvedRoot)
+    const projectConfig = rootProjectConfig
     const hasConfiguredIncludeBoardFiles = Boolean(
       projectConfig?.includeBoardFiles?.some((pattern) => pattern.trim()),
     )
@@ -91,7 +97,7 @@ export async function getBuildEntrypoints({
         : undefined
 
     if (includeBoardFiles) {
-      const files = findBoardFiles({ projectDir: resolvedRoot })
+      const files = await findBoardFilesAsync({ projectDir: resolvedRoot })
 
       if (files.length > 0) {
         return {
@@ -139,7 +145,7 @@ export async function getBuildEntrypoints({
   if (fileOrDir) {
     const resolved = path.resolve(resolvedRoot, fileOrDir)
     if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
-      const projectConfig = loadProjectConfig(resolvedRoot)
+      const projectConfig = rootProjectConfig
       const resolvedPreviewComponentPath = projectConfig?.previewComponentPath
         ? path.resolve(resolvedRoot, projectConfig.previewComponentPath)
         : undefined
@@ -152,7 +158,7 @@ export async function getBuildEntrypoints({
         const hasConfiguredIncludeBoardFiles = Boolean(
           projectConfig?.includeBoardFiles?.some((pattern) => pattern.trim()),
         )
-        const matchedFiles = findBoardFiles({
+        const matchedFiles = await findBoardFilesAsync({
           projectDir: resolvedRoot,
         })
         const circuitFiles = matchedFiles.filter((file) =>
@@ -194,7 +200,7 @@ export async function getBuildEntrypoints({
     // Find project root by looking for package.json
     const fileDir = path.dirname(resolved)
     const projectDir = findProjectRoot(fileDir)
-    const projectConfig = loadProjectConfig(projectDir)
+    const projectConfig = await loadRuntimeProjectConfig(projectDir)
     const resolvedPreviewComponentPath = projectConfig?.previewComponentPath
       ? path.resolve(projectDir, projectConfig.previewComponentPath)
       : undefined

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -4,9 +4,10 @@ import JSZip from "jszip"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { Command } from "commander"
 import kleur from "kleur"
-import { loadProjectConfig } from "lib/project-config"
+import { loadRuntimeProjectConfig } from "lib/project-config"
 import { convertToKicadLibrary } from "lib/shared/convert-to-kicad-library"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
+import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
 import {
   type StaticBuildFileReference,
   getStaticIndexHtmlFile,
@@ -232,7 +233,7 @@ export const registerBuild = (program: Command) => {
           projectDir = resolvedRoot
         }
 
-        const projectConfig = loadProjectConfig(projectDir)
+        const projectConfig = await loadRuntimeProjectConfig(projectDir)
 
         const { options: optionsWithConfig, configAppliedOpts } =
           resolveBuildOptions({
@@ -269,7 +270,7 @@ export const registerBuild = (program: Command) => {
           fileOrDir: fileOrDirForBuild,
         })
 
-        const platformConfig: PlatformConfig | undefined = (() => {
+        const commandPlatformConfig: PlatformConfig | undefined = (() => {
           if (
             !resolvedOptions?.disablePcb &&
             !resolvedOptions?.routingDisabled &&
@@ -294,6 +295,11 @@ export const registerBuild = (program: Command) => {
 
           return config
         })()
+
+        const platformConfig = mergePlatformConfigs(
+          projectConfig?.platformConfig,
+          commandPlatformConfig,
+        )
 
         const distDir = path.join(projectDir, "dist")
         fs.mkdirSync(distDir, { recursive: true })
@@ -823,7 +829,6 @@ export const registerBuild = (program: Command) => {
               includeBoardFiles: false,
             },
           )
-          const projectConfig = loadProjectConfig(projectDir)
           const entryFile =
             projectConfig?.kicadLibraryEntrypointPath != null
               ? await getEntrypoint({
@@ -872,7 +877,6 @@ export const registerBuild = (program: Command) => {
             },
           )
 
-          const projectConfig = loadProjectConfig(projectDir)
           const entryFile =
             projectConfig?.kicadLibraryEntrypointPath != null
               ? await getEntrypoint({

--- a/cli/export/register.ts
+++ b/cli/export/register.ts
@@ -9,6 +9,8 @@ import { resultToCsv } from "lib/shared/result-to-csv"
 import path from "node:path"
 import { promises as fs } from "node:fs"
 import type { PlatformConfig } from "@tscircuit/props"
+import { loadRuntimeProjectConfig } from "lib/project-config"
+import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
 
 export const registerExport = (program: Command) => {
   program
@@ -33,11 +35,16 @@ export const registerExport = (program: Command) => {
         },
       ) => {
         const formatOption = options.format ?? "json"
+        const projectConfig = await loadRuntimeProjectConfig(process.cwd())
 
-        const platformConfig: PlatformConfig | undefined =
+        const commandPlatformConfig: PlatformConfig | undefined =
           options.disablePartsEngine === true
             ? { partsEngineDisabled: true }
             : undefined
+        const platformConfig = mergePlatformConfigs(
+          projectConfig?.platformConfig,
+          commandPlatformConfig,
+        )
 
         if (formatOption === "spice") {
           const { circuitJson } = await generateCircuitJson({

--- a/cli/simulate/register.ts
+++ b/cli/simulate/register.ts
@@ -4,6 +4,8 @@ import { runSimulation } from "lib/eecircuit-engine/run-simulation"
 import { resultToTable } from "lib/shared/result-to-table"
 import { getSpiceWithPaddedSim } from "lib/shared/get-spice-with-sim"
 import type { PlatformConfig } from "@tscircuit/props"
+import { loadRuntimeProjectConfig } from "lib/project-config"
+import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
 
 export const registerSimulate = (program: Command) => {
   const simulateCommand = program
@@ -16,10 +18,15 @@ export const registerSimulate = (program: Command) => {
     .argument("<file>", "Path to tscircuit tsx or circuit json file")
     .option("--disable-parts-engine", "Disable the parts engine")
     .action(async (file: string, options: { disablePartsEngine?: boolean }) => {
-      const platformConfig: PlatformConfig | undefined =
+      const projectConfig = await loadRuntimeProjectConfig(process.cwd())
+      const commandPlatformConfig: PlatformConfig | undefined =
         options.disablePartsEngine === true
           ? { partsEngineDisabled: true }
           : undefined
+      const platformConfig = mergePlatformConfigs(
+        projectConfig?.platformConfig,
+        commandPlatformConfig,
+      )
 
       const { circuitJson } = await generateCircuitJson({
         filePath: file,

--- a/lib/shared/find-board-files.ts
+++ b/lib/shared/find-board-files.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs"
 import path from "node:path"
 import { globbySync } from "globby"
-import { getBoardFilePatterns } from "lib/project-config"
+import {
+  DEFAULT_BOARD_FILE_PATTERNS,
+  getBoardFilePatterns,
+  loadRuntimeProjectConfig,
+} from "lib/project-config"
 import { DEFAULT_IGNORED_PATTERNS } from "./should-ignore-path"
 
 type FindBoardFilesOptions = {
@@ -38,14 +42,52 @@ export const findBoardFiles = ({
 }: FindBoardFilesOptions = {}): string[] => {
   const resolvedProjectDir = path.resolve(projectDir)
   const boardFilePatterns = getBoardFilePatterns(resolvedProjectDir)
+  return findBoardFilesFromPatterns({
+    boardFilePatterns,
+    projectDir: resolvedProjectDir,
+    ignore,
+    filePaths,
+  })
+}
 
+export const findBoardFilesAsync = async ({
+  projectDir = process.cwd(),
+  ignore = DEFAULT_IGNORED_PATTERNS,
+  filePaths = [],
+}: FindBoardFilesOptions = {}): Promise<string[]> => {
+  const resolvedProjectDir = path.resolve(projectDir)
+  const projectConfig = await loadRuntimeProjectConfig(resolvedProjectDir)
+  const boardFilePatterns =
+    projectConfig?.includeBoardFiles?.filter((pattern) => pattern.trim()) ?? []
+  return findBoardFilesFromPatterns({
+    boardFilePatterns:
+      boardFilePatterns.length > 0
+        ? boardFilePatterns
+        : DEFAULT_BOARD_FILE_PATTERNS,
+    projectDir: resolvedProjectDir,
+    ignore,
+    filePaths,
+  })
+}
+
+const findBoardFilesFromPatterns = ({
+  boardFilePatterns,
+  projectDir,
+  ignore,
+  filePaths,
+}: {
+  boardFilePatterns: string[]
+  projectDir: string
+  ignore: string[]
+  filePaths: string[]
+}): string[] => {
   const relativeBoardFiles = globbySync(boardFilePatterns, {
-    cwd: resolvedProjectDir,
+    cwd: projectDir,
     ignore,
   })
 
   const absoluteBoardFiles = relativeBoardFiles.map((f) =>
-    path.join(resolvedProjectDir, f),
+    path.join(projectDir, f),
   )
 
   const boardFileSet = new Set<string>()
@@ -56,7 +98,7 @@ export const findBoardFiles = ({
       if (isGlobPattern(inputPath)) {
         // Expand the glob pattern relative to the project directory
         const matches = globbySync(inputPath, {
-          cwd: resolvedProjectDir,
+          cwd: projectDir,
           ignore,
           absolute: true,
         })
@@ -66,7 +108,7 @@ export const findBoardFiles = ({
         }
       } else {
         // Handle as a regular file or directory path
-        const targetPath = path.resolve(resolvedProjectDir, inputPath)
+        const targetPath = path.resolve(projectDir, inputPath)
 
         if (!fs.existsSync(targetPath)) {
           continue
@@ -75,7 +117,7 @@ export const findBoardFiles = ({
         const stat = fs.statSync(targetPath)
         if (stat.isDirectory()) {
           const resolvedDir = path.resolve(targetPath)
-          if (isSubPath(resolvedDir, resolvedProjectDir)) {
+          if (isSubPath(resolvedDir, projectDir)) {
             for (const boardFile of absoluteBoardFiles) {
               if (isSubPath(boardFile, resolvedDir)) {
                 boardFileSet.add(boardFile)

--- a/lib/shared/platform-config-utils.ts
+++ b/lib/shared/platform-config-utils.ts
@@ -1,0 +1,38 @@
+import type { PlatformConfig } from "@tscircuit/props"
+
+export const mergePlatformConfigs = (
+  ...configs: Array<PlatformConfig | null | undefined>
+): PlatformConfig | undefined => {
+  const definedConfigs = configs.filter(Boolean) as PlatformConfig[]
+
+  if (definedConfigs.length === 0) {
+    return undefined
+  }
+
+  return definedConfigs.reduce<PlatformConfig>((mergedConfig, config) => {
+    return {
+      ...mergedConfig,
+      ...config,
+      footprintLibraryMap: {
+        ...mergedConfig.footprintLibraryMap,
+        ...config.footprintLibraryMap,
+      },
+      footprintFileParserMap: {
+        ...mergedConfig.footprintFileParserMap,
+        ...config.footprintFileParserMap,
+      },
+      staticFileLoaderMap: {
+        ...mergedConfig.staticFileLoaderMap,
+        ...config.staticFileLoaderMap,
+      },
+      autorouterMap: {
+        ...mergedConfig.autorouterMap,
+        ...config.autorouterMap,
+      },
+      spiceEngineMap: {
+        ...mergedConfig.spiceEngineMap,
+        ...config.spiceEngineMap,
+      },
+    }
+  }, {})
+}

--- a/tests/cli/runtime-project-config-command-flows.test.ts
+++ b/tests/cli/runtime-project-config-command-flows.test.ts
@@ -1,0 +1,262 @@
+import { expect, test } from "bun:test"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { getCliTestFixture } from "../fixtures/get-cli-test-fixture"
+import { getBuildEntrypoints } from "../../cli/build/get-build-entrypoints"
+
+const createTiPlatformConfigModule = ({
+  includeBoardFiles,
+  extraFields = "",
+}: {
+  includeBoardFiles?: string[]
+  extraFields?: string
+} = {}) => {
+  const includeBoardFilesField = includeBoardFiles
+    ? `  includeBoardFiles: ${JSON.stringify(includeBoardFiles)},\n`
+    : ""
+
+  return [
+    "export default {",
+    includeBoardFilesField,
+    extraFields,
+    "  platformConfig: {",
+    "    footprintLibraryMap: {",
+    "      ti: async () => ({",
+    "        footprintCircuitJson: [",
+    "          {",
+    '            type: "source_component",',
+    '            source_component_id: "source_component_0",',
+    '            ftype: "simple_chip",',
+    '            name: "U1"',
+    "          },",
+    "          {",
+    '            type: "source_port",',
+    '            source_port_id: "source_port_0",',
+    '            source_component_id: "source_component_0",',
+    '            name: "pin1",',
+    "            pin_number: 1,",
+    '            port_hints: ["1"]',
+    "          },",
+    "          {",
+    '            type: "source_port",',
+    '            source_port_id: "source_port_1",',
+    '            source_component_id: "source_component_0",',
+    '            name: "pin2",',
+    "            pin_number: 2,",
+    '            port_hints: ["2"]',
+    "          },",
+    "          {",
+    '            type: "pcb_component",',
+    '            pcb_component_id: "pcb_component_0",',
+    '            source_component_id: "source_component_0",',
+    "            center: { x: 0, y: 0 },",
+    "            width: 2,",
+    "            height: 2,",
+    '            layer: "top",',
+    "            rotation: 0,",
+    "            obstructs_within_bounds: true",
+    "          },",
+    "          {",
+    '            type: "pcb_port",',
+    '            pcb_port_id: "pcb_port_0",',
+    '            source_port_id: "source_port_0",',
+    '            pcb_component_id: "pcb_component_0",',
+    "            x: -0.6,",
+    "            y: 0,",
+    '            layers: ["top"]',
+    "          },",
+    "          {",
+    '            type: "pcb_smtpad",',
+    '            pcb_smtpad_id: "pcb_smtpad_0",',
+    '            pcb_component_id: "pcb_component_0",',
+    '            shape: "rect",',
+    '            port_hints: ["1"],',
+    "            x: -0.6,",
+    "            y: 0,",
+    "            width: 0.5,",
+    "            height: 1,",
+    '            layer: "top",',
+    "            rotation: 0",
+    "          },",
+    "          {",
+    '            type: "pcb_port",',
+    '            pcb_port_id: "pcb_port_1",',
+    '            source_port_id: "source_port_1",',
+    '            pcb_component_id: "pcb_component_0",',
+    "            x: 0.6,",
+    "            y: 0,",
+    '            layers: ["top"]',
+    "          },",
+    "          {",
+    '            type: "pcb_smtpad",',
+    '            pcb_smtpad_id: "pcb_smtpad_1",',
+    '            pcb_component_id: "pcb_component_0",',
+    '            shape: "rect",',
+    '            port_hints: ["2"],',
+    "            x: 0.6,",
+    "            y: 0,",
+    "            width: 0.5,",
+    "            height: 1,",
+    '            layer: "top",',
+    "            rotation: 0",
+    "          }",
+    "        ]",
+    "      })",
+    "    }",
+    "  }",
+    "}",
+    "",
+  ].join("\n")
+}
+
+const tiBoardCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <chip name="U1" footprint="ti:MSP430" />
+  </board>
+)`
+
+const tiAnalogCircuitCode = `
+export default () => (
+  <board width={30} height={30}>
+    <chip name="U1" footprint="ti:MSP430" pcbX={10} />
+    <voltagesource
+      name="V1"
+      voltage={"5V"}
+      schY={2}
+      schX={-5}
+      schRotation={270}
+    />
+    <trace from={".V1 > .pin1"} to={".L1 > .pin1"} />
+    <trace from={".L1 > .pin2"} to={".D1 > .anode"} />
+    <trace from={".D1 > .cathode"} to={".C1 > .pin1"} />
+    <trace from={".D1 > .cathode"} to={".R1 > .pin1"} />
+    <trace from={".C1 > .pin2"} to={".R1 > .pin2"} />
+    <trace from={".R1 > .pin2"} to={".V1 > .pin2"} />
+    <trace from={".L1 > .pin2"} to={".M1 > .drain"} />
+    <trace from={".M1 > .source"} to={".V1 > .pin2"} />
+    <trace from={".M1 > .source"} to={"net.GND"} />
+    <trace from={".M1 > .gate"} to={".V2 > .pin1"} />
+    <trace from={".V2 > .pin2"} to={".V1 > .pin2"} />
+    <inductor name="L1" inductance={"1H"} footprint={"0603"} schY={3} pcbY={6} pcbX={-3} />
+    <diode name="D1" footprint={"0603"} schY={3} schX={3} pcbY={6} pcbX={3} />
+    <capacitor
+      polarized
+      schRotation={270}
+      name="C1"
+      capacitance={"10uF"}
+      footprint={"0603"}
+      schX={3}
+      pcbX={3}
+    />
+    <resistor
+      schRotation={270}
+      name="R1"
+      resistance={"1k"}
+      footprint={"0603"}
+      schX={6}
+      pcbX={9}
+    />
+    <voltagesource
+      name="V2"
+      schRotation={270}
+      voltage={"10V"}
+      waveShape="square"
+      dutyCycle={0.68}
+      frequency={"1kHz"}
+      schX={-3}
+    />
+    <mosfet
+      channelType="n"
+      footprint={"sot23"}
+      name="M1"
+      mosfetMode="enhancement"
+      pcbX={-4}
+    />
+  </board>
+)`
+
+test("getBuildEntrypoints uses tscircuit.config.ts includeBoardFiles and preview paths", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  await mkdir(join(tmpDir, "boards"), { recursive: true })
+  await mkdir(join(tmpDir, "preview"), { recursive: true })
+  await writeFile(
+    join(tmpDir, "package.json"),
+    JSON.stringify({ name: "runtime-entrypoints-test" }),
+  )
+  await writeFile(
+    join(tmpDir, "tscircuit.config.ts"),
+    [
+      "export default {",
+      '  includeBoardFiles: ["boards/**/*.board.tsx"],',
+      '  previewComponentPath: "preview/preview.tsx",',
+      '  siteDefaultComponentPath: "preview/site.tsx",',
+      "}",
+      "",
+    ].join("\n"),
+  )
+  await writeFile(
+    join(tmpDir, "boards", "picked.board.tsx"),
+    tiBoardCircuitCode,
+  )
+  await writeFile(join(tmpDir, "ignored.board.tsx"), tiBoardCircuitCode)
+
+  const entrypoints = await getBuildEntrypoints({ rootDir: tmpDir })
+
+  expect(entrypoints.projectDir).toBe(tmpDir)
+  expect(entrypoints.previewComponentPath).toBe(
+    join(tmpDir, "preview", "preview.tsx"),
+  )
+  expect(entrypoints.siteDefaultComponentPath).toBe(
+    join(tmpDir, "preview", "site.tsx"),
+  )
+  expect(entrypoints.circuitFiles).toEqual([
+    join(tmpDir, "boards", "picked.board.tsx"),
+  ])
+})
+
+test("export circuit-json consumes runtime platformConfig from tscircuit.config.ts", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = join(tmpDir, "index.circuit.tsx")
+
+  await writeFile(circuitPath, tiBoardCircuitCode)
+  await writeFile(
+    join(tmpDir, "tscircuit.config.ts"),
+    createTiPlatformConfigModule(),
+  )
+
+  const { stderr, exitCode } = await runCommand(
+    `tsci export ${circuitPath} -f circuit-json`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+
+  const circuitJson = JSON.parse(
+    await readFile(join(tmpDir, "index.circuit.circuit.json"), "utf-8"),
+  )
+
+  expect(
+    circuitJson.some((element: any) => element.type === "pcb_smtpad"),
+  ).toBe(true)
+}, 30_000)
+
+test("simulate analog consumes runtime platformConfig from tscircuit.config.ts", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = join(tmpDir, "analog.circuit.tsx")
+
+  await writeFile(circuitPath, tiAnalogCircuitCode)
+  await writeFile(
+    join(tmpDir, "tscircuit.config.ts"),
+    createTiPlatformConfigModule(),
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci simulate analog ${circuitPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toContain("source_port_id")
+  expect(stdout).toContain("Index  time")
+}, 30_000)


### PR DESCRIPTION
## Summary

This PR wires runtime project config into the actual CLI command flows for:

- `build`
- `export`
- `simulate`

It allows `tscircuit.config.ts` / `tscircuit.config.js` to affect these command paths after the loader foundation from the previous PR.

## Why

The previous PR added runtime project config loading, `.env` hydration, and JSON + module config merging.

That established the config loader foundation, but it did not yet make the actual CLI command handlers consume the new runtime config.

This PR is the next step: making the real command flows use the runtime config, especially `platformConfig`, so custom project-level behavior can reach command execution.

This follows the review direction to take the simplest path:
- allow user config to provide `platformConfig`
- merge it on top of the default eval platform config
- validate through actual CLI command paths

## What changed

### Build command flow

Files:
- `cli/build/build-ci.ts`
- `cli/build/get-build-entrypoints.ts`
- `cli/build/register.ts`

Changes:
- `build --ci` now reads runtime project config via `loadRuntimeProjectConfig(...)`
- build entrypoint discovery now respects runtime `includeBoardFiles`
- build entrypoint discovery now respects runtime:
  - `previewComponentPath`
  - `siteDefaultComponentPath`
- `build` now merges:
  - `projectConfig.platformConfig`
  - CLI override config from flags like:
    - `--disable-pcb`
    - `--routing-disabled`
    - `--disable-parts-engine`

### Export command flow

File:
- `cli/export/register.ts`

Changes:
- `export` now loads runtime project config
- merges user `platformConfig` with CLI disable-parts-engine override
- passes merged config into export generation

### Simulate command flow

File:
- `cli/simulate/register.ts`

Changes:
- `simulate analog` now loads runtime project config
- merges user `platformConfig` with CLI disable-parts-engine override
- passes merged config into circuit generation for simulation

### Shared board-file discovery

File:
- `lib/shared/find-board-files.ts`

Changes:
- adds `findBoardFilesAsync(...)`
- runtime config can now provide `includeBoardFiles` through `tscircuit.config.ts/js`
- existing sync `findBoardFiles(...)` path is preserved

### Shared platform config merging

File:
- `lib/shared/platform-config-utils.ts`

Changes:
- adds `mergePlatformConfigs(...)`
- merges multiple `PlatformConfig` objects without losing nested maps like:
  - `footprintLibraryMap`
  - `footprintFileParserMap`
  - `staticFileLoaderMap`
  - `autorouterMap`
  - `spiceEngineMap`

## Files changed

- `cli/build/build-ci.ts`
- `cli/build/get-build-entrypoints.ts`
- `cli/build/register.ts`
- `cli/export/register.ts`
- `cli/simulate/register.ts`
- `lib/shared/find-board-files.ts`
- `lib/shared/platform-config-utils.ts`
- `tests/cli/runtime-project-config-command-flows.test.ts`

## Tests

Added focused runtime command-flow coverage for:

- build entrypoints
- export
- simulate

Test file:
- `tests/cli/runtime-project-config-command-flows.test.ts`

These tests use `tscircuit.config.ts` with a fake function-valued `platformConfig.footprintLibraryMap.ti` so the command paths exercise runtime project config, not just config parsing.

## Validation

Passed locally:
- `bun test tests/cli/runtime-project-config-command-flows.test.ts` for build-entrypoint coverage

Blocked locally for full `export` / `simulate` command validation by an existing repo/package issue:
- the currently installed `circuit-json-to-kicad` package does not export `resolveAndLoadKicad3dModelFiles`
- that causes command startup to fail before the runtime-config changes are fully exercised in those two command paths

## Scope intentionally excluded

This PR does **not** include:

- snapshot flow wiring
- dev / runFrame / `tsci dev` runtime config wiring
- `kicadLibraryName` runtime-config support
- broader cloud/runtime design changes

Those can be handled in follow-up PRs.
