### PR TITLE
Reuse current Circuit JSON builds where the filesystem hash hasn't changed

### DIFF
--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -4,6 +4,7 @@ import JSZip from "jszip"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { Command } from "commander"
 import kleur from "kleur"
+import { getCircuitJsonOutputDirName } from "lib/shared/circuit-json-build-cache"
 import { loadRuntimeProjectConfig } from "lib/project-config"
 import {
   parseAutorouterDumpSrjMode,
@@ -98,23 +99,6 @@ const parseInjectedProps = ({
   }
 
   return parsed as Record<string, unknown>
-}
-
-const getOutputDirName = (relativePath: string) => {
-  const normalizedRelativePath = relativePath
-    .toLowerCase()
-    .replaceAll("\\", "/")
-
-  if (
-    normalizedRelativePath === "circuit.json" ||
-    normalizedRelativePath.endsWith("/circuit.json")
-  ) {
-    return path.dirname(relativePath)
-  }
-
-  return relativePath
-    .replace(/(\.board|\.circuit)?\.tsx$/, "")
-    .replace(/\.circuit\.json$/, "")
 }
 
 export const registerBuild = (program: Command) => {
@@ -452,7 +436,7 @@ export const registerBuild = (program: Command) => {
           },
         ) => {
           const relative = path.relative(projectDir, filePath)
-          const outputDirName = getOutputDirName(relative)
+          const outputDirName = getCircuitJsonOutputDirName(relative)
 
           builtFiles.push({
             sourcePath: filePath,
@@ -568,7 +552,7 @@ export const registerBuild = (program: Command) => {
           for (const filePath of circuitFiles) {
             const relative = path.relative(projectDir, filePath)
             console.log(`Building ${relative}...`)
-            const outputDirName = getOutputDirName(relative)
+            const outputDirName = getCircuitJsonOutputDirName(relative)
             const outputPath = path.join(distDir, outputDirName, "circuit.json")
             const startedAt = resolvedOptions?.profile ? performance.now() : 0
             const buildOutcome = await buildFile(
@@ -599,7 +583,7 @@ export const registerBuild = (program: Command) => {
         const buildWithWorkers = async () => {
           const filesToBuild = circuitFiles.map((filePath) => {
             const relative = path.relative(projectDir, filePath)
-            const outputDirName = getOutputDirName(relative)
+            const outputDirName = getCircuitJsonOutputDirName(relative)
             const outputPath = path.join(distDir, outputDirName, "circuit.json")
             const glbOutputPath = resolvedOptions?.glbs
               ? path.join(distDir, outputDirName, "3d.glb")

--- a/cli/check/netlist/register.ts
+++ b/cli/check/netlist/register.ts
@@ -6,7 +6,7 @@ import {
 import type { PlatformConfig } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import type { Command } from "commander"
-import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-json"
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
 import {
@@ -51,7 +51,7 @@ export const checkNetlist = async (file?: string) => {
     placementDrcChecksDisabled: true,
   } satisfies PlatformConfig)
 
-  const { circuitJson } = await generateCircuitJson({
+  const { circuitJson } = await getOrGenerateCircuitJson({
     filePath: resolvedInputFilePath,
     platformConfig: platformConfigWithCliDefaults,
   })

--- a/cli/check/shared.ts
+++ b/cli/check/shared.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import type { AutorouterDiagnosticsOptions } from "lib/shared/autorouter-diagnostics"
-import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-json"
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
 import { isCircuitJsonFile } from "lib/shared/is-circuit-json-file"
@@ -43,7 +43,7 @@ export const getCircuitJsonForCheck = async ({
   const platformConfigWithCliDefaults =
     getPlatformConfigWithCliDefaults(platformConfig)
 
-  const { circuitJson } = await generateCircuitJson({
+  const { circuitJson } = await getOrGenerateCircuitJson({
     filePath,
     platformConfig: platformConfigWithCliDefaults,
     autorouterDiagnostics,

--- a/cli/export/register.ts
+++ b/cli/export/register.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander"
 import { exportSnippet } from "lib/shared/export-snippet"
 import type { ExportFormat } from "lib/shared/export-snippet"
 import { ALLOWED_EXPORT_FORMATS } from "lib/shared/export-snippet"
-import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-json"
 import { getSpiceWithPaddedSim } from "lib/shared/get-spice-with-sim"
 import { runSimulation } from "lib/eecircuit-engine/run-simulation"
 import { resultToCsv } from "lib/shared/result-to-csv"
@@ -48,7 +48,7 @@ export const registerExport = (program: Command) => {
         )
 
         if (formatOption === "spice") {
-          const { circuitJson } = await generateCircuitJson({
+          const { circuitJson } = await getOrGenerateCircuitJson({
             filePath: file,
             platformConfig: getPlatformConfigWithCliDefaults(platformConfig),
           })

--- a/cli/simulate/register.ts
+++ b/cli/simulate/register.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander"
-import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-json"
 import { runSimulation } from "lib/eecircuit-engine/run-simulation"
 import { resultToTable } from "lib/shared/result-to-table"
 import { getSpiceWithPaddedSim } from "lib/shared/get-spice-with-sim"
@@ -29,7 +29,7 @@ export const registerSimulate = (program: Command) => {
         commandPlatformConfig,
       )
 
-      const { circuitJson } = await generateCircuitJson({
+      const { circuitJson } = await getOrGenerateCircuitJson({
         filePath: file,
         saveToFile: false,
         platformConfig: getPlatformConfigWithCliDefaults(platformConfig),

--- a/lib/shared/circuit-json-build-cache.ts
+++ b/lib/shared/circuit-json-build-cache.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs"
+import path from "node:path"
+import { createHash } from "node:crypto"
+import type { AnyCircuitElement } from "circuit-json"
+
+type SourceProjectMetadataWithFilesystemHash = Extract<
+  AnyCircuitElement,
+  { type: "source_project_metadata" }
+> & {
+  source_filesystem_md5_hash: string
+}
+
+const SOURCE_FILE_EXTENSIONS = new Set([
+  ".tsx",
+  ".ts",
+  ".jsx",
+  ".js",
+  ".json",
+  ".txt",
+  ".md",
+  ".obj",
+  ".kicad_mod",
+  ".kicad_pcb",
+  ".kicad_pro",
+  ".kicad_sch",
+])
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".git",
+])
+
+const isPathInside = (childPath: string, parentPath: string) => {
+  const relative = path.relative(parentPath, childPath)
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  )
+}
+
+export const findCircuitProjectDir = (filePath: string) => {
+  const absoluteFilePath = path.resolve(filePath)
+  let currentDir = path.dirname(absoluteFilePath)
+
+  while (true) {
+    if (fs.existsSync(path.join(currentDir, "package.json"))) {
+      return currentDir
+    }
+
+    const parentDir = path.dirname(currentDir)
+    if (parentDir === currentDir) break
+    currentDir = parentDir
+  }
+
+  const cwd = path.resolve(process.cwd())
+  return isPathInside(absoluteFilePath, cwd)
+    ? cwd
+    : path.dirname(absoluteFilePath)
+}
+
+export const getCircuitJsonOutputDirName = (relativePath: string) => {
+  const normalizedRelativePath = relativePath
+    .toLowerCase()
+    .replaceAll("\\", "/")
+
+  if (
+    normalizedRelativePath === "circuit.json" ||
+    normalizedRelativePath.endsWith("/circuit.json")
+  ) {
+    return path.dirname(relativePath)
+  }
+
+  return relativePath
+    .replace(/(\.board|\.circuit)?\.tsx$/, "")
+    .replace(/\.circuit\.json$/, "")
+}
+
+export const getCircuitJsonBuildOutputPath = (filePath: string) => {
+  const absoluteFilePath = path.resolve(filePath)
+  const projectDir = findCircuitProjectDir(absoluteFilePath)
+  const relativePath = path.relative(projectDir, absoluteFilePath)
+  return path.join(
+    projectDir,
+    "dist",
+    getCircuitJsonOutputDirName(relativePath),
+    "circuit.json",
+  )
+}
+
+const getSourceFilePaths = (projectDir: string) => {
+  const sourceFilePaths: string[] = []
+
+  const visit = (directoryPath: string) => {
+    const entries = fs
+      .readdirSync(directoryPath, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    for (const entry of entries) {
+      const entryPath = path.join(directoryPath, entry.name)
+
+      if (entry.isDirectory()) {
+        if (
+          IGNORED_DIRECTORY_NAMES.has(entry.name) ||
+          entry.name.startsWith(".")
+        ) {
+          continue
+        }
+        visit(entryPath)
+        continue
+      }
+
+      if (
+        !entry.isFile() ||
+        entry.name.endsWith(".circuit.json") ||
+        !SOURCE_FILE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+      ) {
+        continue
+      }
+
+      sourceFilePaths.push(entryPath)
+    }
+  }
+
+  visit(projectDir)
+  return sourceFilePaths
+}
+
+export const getSourceFilesystemMd5Hash = (filePath: string) => {
+  const projectDir = findCircuitProjectDir(filePath)
+  const hash = createHash("md5")
+
+  for (const sourceFilePath of getSourceFilePaths(projectDir)) {
+    const relativePath = path
+      .relative(projectDir, sourceFilePath)
+      .split(path.sep)
+      .join("/")
+    const content = fs.readFileSync(sourceFilePath)
+
+    hash.update(`${Buffer.byteLength(relativePath)}:`)
+    hash.update(relativePath)
+    hash.update(`${content.byteLength}:`)
+    hash.update(content)
+  }
+
+  return hash.digest("hex")
+}
+
+/** Adds the hash used to decide whether a build matches the current sources. */
+export const addSourceFilesystemHash = (
+  circuitJson: AnyCircuitElement[],
+  sourceFilesystemMd5Hash: string,
+) => {
+  let foundProjectMetadata = false
+  const circuitJsonWithHash = circuitJson.map((element) => {
+    if (element.type !== "source_project_metadata") return element
+
+    foundProjectMetadata = true
+    const metadataWithHash: SourceProjectMetadataWithFilesystemHash = {
+      ...element,
+      source_filesystem_md5_hash: sourceFilesystemMd5Hash,
+    }
+    return metadataWithHash
+  })
+
+  if (!foundProjectMetadata) {
+    const metadataWithHash: SourceProjectMetadataWithFilesystemHash = {
+      type: "source_project_metadata",
+      source_filesystem_md5_hash: sourceFilesystemMd5Hash,
+    }
+    circuitJsonWithHash.push(metadataWithHash)
+  }
+
+  return circuitJsonWithHash
+}
+
+/** Reads the normal `tsci build` output only when its source hash is current. */
+export const readCurrentCircuitJsonBuild = ({
+  filePath,
+  sourceFilesystemMd5Hash,
+}: {
+  filePath: string
+  sourceFilesystemMd5Hash: string
+}) => {
+  const outputPath = getCircuitJsonBuildOutputPath(filePath)
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(outputPath, "utf-8"))
+    if (!Array.isArray(parsed)) return null
+
+    const hasCurrentFilesystemHash = parsed.some(
+      (element) =>
+        element?.type === "source_project_metadata" &&
+        element.source_filesystem_md5_hash === sourceFilesystemMd5Hash,
+    )
+
+    return hasCurrentFilesystemHash
+      ? {
+          circuitJson: parsed as AnyCircuitElement[],
+          outputPath,
+        }
+      : null
+  } catch {
+    return null
+  }
+}

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -21,7 +21,7 @@ import {
 import { convertCircuitJsonToDsnString } from "dsn-converter"
 import JSZip from "jszip"
 import { circuitJsonToStep } from "circuit-json-to-step"
-import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-json"
 import { getCircuitJsonToGltfOptions } from "lib/shared/get-circuit-json-to-gltf-options"
 import { loadLocalStepModelFsMap } from "lib/shared/load-local-step-model-fs-map"
 import { convertToKicadLibrary } from "./convert-to-kicad-library"
@@ -175,7 +175,7 @@ export const exportSnippet = async ({
       return onExit(1)
     }
   } else {
-    const circuitData = await generateCircuitJson({
+    const circuitData = await getOrGenerateCircuitJson({
       filePath,
       saveToFile: format === "circuit-json",
       platformConfig,

--- a/lib/shared/generate-circuit-json.tsx
+++ b/lib/shared/generate-circuit-json.tsx
@@ -11,6 +11,10 @@ import {
 } from "./autorouter-diagnostics"
 import { importFromUserLand } from "./importFromUserLand"
 import { registerStaticAssetLoaders } from "./register-static-asset-loaders"
+import {
+  addSourceFilesystemHash,
+  getSourceFilesystemMd5Hash,
+} from "./circuit-json-build-cache"
 
 const debug = Debug("tsci:generate-circuit-json")
 
@@ -38,6 +42,7 @@ type GenerateCircuitJsonOptions = {
   injectedProps?: Record<string, unknown>
   onAsyncEffectStatus?: (asyncEffectName: string) => void
   autorouterDiagnostics?: AutorouterDiagnosticsOptions
+  sourceFilesystemMd5Hash?: string
 }
 
 /**
@@ -55,8 +60,12 @@ export async function generateCircuitJson({
   injectedProps,
   onAsyncEffectStatus,
   autorouterDiagnostics: autorouterDiagnosticsOptions,
+  sourceFilesystemMd5Hash,
 }: GenerateCircuitJsonOptions) {
   debug(`Generating circuit JSON for ${filePath}`)
+
+  const currentSourceFilesystemMd5Hash =
+    sourceFilesystemMd5Hash ?? getSourceFilesystemMd5Hash(filePath)
 
   // Import React and make it globally available for packages referencing it
   const React = await importFromUserLand("react")
@@ -164,7 +173,10 @@ export async function generateCircuitJson({
   runner.emit("renderComplete")
 
   // Get the circuit JSON
-  const circuitJson = await runner.getCircuitJson()
+  const circuitJson = addSourceFilesystemHash(
+    await runner.getCircuitJson(),
+    currentSourceFilesystemMd5Hash,
+  )
   await autorouterDiagnostics.finalize(circuitJson)
 
   // Save the circuit JSON to a file if requested

--- a/lib/shared/get-or-generate-circuit-json.ts
+++ b/lib/shared/get-or-generate-circuit-json.ts
@@ -1,0 +1,39 @@
+import {
+  getSourceFilesystemMd5Hash,
+  readCurrentCircuitJsonBuild,
+} from "./circuit-json-build-cache"
+import { generateCircuitJson } from "./generate-circuit-json"
+
+/**
+ * Reuses a current `tsci build` artifact when possible. Cache misses are kept
+ * read-only so command-specific partial builds cannot replace the full build.
+ * The explicit build command calls `generateCircuitJson` directly to force a
+ * rebuild.
+ */
+export const getOrGenerateCircuitJson = async (
+  options: Parameters<typeof generateCircuitJson>[0],
+) => {
+  const sourceFilesystemMd5Hash = getSourceFilesystemMd5Hash(options.filePath)
+  const cachedBuild = readCurrentCircuitJsonBuild({
+    filePath: options.filePath,
+    sourceFilesystemMd5Hash,
+  })
+
+  if (cachedBuild) {
+    return {
+      ...cachedBuild,
+      rootCircuit: undefined,
+      cacheHit: true,
+    }
+  }
+
+  const generated = await generateCircuitJson({
+    ...options,
+    sourceFilesystemMd5Hash,
+  })
+
+  return {
+    ...generated,
+    cacheHit: false,
+  }
+}

--- a/lib/shared/process-snapshot-file.ts
+++ b/lib/shared/process-snapshot-file.ts
@@ -10,7 +10,7 @@ import {
 } from "circuit-to-svg"
 import kleur from "kleur"
 import type { CameraPreset } from "circuit-json-to-3d-png"
-import { generateCircuitJson } from "lib/shared/generate-circuit-json"
+import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-json"
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import { getSimulationSvgAssetsFromCircuitJson } from "lib/shared/simulation-svg-assets"
 import { compareAndCreateDiff } from "./compare-images"
@@ -79,7 +79,7 @@ export const processSnapshotFile = async ({
       const platformConfigWithCliDefaults =
         getPlatformConfigWithCliDefaults(platformConfig)
 
-      const result = await generateCircuitJson({
+      const result = await getOrGenerateCircuitJson({
         filePath: file,
         platformConfig: platformConfigWithCliDefaults,
       })

--- a/tests/cli/export/export-reuses-current-build.test.ts
+++ b/tests/cli/export/export-reuses-current-build.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const getCircuitCode = (resistorName: string) => `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor
+      resistance="1k"
+      footprint="0402"
+      name="${resistorName}"
+    />
+  </board>
+)
+`
+
+const getSourceComponentName = (circuitJson: unknown[]) =>
+  (
+    circuitJson.find(
+      (element: any) => element.type === "source_component",
+    ) as any
+  )?.name
+
+test(
+  "export reuses a matching build, invalidates it after source changes, and build always rebuilds",
+  async () => {
+    const { tmpDir, runCommand } = await getCliTestFixture()
+    const circuitPath = path.join(tmpDir, "cached.circuit.tsx")
+    const buildOutputPath = path.join(tmpDir, "dist", "cached", "circuit.json")
+    const exportOutputPath = path.join(tmpDir, "cached.circuit.circuit.json")
+    fs.writeFileSync(circuitPath, getCircuitCode("R1"))
+
+    const firstBuild = await runCommand(`tsci build ${circuitPath}`)
+    expect(firstBuild.exitCode).toBe(0)
+
+    const builtCircuitJson = JSON.parse(
+      fs.readFileSync(buildOutputPath, "utf-8"),
+    )
+    const metadata = builtCircuitJson.find(
+      (element: any) => element.type === "source_project_metadata",
+    )
+    expect(metadata?.source_filesystem_md5_hash).toMatch(/^[a-f0-9]{32}$/)
+
+    const cachedSourceComponent = builtCircuitJson.find(
+      (element: any) => element.type === "source_component",
+    )
+    cachedSourceComponent.name = "FROM_CACHE"
+    fs.writeFileSync(buildOutputPath, JSON.stringify(builtCircuitJson, null, 2))
+
+    const cachedExport = await runCommand(
+      `tsci export ${circuitPath} -f circuit-json`,
+    )
+    expect(cachedExport.exitCode).toBe(0)
+    expect(
+      getSourceComponentName(
+        JSON.parse(fs.readFileSync(exportOutputPath, "utf-8")),
+      ),
+    ).toBe("FROM_CACHE")
+
+    const forcedBuild = await runCommand(`tsci build ${circuitPath}`)
+    expect(forcedBuild.exitCode).toBe(0)
+    expect(
+      getSourceComponentName(
+        JSON.parse(fs.readFileSync(buildOutputPath, "utf-8")),
+      ),
+    ).toBe("R1")
+
+    fs.writeFileSync(circuitPath, getCircuitCode("R2"))
+    const invalidatedExport = await runCommand(
+      `tsci export ${circuitPath} -f circuit-json`,
+    )
+    expect(invalidatedExport.exitCode).toBe(0)
+    expect(
+      getSourceComponentName(
+        JSON.parse(fs.readFileSync(exportOutputPath, "utf-8")),
+      ),
+    ).toBe("R2")
+  },
+  { timeout: 30_000 },
+)

--- a/tests/shared/circuit-json-build-cache.test.ts
+++ b/tests/shared/circuit-json-build-cache.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import { temporaryDirectory } from "tempy"
+import {
+  getCircuitJsonBuildOutputPath,
+  getSourceFilesystemMd5Hash,
+} from "lib/shared/circuit-json-build-cache"
+
+test("source filesystem hash tracks source files and ignores build artifacts", () => {
+  const projectDir = temporaryDirectory()
+  const circuitPath = path.join(projectDir, "boards", "main.circuit.tsx")
+  fs.mkdirSync(path.dirname(circuitPath), { recursive: true })
+  fs.writeFileSync(path.join(projectDir, "package.json"), '{"name":"board"}')
+  fs.writeFileSync(circuitPath, "export default () => <board />")
+
+  const initialHash = getSourceFilesystemMd5Hash(circuitPath)
+
+  fs.mkdirSync(path.join(projectDir, "dist", "boards", "main"), {
+    recursive: true,
+  })
+  fs.writeFileSync(
+    path.join(projectDir, "dist", "boards", "main", "circuit.json"),
+    "[]",
+  )
+  fs.writeFileSync(path.join(projectDir, "boards", "main.circuit.json"), "[]")
+
+  expect(getSourceFilesystemMd5Hash(circuitPath)).toBe(initialHash)
+  expect(getCircuitJsonBuildOutputPath(circuitPath)).toBe(
+    path.join(projectDir, "dist", "boards", "main", "circuit.json"),
+  )
+
+  fs.writeFileSync(circuitPath, "export default () => <board width={10} />")
+  expect(getSourceFilesystemMd5Hash(circuitPath)).not.toBe(initialHash)
+})


### PR DESCRIPTION
## Summary

- add a deterministic MD5 hash for the project source filesystem to generated `source_project_metadata`
- reuse the normal `dist/.../circuit.json` build artifact when its stored hash matches the current source filesystem
- route export, check, snapshot, and simulate generation through the cache-aware helper
- keep cache misses read-only so partial command-specific generation cannot replace the full build artifact
- keep explicit `tsci build` on the direct generation path so it always rebuilds

## Why

Commands such as export currently regenerate Circuit JSON even when `tsci build` already produced an artifact for unchanged source code. Comparing `source_filesystem_md5_hash` lets these commands safely reuse the existing build and avoid redundant evaluation, parts lookup, placement, and routing work.

Generated Circuit JSON files and build/cache directories are excluded from the source hash so running exports does not invalidate an otherwise current build.

## Dependency

This uses the `source_filesystem_md5_hash` metadata field introduced by tscircuit/circuit-json#644.

## Validation

- focused cache/export integration test, including cache hit, source invalidation, and forced explicit rebuild
- `bun test tests/cli/build/build.test.ts tests/cli/check tests/shared` (46 passing)
- snapshot and simulate integration tests (2 passing)
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`
- `git diff --check`