### PR TITLE
test: cover push with circuit-only project

### DIFF
--- a/tests/cli/push/push1-no-entrypoint.test.ts
+++ b/tests/cli/push/push1-no-entrypoint.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "bun:test"
-import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { expect, test } from "bun:test"
 import * as fs from "node:fs"
 import * as path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
 test("should fail if no package.json is found", async () => {
   const { runCommand } = await getCliTestFixture({ loggedIn: true })
@@ -39,4 +39,31 @@ test("should push a package without an entrypoint", async () => {
   expect(stdout).toContain("⬆︎ prebuilt.circuit.json")
   expect(stdout).toContain("⬆︎ tscircuit.config.json")
   expect(stdout).toContain('"@tsci/test-user.test-package@1.0.0" published!')
+}, 30_000)
+
+test("should push when the project only has a circuit file", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture({
+    loggedIn: true,
+  })
+
+  fs.writeFileSync(
+    path.resolve(tmpDir, "package.json"),
+    JSON.stringify({
+      name: "@tsci/test-user.circuit-only-package",
+      version: "1.0.0",
+    }),
+  )
+  fs.writeFileSync(
+    path.resolve(tmpDir, "my-board.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm" />\n',
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand("tsci push")
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("my-board.circuit.tsx")
+  expect(stdout).toContain(
+    '"@tsci/test-user.circuit-only-package@1.0.0" published!',
+  )
 }, 30_000)


### PR DESCRIPTION
﻿Fixes #2797

Summary
- Add a regression test for `tsci push` when a package has only a `*.circuit.tsx` board file.
- Assert the push uploads the circuit file and publishes without requiring `index.circuit.tsx` or `mainEntrypoint`.

Verification
- bun test tests/cli/push/push1-no-entrypoint.test.ts -t "should push when the project only has a circuit file"
- bun x biome check tests/cli/push/push1-no-entrypoint.test.ts
- bun x tsc --noEmit
- git diff --check

Note
- `bun install` initially tried to build sharp and failed on this Windows toolchain; rerunning with `bun install --ignore-scripts` installed the dependency tree for tests/typecheck.
