### PR TITLE
Fix: tsci dev uses the project-local tscircuit version when available

### DIFF
--- a/lib/server/createHttpServer.ts
+++ b/lib/server/createHttpServer.ts
@@ -1,5 +1,7 @@
 import * as fs from "node:fs"
 import * as http from "node:http"
+import { createRequire } from "node:module"
+import * as path from "node:path"
 // @ts-ignore
 import runFrameStandaloneBundleContent from "@tscircuit/runframe/standalone" with {
   type: "text",
@@ -11,6 +13,31 @@ import pkg from "../../package.json"
 import winterspecBundle from "@tscircuit/file-server/dist/bundle.js"
 import { getIndex } from "../site/getIndex"
 import { createKicadPcmProxy } from "./kicad-pcm-proxy"
+
+/**
+ * Resolves the standalone runframe + eval bundle (`dist/browser.min.js`) shipped
+ * by the `tscircuit` version installed in the user's project, so `tsci dev` uses
+ * the version pinned in the project (like `bun run dev` would). Returns undefined
+ * when it isn't installed locally, in which case the caller falls back to the
+ * runframe bundled into the CLI.
+ */
+const resolveLocalTscircuitStandalonePath = (
+  projectDir?: string,
+): string | undefined => {
+  if (!projectDir) return undefined
+  try {
+    const projectRequire = createRequire(path.join(projectDir, "package.json"))
+    const browserBundlePath = path.join(
+      path.dirname(projectRequire.resolve("tscircuit/package.json")),
+      "dist",
+      "browser.min.js",
+    )
+    if (fs.existsSync(browserBundlePath)) return browserBundlePath
+  } catch {
+    // `tscircuit` isn't installed locally; fall back to the CLI-bundled runframe
+  }
+  return undefined
+}
 
 export const createHttpServer = async ({
   port = 3020,
@@ -107,9 +134,26 @@ export const createHttpServer = async ({
     }
 
     if (url.pathname === "/standalone.min.js") {
-      const standaloneFilePath = process.env.RUNFRAME_STANDALONE_FILE_PATH
+      const explicitStandalonePath = process.env.RUNFRAME_STANDALONE_FILE_PATH
 
-      if (!standaloneFilePath) {
+      if (!explicitStandalonePath) {
+        // Prefer the locally installed tscircuit version's bundle so `tsci dev`
+        // automatically uses the version pinned in the project when available.
+        const localStandalonePath =
+          resolveLocalTscircuitStandalonePath(projectDir)
+        if (localStandalonePath) {
+          try {
+            const content = fs.readFileSync(localStandalonePath, "utf8")
+            res.writeHead(200, {
+              "Content-Type": "application/javascript; charset=utf-8",
+            })
+            res.end(content)
+            return
+          } catch {
+            // fall back to the CLI-bundled runframe standalone below
+          }
+        }
+
         res.writeHead(200, {
           "Content-Type": "application/javascript; charset=utf-8",
         })
@@ -118,7 +162,7 @@ export const createHttpServer = async ({
       }
 
       try {
-        const content = fs.readFileSync(standaloneFilePath, "utf8")
+        const content = fs.readFileSync(explicitStandalonePath, "utf8")
         res.writeHead(200, {
           "Content-Type": "application/javascript; charset=utf-8",
         })

--- a/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
+++ b/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { DevServer } from "cli/dev/DevServer"
+import getPort from "get-port"
+import { join } from "node:path"
+import { mkdir, writeFile } from "node:fs/promises"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const LOCAL_BUNDLE = "LOCAL_TSCIRCUIT_BUNDLE_SENTINEL"
+
+/**
+ * `tsci dev` should render with the `tscircuit` version installed in the project,
+ * so the dev server must serve that package's `dist/browser.min.js` (the
+ * standalone runframe + eval bundle) instead of the runframe bundled into the CLI.
+ */
+test("dev server serves the project-local tscircuit standalone bundle", async () => {
+  const fixture = await getCliTestFixture()
+  const projectDir = fixture.tmpDir
+
+  await writeFile(
+    join(projectDir, "index.tsx"),
+    'export default () => <board width="10mm" height="10mm" />\n',
+  )
+  await writeFile(
+    join(projectDir, "package.json"),
+    JSON.stringify({ name: "test-project", version: "1.0.0" }),
+  )
+
+  // Install a project-local tscircuit whose browser bundle is recognizable
+  const tscircuitDir = join(projectDir, "node_modules", "tscircuit")
+  await mkdir(join(tscircuitDir, "dist"), { recursive: true })
+  await writeFile(
+    join(tscircuitDir, "package.json"),
+    JSON.stringify({
+      name: "tscircuit",
+      version: "0.0.999-local",
+      exports: { "./browser": "./dist/browser.min.js" },
+    }),
+  )
+  await writeFile(join(tscircuitDir, "dist", "browser.min.js"), LOCAL_BUNDLE)
+
+  const devServerPort = await getPort()
+  const devServer = new DevServer({
+    port: devServerPort,
+    componentFilePath: join(projectDir, "index.tsx"),
+    projectDir,
+  })
+
+  try {
+    await devServer.start()
+
+    const standalone = await fetch(
+      `http://localhost:${devServerPort}/standalone.min.js`,
+    ).then((res) => res.text())
+
+    expect(standalone).toBe(LOCAL_BUNDLE)
+  } finally {
+    await devServer.stop()
+  }
+}, 30_000)

--- a/tests/fixtures/runBrowserTest.ts
+++ b/tests/fixtures/runBrowserTest.ts
@@ -258,6 +258,16 @@ export async function runBrowserTest(
     )
   }
 
+  // This harness verifies the circuit against the CLI's current runframe/eval,
+  // not the tscircuit version pinned by the downloaded project (which can be old
+  // and incompatible with the dev server's file-server protocol). Remove any
+  // locally installed tscircuit so the dev server serves the CLI-bundled runframe
+  // instead of the project's `tscircuit/dist/browser.min.js`.
+  fs.rmSync(path.join(tmpDir, "node_modules", "tscircuit"), {
+    recursive: true,
+    force: true,
+  })
+
   // Start DevServer
   const port = await getPort()
   const devServer = new DevServer({


### PR DESCRIPTION
`tsci dev` now renders the preview with the `tscircuit` version installed in the project, instead of always using the runframe baked into the CLI.

Previously the dev server served its own bundled `@tscircuit/runframe/standalone` (pinned to the CLI's devDependency, with eval fetched from the CDN at runtime) for every project — so a project pinning a specific `tscircuit` version was ignored.

## How

The `/standalone.min.js` route in `lib/server/createHttpServer.ts` now resolves `tscircuit` from the project dir (`createRequire(projectDir/package.json)`) and, if found, serves that package's `dist/browser.min.js` — the self-contained runframe + eval bundle with the matching `@tscircuit/core`/`@tscircuit/eval`  baked in.

Resolution order:
1. `RUNFRAME_STANDALONE_FILE_PATH` env override (unchanged)
2. project-local `tscircuit/dist/browser.min.js` (new)
3. the runframe bundled into the CLI (existing fallback)

No changes needed in the `tscircuit` or `runframe` repos — `tscircuit` already ships the bundle; the CLI just wasn't looking for it.