### PR TITLE
add proxy cookie leak repro test

### DIFF
--- a/tests/cli/dev/proxy-cookie-isolation.test.ts
+++ b/tests/cli/dev/proxy-cookie-isolation.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test"
+import { createHttpServer } from "lib/server/createHttpServer"
+import getPort from "get-port"
+import * as http from "node:http"
+
+const listenOnRandomPort = (server: http.Server) =>
+  new Promise<number>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject)
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        reject(new Error("Expected the target server to listen on a TCP port"))
+        return
+      }
+      resolve(address.port)
+    })
+  })
+
+const closeServer = (server: http.Server) =>
+  new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+
+test("dev proxy does not forward localhost cookies to the target", async () => {
+  let targetCookie: string | undefined
+  const targetServer = http.createServer((req, res) => {
+    targetCookie = req.headers.cookie
+    res.writeHead(200, { "Content-Type": "application/json" })
+    res.end(JSON.stringify({ ok: true }))
+  })
+  const targetPort = await listenOnRandomPort(targetServer)
+
+  const devServerPort = await getPort()
+  const { server: devServer } = await createHttpServer({
+    port: devServerPort,
+  })
+
+  try {
+    const syntheticPosthogCookie = encodeURIComponent(
+      JSON.stringify({
+        $device_id: "synthetic-device-id",
+        distinct_id: "anonymous:synthetic-user",
+        $initial_person_info: {
+          r: "$direct",
+          u: `http://localhost:${devServerPort}/`,
+        },
+      }),
+    )
+
+    const response = await fetch(
+      `http://localhost:${devServerPort}/api/proxy`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Cookie: `ph_test_posthog=${syntheticPosthogCookie}`,
+          "X-Target-Url": `http://127.0.0.1:${targetPort}/components/search`,
+          "X-Sender-Cookie": "",
+        },
+        body: "wd=C2765186",
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(targetCookie).toBeUndefined()
+  } finally {
+    await Promise.all([closeServer(devServer), closeServer(targetServer)])
+  }
+})


### PR DESCRIPTION
## Summary

- add a local-only integration test for the CLI dev server's `/api/proxy` route
- send a synthetic PostHog-style localhost cookie through the proxy
- verify that the upstream target does not receive proxy-origin cookies
- avoid any dependency on EasyEDA or other external services

## Why

A standard USB-C connector can fail to load in `tsci dev` because the browser sends its localhost analytics cookie to `/api/proxy`. The proxy currently forwards that cookie to EasyEDA when `X-Sender-Cookie` is empty, and EasyEDA's CloudFront/WAF rejects the request with `403 Forbidden`.

The test reproduces the header leak directly using local CLI and target HTTP servers.

## Current result

This draft intentionally contains a failing regression test until the proxy fix is implemented:

```text
expect(received).toBeUndefined()
Received: "ph_test_posthog=..."
```

## Validation

- `bun run format:check` — passes
- `bun test tests/cli/dev/proxy-cookie-isolation.test.ts` — fails as expected, proving the synthetic localhost cookie reaches the target