### PR TITLE
Output SVGs for every analog simulation

### DIFF
--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -98,11 +98,11 @@ const generatePreviewAssets = async ({
         imageFormats,
       )
       if (wroteSimulationSvgs) {
-        if (imageFormats.simulationSvgs) {
-          console.log(`${prefix}Written simulation.svg`)
+        for (const fileName of wroteSimulationSvgs.simulationFileNames) {
+          console.log(`${prefix}Written ${fileName}`)
         }
-        if (imageFormats.simulationSchematicSvgs) {
-          console.log(`${prefix}Written simulation-schematic.svg`)
+        for (const fileName of wroteSimulationSvgs.schematicSimulationFileNames) {
+          console.log(`${prefix}Written ${fileName}`)
         }
       }
     } catch (error) {

--- a/cli/build/worker-output-generators.ts
+++ b/cli/build/worker-output-generators.ts
@@ -27,25 +27,39 @@ export const writeSimulationSvgAssetsFromCircuitJson = (
   }
 
   const simulationSvgAssets = getSimulationSvgAssetsFromCircuitJson(circuitJson)
-  if (!simulationSvgAssets) return false
+  if (simulationSvgAssets.length === 0) return false
 
-  if (imageFormats.simulationSvgs) {
-    fs.writeFileSync(
-      path.join(outputDir, "simulation.svg"),
-      simulationSvgAssets.simulationSvg,
-      "utf-8",
-    )
+  const hasMultipleSimulations = simulationSvgAssets.length > 1
+  const simulationFileNames: string[] = []
+  const schematicSimulationFileNames: string[] = []
+
+  for (const simulationSvgAsset of simulationSvgAssets) {
+    if (imageFormats.simulationSvgs) {
+      const fileName = hasMultipleSimulations
+        ? `simulation-${simulationSvgAsset.fileNameSuffix}.svg`
+        : "simulation.svg"
+      fs.writeFileSync(
+        path.join(outputDir, fileName),
+        simulationSvgAsset.simulationSvg,
+        "utf-8",
+      )
+      simulationFileNames.push(fileName)
+    }
+
+    if (imageFormats.simulationSchematicSvgs) {
+      const fileName = hasMultipleSimulations
+        ? `simulation-schematic-${simulationSvgAsset.fileNameSuffix}.svg`
+        : "simulation-schematic.svg"
+      fs.writeFileSync(
+        path.join(outputDir, fileName),
+        simulationSvgAsset.schematicSimulationSvg,
+        "utf-8",
+      )
+      schematicSimulationFileNames.push(fileName)
+    }
   }
 
-  if (imageFormats.simulationSchematicSvgs) {
-    fs.writeFileSync(
-      path.join(outputDir, "simulation-schematic.svg"),
-      simulationSvgAssets.schematicSimulationSvg,
-      "utf-8",
-    )
-  }
-
-  return true
+  return { simulationFileNames, schematicSimulationFileNames }
 }
 
 export const writeGlbFromCircuitJson = async (

--- a/lib/shared/process-snapshot-file.ts
+++ b/lib/shared/process-snapshot-file.ts
@@ -67,9 +67,9 @@ export const processSnapshotFile = async ({
   let circuitJson: AnyCircuitElement[]
   let pcbSvg: string | undefined
   let schSvg: string | undefined
-  let simulationSvgAssets:
-    | ReturnType<typeof getSimulationSvgAssetsFromCircuitJson>
-    | undefined
+  let simulationSvgAssets: ReturnType<
+    typeof getSimulationSvgAssetsFromCircuitJson
+  > = []
 
   try {
     if (isCircuitJsonFile(file)) {
@@ -228,12 +228,7 @@ export const processSnapshotFile = async ({
   const base = path.basename(file).replace(/\.[^.]+$/, "")
   const snapshots: Array<
     | {
-        type:
-          | "pcb"
-          | "schematic"
-          | "simulation"
-          | "schematic-simulation"
-          | VisibleLayerRef
+        type: string | VisibleLayerRef
         content: string
         isBinary: false
       }
@@ -256,17 +251,29 @@ export const processSnapshotFile = async ({
   if (threeD && png3d) {
     snapshots.push({ type: "3d", content: png3d, isBinary: true })
   }
-  if ((simulationOnly || (!pcbOnly && !schematicOnly)) && simulationSvgAssets) {
-    snapshots.push({
-      type: "simulation",
-      content: simulationSvgAssets.simulationSvg,
-      isBinary: false,
-    })
-    snapshots.push({
-      type: "schematic-simulation",
-      content: simulationSvgAssets.schematicSimulationSvg,
-      isBinary: false,
-    })
+  if (
+    (simulationOnly || (!pcbOnly && !schematicOnly)) &&
+    simulationSvgAssets.length > 0
+  ) {
+    const hasMultipleSimulations = simulationSvgAssets.length > 1
+    for (const simulationSvgAsset of simulationSvgAssets) {
+      const simulationType = hasMultipleSimulations
+        ? `simulation-${simulationSvgAsset.fileNameSuffix}`
+        : "simulation"
+      const schematicSimulationType = hasMultipleSimulations
+        ? `schematic-simulation-${simulationSvgAsset.fileNameSuffix}`
+        : "schematic-simulation"
+      snapshots.push({
+        type: simulationType,
+        content: simulationSvgAsset.simulationSvg,
+        isBinary: false,
+      })
+      snapshots.push({
+        type: schematicSimulationType,
+        content: simulationSvgAsset.schematicSimulationSvg,
+        isBinary: false,
+      })
+    }
   }
 
   for (const snapshot of snapshots) {

--- a/lib/shared/simulation-svg-assets.ts
+++ b/lib/shared/simulation-svg-assets.ts
@@ -15,16 +15,15 @@ const isSimulationTransientCurrentGraph = (
 ): element is SimulationTransientCurrentGraph =>
   element.type === "simulation_transient_current_graph"
 
-const getSimulationSvgInputs = (circuitJson: AnyCircuitElement[]) => {
-  const simulationExperiment = circuitJson.find(isSimulationExperiment)
-  if (!simulationExperiment) return undefined
-
+const getSimulationSvgInputs = (
+  circuitJson: AnyCircuitElement[],
+  simulationExperimentId: string,
+) => {
   const simulationTransientCurrentGraphIds = circuitJson
     .filter(
       (element): element is SimulationTransientCurrentGraph =>
         isSimulationTransientCurrentGraph(element) &&
-        element.simulation_experiment_id ===
-          simulationExperiment.simulation_experiment_id,
+        element.simulation_experiment_id === simulationExperimentId,
     )
     .map((element) => element.simulation_transient_current_graph_id)
 
@@ -32,8 +31,7 @@ const getSimulationSvgInputs = (circuitJson: AnyCircuitElement[]) => {
     .filter(
       (element): element is SimulationTransientVoltageGraph =>
         isSimulationTransientVoltageGraph(element) &&
-        element.simulation_experiment_id ===
-          simulationExperiment.simulation_experiment_id,
+        element.simulation_experiment_id === simulationExperimentId,
     )
     .map((element) => element.simulation_transient_voltage_graph_id)
 
@@ -45,26 +43,65 @@ const getSimulationSvgInputs = (circuitJson: AnyCircuitElement[]) => {
   }
 
   return {
-    simulation_experiment_id: simulationExperiment.simulation_experiment_id,
+    simulation_experiment_id: simulationExperimentId,
     simulation_transient_current_graph_ids: simulationTransientCurrentGraphIds,
     simulation_transient_voltage_graph_ids: simulationTransientVoltageGraphIds,
   }
 }
 
+const toFileNameSuffix = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+const getUniqueFileNameSuffixes = (
+  simulations: Array<{ simulation_experiment_id: string; name: string }>,
+) => {
+  const usedSuffixes = new Set<string>()
+  return simulations.map((simulation) => {
+    const baseSuffix =
+      toFileNameSuffix(simulation.name) ||
+      toFileNameSuffix(simulation.simulation_experiment_id) ||
+      "simulation"
+    let suffix = baseSuffix
+    let duplicateIndex = 2
+    while (usedSuffixes.has(suffix)) {
+      suffix = `${baseSuffix}-${duplicateIndex++}`
+    }
+    usedSuffixes.add(suffix)
+    return suffix
+  })
+}
+
 export const getSimulationSvgAssetsFromCircuitJson = (
   circuitJson: AnyCircuitElement[],
 ) => {
-  const simulationSvgInputs = getSimulationSvgInputs(circuitJson)
-  if (!simulationSvgInputs) return undefined
+  const simulationExperiments = circuitJson.filter(isSimulationExperiment)
+  const fileNameSuffixes = getUniqueFileNameSuffixes(simulationExperiments)
 
-  return {
-    simulationSvg: convertCircuitJsonToSimulationGraphSvg({
+  return simulationExperiments.flatMap((simulationExperiment, index) => {
+    const simulationSvgInputs = getSimulationSvgInputs(
       circuitJson,
-      ...simulationSvgInputs,
-    }),
-    schematicSimulationSvg: convertCircuitJsonToSchematicSimulationSvg({
-      circuitJson,
-      ...simulationSvgInputs,
-    }),
-  }
+      simulationExperiment.simulation_experiment_id,
+    )
+    if (!simulationSvgInputs) return []
+
+    return [
+      {
+        simulationExperimentId: simulationExperiment.simulation_experiment_id,
+        simulationExperimentName: simulationExperiment.name,
+        fileNameSuffix: fileNameSuffixes[index],
+        simulationSvg: convertCircuitJsonToSimulationGraphSvg({
+          circuitJson,
+          ...simulationSvgInputs,
+        }),
+        schematicSimulationSvg: convertCircuitJsonToSchematicSimulationSvg({
+          circuitJson,
+          ...simulationSvgInputs,
+        }),
+      },
+    ]
+  })
 }

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -105,6 +105,36 @@ const currentSimulationCircuitJson = [
   },
 ]
 
+const multiSimulationCircuitJson = [
+  "Root Fast",
+  "Root Slow",
+  "Input Group",
+  "Input-Group",
+].flatMap((name, index) => {
+  const simulationExperimentId = `simulation_experiment_${index}`
+  return [
+    {
+      type: "simulation_experiment",
+      simulation_experiment_id: simulationExperimentId,
+      name,
+      experiment_type: "spice_transient_analysis",
+      time_per_step: 0.25,
+      start_time_ms: 0,
+      end_time_ms: 1,
+    },
+    {
+      type: "simulation_transient_voltage_graph",
+      simulation_transient_voltage_graph_id: `simulation_transient_voltage_graph_${index}`,
+      simulation_experiment_id: simulationExperimentId,
+      voltage_levels: [0, index + 1, 0],
+      time_per_step: 0.5,
+      start_time_ms: 0,
+      end_time_ms: 1,
+      name,
+    },
+  ]
+})
+
 const writeBoostSimulationCircuit = async (tmpDir: string) => {
   const circuitPath = path.join(tmpDir, "simulation.circuit.tsx")
   await writeFile(circuitPath, boostSimulationCircuitCode)
@@ -249,6 +279,40 @@ test("build --simulation-svgs includes current graphs", async () => {
   )
   expect(simulationSvg).toContain("<svg")
   expect(simulationSvg).toContain("I(R1)")
+}, 30_000)
+
+test("build emits a named simulation SVG for every experiment", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "multi-sim.circuit.json")
+  await writeFile(circuitPath, JSON.stringify(multiSimulationCircuitJson))
+
+  await runCommand(
+    `tsci build --simulation-svgs --simulation-schematic-svgs ${circuitPath}`,
+  )
+
+  const outputDir = path.join(tmpDir, "dist", "multi-sim")
+  const suffixes = ["root-fast", "root-slow", "input-group", "input-group-2"]
+  for (const [index, suffix] of suffixes.entries()) {
+    const simulationSvg = await readFile(
+      path.join(outputDir, `simulation-${suffix}.svg`),
+      "utf-8",
+    )
+    const schematicSimulationSvg = await readFile(
+      path.join(outputDir, `simulation-schematic-${suffix}.svg`),
+      "utf-8",
+    )
+    expect(simulationSvg).toContain(
+      `data-simulation-experiment-id="simulation_experiment_${index}"`,
+    )
+    expect(schematicSimulationSvg).toContain(
+      `data-simulation-experiment-id="simulation_experiment_${index}"`,
+    )
+  }
+
+  expect(stat(path.join(outputDir, "simulation.svg"))).rejects.toBeTruthy()
+  expect(
+    stat(path.join(outputDir, "simulation-schematic.svg")),
+  ).rejects.toBeTruthy()
 }, 30_000)
 
 test("build --simulation-schematic-svgs generates only simulation-schematic.svg", async () => {

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -99,6 +99,36 @@ const currentSimulationCircuitJson = [
   },
 ]
 
+const multiSimulationCircuitJson = [
+  "Root Fast",
+  "Root Slow",
+  "Input Group",
+  "Output Group",
+].flatMap((name, index) => {
+  const simulationExperimentId = `simulation_experiment_${index}`
+  return [
+    {
+      type: "simulation_experiment",
+      simulation_experiment_id: simulationExperimentId,
+      name,
+      experiment_type: "spice_transient_analysis",
+      time_per_step: 0.25,
+      start_time_ms: 0,
+      end_time_ms: 1,
+    },
+    {
+      type: "simulation_transient_voltage_graph",
+      simulation_transient_voltage_graph_id: `simulation_transient_voltage_graph_${index}`,
+      simulation_experiment_id: simulationExperimentId,
+      voltage_levels: [0, index + 1, 0],
+      time_per_step: 0.5,
+      start_time_ms: 0,
+      end_time_ms: 1,
+      name,
+    },
+  ]
+})
+
 test("snapshot command creates SVG snapshots", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
@@ -270,6 +300,51 @@ test("snapshot command creates simulation SVG snapshots for current graphs", asy
   expect(simulationSnapshot).toContain("I(R1)")
   expect(schematicSimulationSnapshot).toContain("<svg")
   expect(schematicSimulationSnapshot).toContain("I(R1)")
+}, 30_000)
+
+test("snapshot command creates named snapshots for every simulation", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitFileName = "multi-sim.circuit.json"
+  await Bun.write(
+    join(tmpDir, circuitFileName),
+    JSON.stringify(multiSimulationCircuitJson),
+  )
+
+  const { stdout: updateStdout } = await runCommand(
+    `tsci snapshot ${circuitFileName} --update --simulation-only`,
+  )
+
+  const snapshotDir = join(tmpDir, "__snapshots__")
+  const suffixes = ["root-fast", "root-slow", "input-group", "output-group"]
+  for (const [index, suffix] of suffixes.entries()) {
+    const simulationSnapshotName = `multi-sim.circuit-simulation-${suffix}.snap.svg`
+    const schematicSimulationSnapshotName = `multi-sim.circuit-schematic-simulation-${suffix}.snap.svg`
+    expect(updateStdout).toContain(
+      `✅ ${join("__snapshots__", simulationSnapshotName)}`,
+    )
+    expect(updateStdout).toContain(
+      `✅ ${join("__snapshots__", schematicSimulationSnapshotName)}`,
+    )
+
+    const simulationSnapshot = await Bun.file(
+      join(snapshotDir, simulationSnapshotName),
+    ).text()
+    const schematicSimulationSnapshot = await Bun.file(
+      join(snapshotDir, schematicSimulationSnapshotName),
+    ).text()
+    expect(simulationSnapshot).toContain(
+      `data-simulation-experiment-id="simulation_experiment_${index}"`,
+    )
+    expect(schematicSimulationSnapshot).toContain(
+      `data-simulation-experiment-id="simulation_experiment_${index}"`,
+    )
+  }
+
+  expect(updateStdout).toContain("Created snapshots")
+  const { stdout: testStdout } = await runCommand(
+    `tsci snapshot ${circuitFileName} --simulation-only`,
+  )
+  expect(testStdout).toContain("All snapshots match")
 }, 30_000)
 
 test("snapshot command --simulation-only rejects other snapshot type filters", async () => {

--- a/tests/shared/simulation-svg-assets.test.ts
+++ b/tests/shared/simulation-svg-assets.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getSimulationSvgAssetsFromCircuitJson } from "lib/shared/simulation-svg-assets"
+
+test("simulation SVG assets are separated and receive collision-safe names", () => {
+  const circuitJson = ["Root", "Root", "Root-2", "Group"].flatMap(
+    (name, index) => {
+      const simulationExperimentId = `simulation_experiment_${index}`
+      return [
+        {
+          type: "simulation_experiment",
+          simulation_experiment_id: simulationExperimentId,
+          name,
+          experiment_type: "spice_transient_analysis",
+          time_per_step: 0.5,
+          start_time_ms: 0,
+          end_time_ms: 1,
+        },
+        {
+          type: "simulation_transient_voltage_graph",
+          simulation_transient_voltage_graph_id: `simulation_transient_voltage_graph_${index}`,
+          simulation_experiment_id: simulationExperimentId,
+          voltage_levels: [0, index + 1, 0],
+          time_per_step: 0.5,
+          start_time_ms: 0,
+          end_time_ms: 1,
+          name,
+        },
+      ]
+    },
+  ) as AnyCircuitElement[]
+
+  const assets = getSimulationSvgAssetsFromCircuitJson(circuitJson)
+
+  expect(assets.map((asset) => asset.fileNameSuffix)).toEqual([
+    "root",
+    "root-2",
+    "root-2-2",
+    "group",
+  ])
+  for (const [index, asset] of assets.entries()) {
+    expect(asset.simulationSvg).toContain(
+      `data-simulation-experiment-id="simulation_experiment_${index}"`,
+    )
+    expect(asset.simulationSvg).toContain(
+      `data-simulation-transient-voltage-graph-id="simulation_transient_voltage_graph_${index}"`,
+    )
+  }
+})


### PR DESCRIPTION
## Summary

- generate simulation graph and schematic SVG assets for every simulation experiment
- use readable, collision-safe experiment-name suffixes when a circuit contains multiple simulations
- preserve `simulation.svg` and `simulation-schematic.svg` for single-simulation circuits
- make `tsci snapshot --simulation-only` create and compare one graph/schematic snapshot pair per simulation
- report every generated simulation filename in build output

## Why

The CLI asset pipeline previously selected only the first `simulation_experiment`, so later experiments had no exported SVG or snapshot.

## Impact

Multi-simulation builds now emit files such as `simulation-root-fast.svg` and `simulation-schematic-root-fast.svg`. Existing single-simulation filenames remain backward compatible. The behavior of `tsci simulate analog` is unchanged by this PR.

## Validation

- `bunx tsc --noEmit`
- `bun test tests/shared/simulation-svg-assets.test.ts tests/cli/build/build-output-flags.test.ts tests/cli/snapshot/snapshot.test.ts tests/cli/simulate/simulate.test.ts` (37 passing)

