### PR TITLE
 Add current graph support for simulation SVG outputs

### DIFF
--- a/lib/shared/simulation-svg-assets.ts
+++ b/lib/shared/simulation-svg-assets.ts
@@ -1,5 +1,6 @@
 import type {
   AnyCircuitElement,
+  SimulationTransientCurrentGraph,
   SimulationTransientVoltageGraph,
 } from "circuit-json"
 import {
@@ -9,9 +10,23 @@ import {
   isSimulationTransientVoltageGraph,
 } from "circuit-to-svg"
 
+const isSimulationTransientCurrentGraph = (
+  element: AnyCircuitElement,
+): element is SimulationTransientCurrentGraph =>
+  element.type === "simulation_transient_current_graph"
+
 const getSimulationSvgInputs = (circuitJson: AnyCircuitElement[]) => {
   const simulationExperiment = circuitJson.find(isSimulationExperiment)
   if (!simulationExperiment) return undefined
+
+  const simulationTransientCurrentGraphIds = circuitJson
+    .filter(
+      (element): element is SimulationTransientCurrentGraph =>
+        isSimulationTransientCurrentGraph(element) &&
+        element.simulation_experiment_id ===
+          simulationExperiment.simulation_experiment_id,
+    )
+    .map((element) => element.simulation_transient_current_graph_id)
 
   const simulationTransientVoltageGraphIds = circuitJson
     .filter(
@@ -22,10 +37,16 @@ const getSimulationSvgInputs = (circuitJson: AnyCircuitElement[]) => {
     )
     .map((element) => element.simulation_transient_voltage_graph_id)
 
-  if (simulationTransientVoltageGraphIds.length === 0) return undefined
+  if (
+    simulationTransientCurrentGraphIds.length === 0 &&
+    simulationTransientVoltageGraphIds.length === 0
+  ) {
+    return undefined
+  }
 
   return {
     simulation_experiment_id: simulationExperiment.simulation_experiment_id,
+    simulation_transient_current_graph_ids: simulationTransientCurrentGraphIds,
     simulation_transient_voltage_graph_ids: simulationTransientVoltageGraphIds,
   }
 }

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -81,6 +81,30 @@ export default () => (
   </board>
 )`
 
+const currentSimulationCircuitJson = [
+  {
+    type: "simulation_experiment",
+    simulation_experiment_id: "simulation_experiment_0",
+    name: "Transient",
+    experiment_type: "spice_transient_analysis",
+    time_per_step: 0.25,
+    start_time_ms: 0,
+    end_time_ms: 1,
+  },
+  {
+    type: "simulation_transient_current_graph",
+    simulation_transient_current_graph_id:
+      "simulation_transient_current_graph_0",
+    simulation_experiment_id: "simulation_experiment_0",
+    current_levels: [0, 0.001, 0.002, 0.001, 0],
+    time_per_step: 0.25,
+    start_time_ms: 0,
+    end_time_ms: 1,
+    name: "I(R1)",
+    color: "#ff6600",
+  },
+]
+
 const writeBoostSimulationCircuit = async (tmpDir: string) => {
   const circuitPath = path.join(tmpDir, "simulation.circuit.tsx")
   await writeFile(circuitPath, boostSimulationCircuitCode)
@@ -211,6 +235,21 @@ test("build --simulation-svgs generates only simulation.svg", async () => {
     stat(path.join(tmpDir, "dist", "simulation", "3d.png")),
   ).rejects.toBeTruthy()
 }, 60_000)
+
+test("build --simulation-svgs includes current graphs", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "current-sim.circuit.json")
+  await writeFile(circuitPath, JSON.stringify(currentSimulationCircuitJson))
+
+  await runCommand(`tsci build --simulation-svgs ${circuitPath}`)
+
+  const simulationSvg = await readFile(
+    path.join(tmpDir, "dist", "current-sim", "simulation.svg"),
+    "utf-8",
+  )
+  expect(simulationSvg).toContain("<svg")
+  expect(simulationSvg).toContain("I(R1)")
+}, 30_000)
 
 test("build --simulation-schematic-svgs generates only simulation-schematic.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -75,6 +75,30 @@ export const BoostConverter = () => (
   </board>
 )`
 
+const currentSimulationCircuitJson = [
+  {
+    type: "simulation_experiment",
+    simulation_experiment_id: "simulation_experiment_0",
+    name: "Transient",
+    experiment_type: "spice_transient_analysis",
+    time_per_step: 0.25,
+    start_time_ms: 0,
+    end_time_ms: 1,
+  },
+  {
+    type: "simulation_transient_current_graph",
+    simulation_transient_current_graph_id:
+      "simulation_transient_current_graph_0",
+    simulation_experiment_id: "simulation_experiment_0",
+    current_levels: [0, 0.001, 0.002, 0.001, 0],
+    time_per_step: 0.25,
+    start_time_ms: 0,
+    end_time_ms: 1,
+    name: "I(R1)",
+    color: "#ff6600",
+  },
+]
+
 test("snapshot command creates SVG snapshots", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
@@ -214,6 +238,39 @@ test("snapshot command --simulation-only creates only simulation SVG snapshots",
   )
   expect(testStdout).toContain("All snapshots match")
 }, 60_000)
+
+test("snapshot command creates simulation SVG snapshots for current graphs", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "current-sim.circuit.json"),
+    JSON.stringify(currentSimulationCircuitJson),
+  )
+
+  const { stdout: updateStdout } = await runCommand(
+    "tsci snapshot current-sim.circuit.json --update --simulation-only",
+  )
+  expect(updateStdout).toContain("Created snapshots")
+  expect(updateStdout).toContain(
+    `✅ ${join("__snapshots__", "current-sim.circuit-simulation.snap.svg")}`,
+  )
+  expect(updateStdout).toContain(
+    `✅ ${join("__snapshots__", "current-sim.circuit-schematic-simulation.snap.svg")}`,
+  )
+
+  const snapshotDir = join(tmpDir, "__snapshots__")
+  const simulationSnapshot = await Bun.file(
+    join(snapshotDir, "current-sim.circuit-simulation.snap.svg"),
+  ).text()
+  const schematicSimulationSnapshot = await Bun.file(
+    join(snapshotDir, "current-sim.circuit-schematic-simulation.snap.svg"),
+  ).text()
+
+  expect(simulationSnapshot).toContain("<svg")
+  expect(simulationSnapshot).toContain("I(R1)")
+  expect(schematicSimulationSnapshot).toContain("<svg")
+  expect(schematicSimulationSnapshot).toContain("I(R1)")
+}, 30_000)
 
 test("snapshot command --simulation-only rejects other snapshot type filters", async () => {
   const { runCommand } = await getCliTestFixture()


### PR DESCRIPTION
 Supports simulation_transient_current_graph elements alongside existing voltage graph support when generating simulation SVG assets, so current and voltage graphs render in tsci build --simulation-svgs and tsci snapshot --simulation-only.