### PR TITLE
update easyeda to 0.0.275

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "debug": "^4.4.0",
         "delay": "^6.0.0",
         "dsn-converter": "^0.0.90",
-        "easyeda": "^0.0.269",
+        "easyeda": "^0.0.275",
         "fuse.js": "^7.1.0",
         "get-port": "^7.1.0",
         "globby": "^14.1.0",
@@ -601,7 +601,7 @@
 
     "earcut": ["earcut@3.2.3", "", {}, "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q=="],
 
-    "easyeda": ["easyeda@0.0.269", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda": "dist/main.cjs", "easyeda-converter": "dist/main.cjs" } }, "sha512-uhtMsYxs6K3V82CS18cw5pCPJ45KYqoc4HzMnrA0pIFWAPO6fEd1Z/w0QBK803ngEtiD+GIVjIZm4REKxzQiEQ=="],
+    "easyeda": ["easyeda@0.0.275", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-fzM5mzM1vrh6Pll+4JMKDSyFmnnKjCvIDbWuaqu3gxmquRbpbqYYbwt03/u7OEryROQw3N+P3vKjQt4pjo+QpA=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "debug": "^4.4.0",
     "delay": "^6.0.0",
     "dsn-converter": "^0.0.90",
-    "easyeda": "^0.0.269",
+    "easyeda": "^0.0.275",
     "fuse.js": "^7.1.0",
     "get-port": "^7.1.0",
     "globby": "^14.1.0",


### PR DESCRIPTION
## Summary

- update `easyeda` from `^0.0.269` to `^0.0.275`
- refresh the Bun lockfile entry and integrity hash

## Why

Keeps the CLI on the latest published `easyeda` release while preserving the existing semver range style.

## Impact

The CLI's EasyEDA/JLCPCB import path now builds against `easyeda` 0.0.275. No application code changes are included.

## Validation

- `bun install --frozen-lockfile`
- `bun run format:check`
- `bun run build`
- direct smoke import of every `easyeda` export used by `lib/import/import-component-from-jlcpcb.ts`
- `bun test` (the suite still has unrelated integration failures: an init timeout and missing temporary/external modules in simulation/linking tests)