### PR TITLE
Support adding multiple packages with add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Commands:
   build [options] [file]       Run tscircuit eval and output circuit json
   transpile [file]             Transpile TypeScript/TSX to JavaScript (ESM,
                                CommonJS, and type declarations)
-  add <packageSpec>            Add a tscircuit component package to your project
+  add <packageSpecs...>        Add tscircuit component packages to your project
   remove <component>           Remove a tscircuit component package from your
                                project
   snapshot [options] [path]    Generate schematic and PCB snapshots (add --3d

--- a/cli/add/register.ts
+++ b/cli/add/register.ts
@@ -1,17 +1,17 @@
 import type { Command } from "commander"
-import { addPackage } from "lib/shared/add-package"
+import { addPackages } from "lib/shared/add-package"
 
 export const registerAdd = (program: Command) => {
   program
     .command("add")
-    .description("Add a tscircuit component package to your project")
+    .description("Add tscircuit component packages to your project")
     .argument(
-      "<packageSpec>",
-      "Package to add (e.g. package-name, author/component, https://github.com/user/repo, package@version)",
+      "<packageSpecs...>",
+      "Packages to add (e.g. package-name, author/component, https://github.com/user/repo, package@version)",
     )
-    .action(async (packageSpec: string) => {
+    .action(async (packageSpecs: string[]) => {
       try {
-        await addPackage(packageSpec)
+        await addPackages(packageSpecs)
       } catch (error) {
         process.exit(1)
       }

--- a/lib/shared/add-package.ts
+++ b/lib/shared/add-package.ts
@@ -59,29 +59,40 @@ export function normalizeTscircuitPackageName(
   return null
 }
 
-/**
- * Adds a package to the project (works like bun add).
- * Detects tscircuit component formats and handles @tsci registry setup.
- * All other package specs are passed directly to the package manager.
- *
- * @param packageSpec - Any package specifier (e.g., package-name, author/component, https://github.com/user/repo, package@version)
- * @param projectDir - The root directory of the project (defaults to process.cwd())
- */
 export async function addPackage(
   packageSpec: string,
   projectDir: string = process.cwd(),
 ) {
-  // Check if this is a tscircuit component format
-  const normalizedName = normalizeTscircuitPackageName(packageSpec)
+  return addPackages([packageSpec], projectDir)
+}
 
-  // Determine what to display and what to install
-  const displayName = normalizedName || packageSpec
-  let installTarget = normalizedName || packageSpec
+/**
+ * Adds packages to the project (works like bun add).
+ * Detects tscircuit component formats and handles @tsci registry setup.
+ * All other package specs are passed directly to the package manager.
+ *
+ * @param packageSpecs - Array of package specifiers
+ * @param projectDir - The root directory of the project (defaults to process.cwd())
+ */
+export async function addPackages(
+  packageSpecs: string[],
+  projectDir: string = process.cwd(),
+) {
 
-  console.log(kleur.cyan(`Adding ${kleur.bold(displayName)}...`))
+  const normalized = packageSpecs.map((spec) => ({
+    original: spec,
+    normalized: normalizeTscircuitPackageName(spec),
+  }))
 
-  // Only handle @tsci registry setup if it's a tscircuit component
-  if (normalizedName?.startsWith("@tsci/")) {
+  const displayNames = normalized.map((p) => p.normalized || p.original).join(" ")
+  console.log(kleur.cyan(`Adding ${kleur.bold(displayNames)}...`))
+
+  const hasTsciPackage = normalized.some((p) =>
+    p.normalized?.startsWith("@tsci/"),
+  )
+
+  let useTarball = false
+  if (hasTsciPackage) {
     const npmrcPath = path.join(projectDir, ".npmrc")
     const npmrcContent = fs.existsSync(npmrcPath)
       ? fs.readFileSync(npmrcPath, "utf-8")
@@ -108,27 +119,32 @@ export async function addPackage(
         console.log(
           "Continuing without updating .npmrc; will fetch package directly from registry tarball.",
         )
+        useTarball = true
       }
     }
-
-    if (!hasTsciRegistry) {
-      installTarget = await resolveTarballUrlFromRegistry(normalizedName)
-    }
   }
-  // For all other cases (URLs, scoped packages, regular npm packages), use packageSpec as-is
 
-  // Install the package using the detected package manager
+  const installTargets = await Promise.all(
+    normalized.map(async ({ original, normalized: norm }) => {
+      if (norm?.startsWith("@tsci/") && useTarball) {
+        return resolveTarballUrlFromRegistry(norm)
+      }
+      return norm || original
+    }),
+  )
+
   const packageManager = getPackageManager()
   try {
-    packageManager.install({ name: installTarget, cwd: projectDir })
-    console.log(kleur.green(`✓ Added ${kleur.bold(displayName)} successfully`))
+    packageManager.install({ name: installTargets.join(" "), cwd: projectDir })
+    console.log(kleur.green(`✓ Added ${kleur.bold(displayNames)} successfully`))
 
-    // After installation, check if it's a KiCad library and setup types if needed
-    await detectAndSetupKicadLibrary(packageSpec, projectDir)
+    await Promise.all(
+      packageSpecs.map((spec) => detectAndSetupKicadLibrary(spec, projectDir)),
+    )
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
-    console.error(kleur.red(`✗ Failed to add ${displayName}:`), errorMessage)
+    console.error(kleur.red(`✗ Failed to add ${displayNames}:`), errorMessage)
     handleRegistryAuthError({ error, projectDir })
-    throw new Error(`Failed to add ${displayName}: ${errorMessage}`)
+    throw new Error(`Failed to add ${displayNames}: ${errorMessage}`)
   }
 }

--- a/lib/shared/add-package.ts
+++ b/lib/shared/add-package.ts
@@ -78,13 +78,14 @@ export async function addPackages(
   packageSpecs: string[],
   projectDir: string = process.cwd(),
 ) {
-
   const normalized = packageSpecs.map((spec) => ({
     original: spec,
     normalized: normalizeTscircuitPackageName(spec),
   }))
 
-  const displayNames = normalized.map((p) => p.normalized || p.original).join(" ")
+  const displayNames = normalized
+    .map((p) => p.normalized || p.original)
+    .join(" ")
   console.log(kleur.cyan(`Adding ${kleur.bold(displayNames)}...`))
 
   const hasTsciPackage = normalized.some((p) =>

--- a/tests/cli/add/add-package07.test.ts
+++ b/tests/cli/add/add-package07.test.ts
@@ -1,0 +1,29 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { join } from "node:path"
+import { existsSync } from "node:fs"
+
+test("tsci add - adds multiple packages in a single command", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "package.json"),
+    JSON.stringify({
+      name: "test-project",
+      dependencies: {},
+    }),
+  )
+
+  const { stdout } = await runCommand("tsci add @tsci/seveibar.Key @tsci/seveibar.PICO")
+  expect(stdout).toContain("Adding @tsci/seveibar.Key @tsci/seveibar.PICO")
+  expect(stdout).toContain("successfully")
+
+  const pkgJson = JSON.parse(
+    await Bun.file(join(tmpDir, "package.json")).text(),
+  )
+  expect(pkgJson.dependencies["@tsci/seveibar.Key"]).toBeDefined()
+  expect(pkgJson.dependencies["@tsci/seveibar.PICO"]).toBeDefined()
+
+  expect(existsSync(join(tmpDir, "node_modules", "@tsci", "seveibar.Key"))).toBe(true)
+  expect(existsSync(join(tmpDir, "node_modules", "@tsci", "seveibar.PICO"))).toBe(true)
+})

--- a/tests/cli/add/add-package07.test.ts
+++ b/tests/cli/add/add-package07.test.ts
@@ -14,7 +14,9 @@ test("tsci add - adds multiple packages in a single command", async () => {
     }),
   )
 
-  const { stdout } = await runCommand("tsci add @tsci/seveibar.Key @tsci/seveibar.PICO")
+  const { stdout } = await runCommand(
+    "tsci add @tsci/seveibar.Key @tsci/seveibar.PICO",
+  )
   expect(stdout).toContain("Adding @tsci/seveibar.Key @tsci/seveibar.PICO")
   expect(stdout).toContain("successfully")
 
@@ -24,6 +26,10 @@ test("tsci add - adds multiple packages in a single command", async () => {
   expect(pkgJson.dependencies["@tsci/seveibar.Key"]).toBeDefined()
   expect(pkgJson.dependencies["@tsci/seveibar.PICO"]).toBeDefined()
 
-  expect(existsSync(join(tmpDir, "node_modules", "@tsci", "seveibar.Key"))).toBe(true)
-  expect(existsSync(join(tmpDir, "node_modules", "@tsci", "seveibar.PICO"))).toBe(true)
+  expect(
+    existsSync(join(tmpDir, "node_modules", "@tsci", "seveibar.Key")),
+  ).toBe(true)
+  expect(
+    existsSync(join(tmpDir, "node_modules", "@tsci", "seveibar.PICO")),
+  ).toBe(true)
 })


### PR DESCRIPTION
While following the tutorial at: https://docs.tscircuit.com/tutorials/build-a-custom-keyboard-with-tscircuit, it says to run:
```bash
tsci add @tsci/seveibar.PICO @tsci/seveibar.Key
```

However this throws an error:
```bash
error: too many arguments for 'add'. Expected 1 argument but got 2.
```

Using the variadic argument `<packageSpecs...>` in the commander definition resolves this. 

Note that adding multiple packages through the interactive cli (i.e. running `tsci` and then selecting add from the menu) did work.

However, this highlighted a bug with the `addPackage` function where it was only normalizing the first package in a list of packages. So I added a new function `addPackages` which normalizes all the packages, and have `addPackage` just call that.

All the existing add testcases pass, and I added a new one to verify that adding two packages works