### PR TITLE
Add login guidance for expired sessions

### DIFF
--- a/lib/registry-api/get-ky.ts
+++ b/lib/registry-api/get-ky.ts
@@ -50,6 +50,13 @@ export const prettyResponseErrorHook: AfterResponseHook = async (
     const errorString = apiError
       ? `\n${apiError.error_code}: ${apiError.message}`
       : ""
+    const sessionExpiredAdvice =
+      request.headers.has("Authorization") &&
+      /session_expired|token_expired|expired_session/i.test(
+        apiError?.error_code ?? "",
+      )
+        ? "\n\nYour tscircuit session has expired. Run `tsci logout`, then `tsci login` to log back in."
+        : ""
 
     const bodyDisplay = errorData
       ? JSON.stringify(errorData, null, 2)
@@ -58,7 +65,7 @@ export const prettyResponseErrorHook: AfterResponseHook = async (
     throw new PrettyHttpError(
       `FAIL [${response.status}]: ${request.method} ${
         new URL(request.url).pathname
-      }${errorString}${requestBody ? `\n\nRequest Body:\n${requestBody}` : ""}\n\n${bodyDisplay}`,
+      }${errorString}${sessionExpiredAdvice}${requestBody ? `\n\nRequest Body:\n${requestBody}` : ""}\n\n${bodyDisplay}`,
       request,
       response,
     )

--- a/tests/lib/registry-api/get-ky-session-expired.test.ts
+++ b/tests/lib/registry-api/get-ky-session-expired.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import getPort from "get-port"
+import { getRegistryApiKy } from "lib/registry-api/get-ky"
+import { cliConfig } from "lib/cli-config"
+
+test("getRegistryApiKy tells users to log out and log back in when their session is expired", async () => {
+  const port = await getPort()
+  const server = Bun.serve({
+    port,
+    fetch: () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            error_code: "session_expired",
+            message: "Session expired",
+          },
+        }),
+        { status: 401, headers: { "Content-Type": "application/json" } },
+      ),
+  })
+
+  const previousRegistryApiUrl = cliConfig.get("registryApiUrl")
+  cliConfig.set("registryApiUrl", `http://localhost:${port}`)
+
+  try {
+    let message = ""
+    try {
+      await getRegistryApiKy({ sessionToken: "expired-user-token" })
+        .post("accounts/get", { json: { account_id: "account_123" } })
+        .json()
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+
+    expect(message).toContain("Your tscircuit session has expired")
+    expect(message).toContain("tsci logout")
+    expect(message).toContain("tsci login")
+  } finally {
+    if (previousRegistryApiUrl) {
+      cliConfig.set("registryApiUrl", previousRegistryApiUrl)
+    } else {
+      cliConfig.delete("registryApiUrl")
+    }
+    server.stop()
+  }
+})


### PR DESCRIPTION
### Motivation
- When the registry API returns an expired-session error for an authenticated request, users should be told how to recover (log out and log back in) rather than only seeing a generic HTTP failure message.

### Description
- Detect `session_expired`, `token_expired`, or `expired_session` API error codes in `prettyResponseErrorHook` in `lib/registry-api/get-ky.ts` and, when the request included an `Authorization` header, append the advice: `Run \
\`tsci logout\`, then \
\`tsci login\` to log back in.` to the thrown `PrettyHttpError` message.
- Add a regression test `tests/lib/registry-api/get-ky-session-expired.test.ts` that simulates a `session_expired` 401 response and asserts the logout/login guidance appears in the error message.
- Run code formatting after changes with `bun run format`.

### Testing
- Ran `bun test tests/lib/registry-api/get-ky-session-expired.test.ts` and the new test passed (1 pass, 0 fail). 
- Ran `bunx tsc --noEmit` for type-checking and it completed successfully. 
- Ran `bun run format` to ensure formatting; formatting completed with no fixes needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20763887cc832e9c863b43687e812e)