### PR TITLE
Use sheet-aware schematic placement analysis

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@tscircuit/check-shorts": "https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.12.tgz",
         "@tscircuit/circuit-json-placement-analysis": "^0.0.6",
         "@tscircuit/circuit-json-routing-analysis": "^0.0.6",
-        "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#b6d5fe675adc26a2fc988aa081e6fb51e6bf696a",
+        "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
         "@tscircuit/eval": "^0.0.1016",
         "@tscircuit/fake-snippets": "^0.0.182",
         "@tscircuit/file-server": "^0.0.32",
@@ -319,7 +319,7 @@
 
     "@tscircuit/circuit-json-routing-analysis": ["@tscircuit/circuit-json-routing-analysis@0.0.6", "", { "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "sha512-JRmCqieAV7janGaDvWvwFEbFt8xjf5bf6cBDMb3qM3hgR0tv71Dk8P0ClZLJ1I6FWE/PwtIS8h+24ehDHfgW2A=="],
 
-    "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#b6d5fe6", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-b6d5fe6", "sha512-+4c9n3cdvfRJtCWd+GH9/05N/kEDlhxg7wVeJpMB0zed1JINMAOQvN6/g36e5KjaBO09KDfeql5HV9xSwighNQ=="],
+    "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-bb0b41d"],
 
     "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@tscircuit/check-shorts": "https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.12.tgz",
     "@tscircuit/circuit-json-placement-analysis": "^0.0.6",
     "@tscircuit/circuit-json-routing-analysis": "^0.0.6",
-    "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#b6d5fe675adc26a2fc988aa081e6fb51e6bf696a",
+    "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
     "@tscircuit/eval": "^0.0.1016",
     "@tscircuit/fake-snippets": "^0.0.182",
     "@tscircuit/file-server": "^0.0.32",

--- a/tests/cli/check/check-schematic-placement-multi-sheet.test.ts
+++ b/tests/cli/check/check-schematic-placement-multi-sheet.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { rm, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { checkSchematicPlacement } from "../../../cli/check/schematic-placement/register"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const circuitCode = `
+export default () => (
+  <board width="20mm" height="10mm">
+    <schematicsheet name="power" displayName="Power" sheetIndex={1} />
+    <schematicsheet name="control" displayName="Control" sheetIndex={2} />
+    <resistor
+      resistance="1k"
+      name="R1"
+      schX={0}
+      schY={0}
+      schSheetName="power"
+    />
+    <capacitor
+      capacitance="1uF"
+      name="C1"
+      schX={0}
+      schY={0}
+      schOrientation="vertical"
+      schSheetName="control"
+    />
+  </board>
+)
+`
+
+test("schematic placement ignores overlaps across sheets", async () => {
+  const { runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(
+    process.cwd(),
+    `tmp-check-schematic-placement-sheets-${Date.now()}-${Math.random().toString(36).slice(2)}.tsx`,
+  )
+
+  try {
+    await writeFile(circuitPath, circuitCode)
+
+    const analysis = await checkSchematicPlacement(circuitPath)
+    const { stdout, stderr, exitCode } = await runCommand(
+      `tsci check schematic-placement ${circuitPath}`,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stderr).toBe("")
+    expect(analysis).not.toContain("<SchematicPlacementIssues>")
+    expect(stdout).not.toContain("<SchematicPlacementIssues>")
+    expect(stdout).toContain('componentName="R1"')
+    expect(stdout).toContain('componentName="C1"')
+  } finally {
+    await rm(circuitPath, { force: true })
+  }
+}, 20_000)


### PR DESCRIPTION
## Summary

- update the schematic placement analyzer to its merged multi-sheet implementation
- add a CLI regression proving coincident components on separate sheets do not produce placement issues

## Root cause

The CLI still bundled an analyzer revision from before schematic-sheet support was merged. That made `tsci check schematic-placement` compare components and net labels across separate sheet coordinate spaces.

## Validation

- `bun test tests/cli/check/check-schematic-placement.test.ts tests/cli/check/check-schematic-placement-multi-sheet.test.ts`
- `bun run format:check`
- `bunx tsc --noEmit`
