### PR TITLE
Apply CLI platform defaults to exports (enable platform autorouters + loaders)

### DIFF
--- a/cli/export/register.ts
+++ b/cli/export/register.ts
@@ -87,7 +87,7 @@ export const registerExport = (program: Command) => {
           filePath: file,
           format,
           outputPath: options.output,
-          platformConfig,
+          platformConfig: getPlatformConfigWithCliDefaults(platformConfig),
           pcbSnapshotSettings: options.showCourtyards
             ? { showCourtyards: true }
             : undefined,


### PR DESCRIPTION
## Bug
`tsci export` renders the board with the **raw** `platformConfig`, but the `spice` path wraps it with `getPlatformConfigWithCliDefaults(...)`. Result: kicad / gerbers / pcb / etc. exports never receive the CLI platform defaults from `@tscircuit/eval` — the **`autorouterMap`** (e.g. the `krt` KiCad-routing-tools autorouter), the static-file loaders and footprint loaders.

Concretely, a board with `autorouter="krt"` **silently falls back to the built-in router on export** (verified: selecting `krt` changed nothing until this fix, after which the platform autorouter is actually invoked).

`cli/export/register.ts`:
```ts
// spice branch (already correct):
platformConfig: getPlatformConfigWithCliDefaults(platformConfig),
// export branch (was raw):
-  platformConfig,
+  platformConfig: getPlatformConfigWithCliDefaults(platformConfig),
```

## Fix
Wrap the export `platformConfig` the same way the spice path does, so exports and the dev server resolve the **same** platform autorouters and loaders. One line, mirrors existing behavior.

## Verification
With `autorouter="krt"`, before this change the export produced the built-in-router result; after it, the `krt` platform autorouter is invoked (route changes). Happy to add a regression test asserting a board with a platform-mapped autorouter routes via that autorouter on export.