### PR TITLE
fix: tsci dev falls back to the global tscircuit standalone bundle

### DIFF
--- a/lib/server/createHttpServer.ts
+++ b/lib/server/createHttpServer.ts
@@ -150,6 +150,23 @@ export const createHttpServer = async ({
             res.end(content)
             return
           } catch {
+            // fall back to the global tscircuit bundle, then the CLI
+          }
+        }
+
+        // Otherwise use the bundle from the globally installed tscircuit (the one
+        // that provides the `tsci` binary, set by tscircuit's cli.mjs).
+        const globalStandalonePath =
+          process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH
+        if (globalStandalonePath) {
+          try {
+            const content = fs.readFileSync(globalStandalonePath, "utf8")
+            res.writeHead(200, {
+              "Content-Type": "application/javascript; charset=utf-8",
+            })
+            res.end(content)
+            return
+          } catch {
             // fall back to the CLI-bundled runframe standalone below
           }
         }

--- a/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
+++ b/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
@@ -6,16 +6,9 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
 const LOCAL_BUNDLE = "LOCAL_TSCIRCUIT_BUNDLE_SENTINEL"
+const GLOBAL_BUNDLE = "GLOBAL_TSCIRCUIT_BUNDLE_SENTINEL"
 
-/**
- * `tsci dev` should render with the `tscircuit` version installed in the project,
- * so the dev server must serve that package's `dist/browser.min.js` (the
- * standalone runframe + eval bundle) instead of the runframe bundled into the CLI.
- */
-test("dev server serves the project-local tscircuit standalone bundle", async () => {
-  const fixture = await getCliTestFixture()
-  const projectDir = fixture.tmpDir
-
+const writeProject = async (projectDir: string) => {
   await writeFile(
     join(projectDir, "index.tsx"),
     'export default () => <board width="10mm" height="10mm" />\n',
@@ -24,8 +17,9 @@ test("dev server serves the project-local tscircuit standalone bundle", async ()
     join(projectDir, "package.json"),
     JSON.stringify({ name: "test-project", version: "1.0.0" }),
   )
+}
 
-  // Install a project-local tscircuit whose browser bundle is recognizable
+const installLocalTscircuit = async (projectDir: string, bundle: string) => {
   const tscircuitDir = join(projectDir, "node_modules", "tscircuit")
   await mkdir(join(tscircuitDir, "dist"), { recursive: true })
   await writeFile(
@@ -36,24 +30,64 @@ test("dev server serves the project-local tscircuit standalone bundle", async ()
       exports: { "./browser": "./dist/browser.min.js" },
     }),
   )
-  await writeFile(join(tscircuitDir, "dist", "browser.min.js"), LOCAL_BUNDLE)
+  await writeFile(join(tscircuitDir, "dist", "browser.min.js"), bundle)
+}
 
-  const devServerPort = await getPort()
+const fetchStandalone = async (projectDir: string) => {
+  const port = await getPort()
   const devServer = new DevServer({
-    port: devServerPort,
+    port,
     componentFilePath: join(projectDir, "index.tsx"),
     projectDir,
   })
-
   try {
     await devServer.start()
-
-    const standalone = await fetch(
-      `http://localhost:${devServerPort}/standalone.min.js`,
-    ).then((res) => res.text())
-
-    expect(standalone).toBe(LOCAL_BUNDLE)
+    return await fetch(`http://localhost:${port}/standalone.min.js`).then(
+      (res) => res.text(),
+    )
   } finally {
     await devServer.stop()
+  }
+}
+
+/**
+ * `tsci dev` renders with the `tscircuit` installed in the project, so the dev
+ * server serves that package's `dist/browser.min.js`. It is preferred over the
+ * global tscircuit bundle (the `tsci` binary's), since a project pin is the
+ * stronger signal.
+ */
+test("dev server serves the project-local tscircuit bundle, even when a global bundle is set", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  await writeProject(tmpDir)
+  await installLocalTscircuit(tmpDir, LOCAL_BUNDLE)
+
+  const globalBundlePath = join(tmpDir, "global-browser.min.js")
+  await writeFile(globalBundlePath, GLOBAL_BUNDLE)
+  process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = globalBundlePath
+
+  try {
+    expect(await fetchStandalone(tmpDir)).toBe(LOCAL_BUNDLE)
+  } finally {
+    delete process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH
+  }
+}, 30_000)
+
+/**
+ * When the project has no local tscircuit, the dev server serves the bundle from
+ * the tscircuit that provides the `tsci` binary, exposed via
+ * TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH (set by tscircuit's cli.mjs).
+ */
+test("dev server falls back to TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH when no local tscircuit", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  await writeProject(tmpDir)
+
+  const globalBundlePath = join(tmpDir, "global-browser.min.js")
+  await writeFile(globalBundlePath, GLOBAL_BUNDLE)
+  process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = globalBundlePath
+
+  try {
+    expect(await fetchStandalone(tmpDir)).toBe(GLOBAL_BUNDLE)
+  } finally {
+    delete process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH
   }
 }, 30_000)


### PR DESCRIPTION
When a project has no local tscircuit, the dev server now serves the bundle exposed via TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH (set by tscircuit's cli.mjs, i.e. the globally installed tscircuit that provides the `tsci` binary) before falling back to the runframe bundled into the CLI.

Precedence: RUNFRAME_STANDALONE_FILE_PATH -> project-local tscircuit ->
TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH -> CLI-bundled runframe.


related: https://github.com/tscircuit/cli/pull/3469