### PR TITLE
Add chip-focused PCB snapshots

### DIFF
--- a/cli/snapshot/register.ts
+++ b/cli/snapshot/register.ts
@@ -23,6 +23,14 @@ export const registerSnapshot = (program: Command) => {
       "--layer <layer>",
       "Generate a PCB snapshot for one layer: top or bottom (implies --pcb-only)",
     )
+    .option(
+      "--chip <name>",
+      "Crop the PCB snapshot around a named chip/component (implies --pcb-only)",
+    )
+    .option(
+      "--chip-padding <millimeters>",
+      "Padding around a focused chip in millimeters (default: 2)",
+    )
     .option("--disable-parts-engine", "Disable the parts engine")
     .option("--show-courtyards", "Show courtyard outlines in PCB snapshots")
     .option(
@@ -49,6 +57,8 @@ export const registerSnapshot = (program: Command) => {
           disablePartsEngine?: boolean
           showCourtyards?: boolean
           layer?: string
+          chip?: string
+          chipPadding?: string
           cameraPreset?: string
           ci?: boolean
           test?: boolean
@@ -83,6 +93,35 @@ export const registerSnapshot = (program: Command) => {
         }
 
         if (
+          options.chip &&
+          (options.schematicOnly ||
+            options.simulationOnly ||
+            options["3d"] ||
+            options.cameraPreset)
+        ) {
+          console.error(
+            "--chip cannot be combined with --schematic-only, --simulation-only, --3d, or --camera-preset.",
+          )
+          process.exit(1)
+        }
+
+        if (options.chipPadding && !options.chip) {
+          console.error("--chip-padding requires --chip.")
+          process.exit(1)
+        }
+
+        const chipPadding = options.chipPadding
+          ? Number(options.chipPadding)
+          : undefined
+        if (
+          chipPadding !== undefined &&
+          (!Number.isFinite(chipPadding) || chipPadding < 0)
+        ) {
+          console.error("--chip-padding must be a non-negative number.")
+          process.exit(1)
+        }
+
+        if (
           options.simulationOnly &&
           (options.pcbOnly ||
             options.schematicOnly ||
@@ -97,7 +136,7 @@ export const registerSnapshot = (program: Command) => {
         }
 
         let pcbOnly = options.pcbOnly ?? false
-        if (pcbLayer) {
+        if (pcbLayer || options.chip) {
           pcbOnly = true
         }
 
@@ -112,6 +151,8 @@ export const registerSnapshot = (program: Command) => {
           schematicOnly: options.schematicOnly ?? false,
           simulationOnly: options.simulationOnly ?? false,
           pcbLayer,
+          pcbComponentName: options.chip,
+          pcbComponentPadding: chipPadding,
           forceUpdate: options.forceUpdate ?? false,
           filePaths: target ? [target] : [],
           platformConfig: options.disablePartsEngine

--- a/cli/snapshot/worker-pool.ts
+++ b/cli/snapshot/worker-pool.ts
@@ -81,6 +81,8 @@ export const snapshotFilesWithWorkerPool = async (options: {
         createDiff: job.options.createDiff,
         cameraPreset: job.options.cameraPreset,
         pcbLayer: job.options.pcbLayer,
+        pcbComponentName: job.options.pcbComponentName,
+        pcbComponentPadding: job.options.pcbComponentPadding,
       },
     }),
     isLogMessage: (message) => message.message_type === "worker_log",

--- a/cli/snapshot/worker-snapshot-handlers.ts
+++ b/cli/snapshot/worker-snapshot-handlers.ts
@@ -20,6 +20,8 @@ type SnapshotWorkerOptions = {
   createDiff: boolean
   cameraPreset?: CameraPreset
   pcbLayer?: VisibleLayerRef
+  pcbComponentName?: string
+  pcbComponentPadding?: number
 }
 
 export const handleSnapshotFile = async (
@@ -51,6 +53,8 @@ export const handleSnapshotFile = async (
     createDiff: options.createDiff,
     cameraPreset: options.cameraPreset,
     pcbLayer: options.pcbLayer,
+    pcbComponentName: options.pcbComponentName,
+    pcbComponentPadding: options.pcbComponentPadding,
   })
 
   return {

--- a/cli/snapshot/worker-types.ts
+++ b/cli/snapshot/worker-types.ts
@@ -21,6 +21,8 @@ export type SnapshotFileMessage = {
     createDiff: boolean
     cameraPreset?: CameraPreset
     pcbLayer?: VisibleLayerRef
+    pcbComponentName?: string
+    pcbComponentPadding?: number
   }
 }
 

--- a/lib/shared/get-pcb-component-viewport.ts
+++ b/lib/shared/get-pcb-component-viewport.ts
@@ -1,0 +1,77 @@
+import type { AnyCircuitElement, PcbComponent } from "circuit-json"
+
+type SourceComponent = Extract<AnyCircuitElement, { type: "source_component" }>
+
+export type PcbViewport = {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+export const DEFAULT_PCB_COMPONENT_PADDING_MM = 2
+
+export const getPcbComponentViewport = (
+  circuitJson: AnyCircuitElement[],
+  componentName: string,
+  padding = DEFAULT_PCB_COMPONENT_PADDING_MM,
+): PcbViewport => {
+  const sourceComponents = circuitJson.filter(
+    (element): element is SourceComponent =>
+      element.type === "source_component",
+  )
+  const sourceComponentIds = new Set(
+    sourceComponents
+      .filter((component) => component.name === componentName)
+      .map((component) => component.source_component_id),
+  )
+  const matchingPcbComponents = circuitJson.filter(
+    (element): element is PcbComponent =>
+      element.type === "pcb_component" &&
+      sourceComponentIds.has(element.source_component_id),
+  )
+
+  if (matchingPcbComponents.length === 0) {
+    const availableComponentNames = sourceComponents
+      .filter((sourceComponent) =>
+        circuitJson.some(
+          (element) =>
+            element.type === "pcb_component" &&
+            element.source_component_id === sourceComponent.source_component_id,
+        ),
+      )
+      .map((component) => component.name)
+      .sort()
+
+    const availableComponentsMessage =
+      availableComponentNames.length > 0
+        ? ` Available PCB components: ${availableComponentNames.join(", ")}.`
+        : ""
+
+    throw new Error(
+      `PCB component "${componentName}" was not found.${availableComponentsMessage}`,
+    )
+  }
+
+  if (matchingPcbComponents.length > 1) {
+    throw new Error(
+      `PCB component name "${componentName}" is ambiguous (${matchingPcbComponents.length} matches).`,
+    )
+  }
+
+  const component = matchingPcbComponents[0]
+  const rotationRadians = (Number(component.rotation) * Math.PI) / 180
+  const rotatedWidth =
+    Math.abs(component.width * Math.cos(rotationRadians)) +
+    Math.abs(component.height * Math.sin(rotationRadians))
+  const rotatedHeight =
+    Math.abs(component.width * Math.sin(rotationRadians)) +
+    Math.abs(component.height * Math.cos(rotationRadians))
+
+  return {
+    minX: component.center.x - rotatedWidth / 2 - padding,
+    minY: component.center.y - rotatedHeight / 2 - padding,
+    maxX: component.center.x + rotatedWidth / 2 + padding,
+    maxY: component.center.y + rotatedHeight / 2 + padding,
+  }
+}

--- a/lib/shared/process-snapshot-file.ts
+++ b/lib/shared/process-snapshot-file.ts
@@ -14,6 +14,7 @@ import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-jso
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import { getSimulationSvgAssetsFromCircuitJson } from "lib/shared/simulation-svg-assets"
 import { compareAndCreateDiff } from "./compare-images"
+import { getPcbComponentViewport } from "./get-pcb-component-viewport"
 import { isCircuitJsonFile } from "./is-circuit-json-file"
 
 export type ProcessSnapshotFileOptions = {
@@ -31,6 +32,8 @@ export type ProcessSnapshotFileOptions = {
   createDiff: boolean
   cameraPreset?: CameraPreset
   pcbLayer?: VisibleLayerRef
+  pcbComponentName?: string
+  pcbComponentPadding?: number
 }
 
 export type ProcessSnapshotFileResult = {
@@ -57,6 +60,8 @@ export const processSnapshotFile = async ({
   createDiff,
   cameraPreset,
   pcbLayer,
+  pcbComponentName,
+  pcbComponentPadding,
 }: ProcessSnapshotFileOptions): Promise<ProcessSnapshotFileResult> => {
   const relativeFilePath = path.relative(projectDir, file)
   const successPaths: string[] = []
@@ -102,9 +107,17 @@ export const processSnapshotFile = async ({
 
   if (!simulationOnly) {
     try {
+      const viewport = pcbComponentName
+        ? getPcbComponentViewport(
+            circuitJson,
+            pcbComponentName,
+            pcbComponentPadding,
+          )
+        : undefined
       pcbSvg = convertCircuitJsonToPcbSvg(circuitJson, {
         ...pcbSnapshotSettings,
         layer: pcbLayer,
+        viewport,
       })
     } catch (error) {
       const errorMessage =
@@ -235,9 +248,14 @@ export const processSnapshotFile = async ({
     | { type: "3d"; content: Uint8Array; isBinary: true }
   > = []
   if (!simulationOnly && (pcbOnly || !schematicOnly)) {
-    let pcbSnapshotType: "pcb" | VisibleLayerRef = "pcb"
+    let pcbSnapshotType: string | VisibleLayerRef = "pcb"
     if (pcbLayer) {
       pcbSnapshotType = pcbLayer
+    }
+    if (pcbComponentName) {
+      const safeComponentName =
+        pcbComponentName.replace(/[^a-zA-Z0-9._-]+/g, "_") || "component"
+      pcbSnapshotType = `${pcbSnapshotType}-${safeComponentName}`
     }
     snapshots.push({
       type: pcbSnapshotType,

--- a/lib/shared/snapshot-project.ts
+++ b/lib/shared/snapshot-project.ts
@@ -44,6 +44,10 @@ type SnapshotOptions = {
   cameraPreset?: CameraPreset
   /** Limit PCB snapshots to one layer */
   pcbLayer?: VisibleLayerRef
+  /** Crop PCB snapshots to a named component */
+  pcbComponentName?: string
+  /** Padding around a focused PCB component in millimeters */
+  pcbComponentPadding?: number
   /** Number of files to process in parallel (default: 1) */
   concurrency?: number
   onExit?: (code: number) => void
@@ -78,6 +82,8 @@ export const snapshotProject = async ({
   createDiff = false,
   cameraPreset,
   pcbLayer,
+  pcbComponentName,
+  pcbComponentPadding,
   concurrency = 1,
 }: SnapshotOptions = {}) => {
   // --camera-preset implies --3d
@@ -188,6 +194,8 @@ export const snapshotProject = async ({
           createDiff,
           cameraPreset,
           pcbLayer,
+          pcbComponentName,
+          pcbComponentPadding,
         },
         stopOnFailure: true,
         onLog: (lines) => {
@@ -232,6 +240,8 @@ export const snapshotProject = async ({
         createDiff,
         cameraPreset,
         pcbLayer,
+        pcbComponentName,
+        pcbComponentPadding,
       })
 
       processResult(result)

--- a/tests/cli/snapshot/snapshot-chip.test.ts
+++ b/tests/cli/snapshot/snapshot-chip.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import { join } from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const focusedSnapshotCircuitJson = [
+  {
+    type: "pcb_board",
+    pcb_board_id: "pcb_board_0",
+    center: { x: 0, y: 0 },
+    width: 40,
+    height: 20,
+    material: "fr4",
+    thickness: 1.6,
+    num_layers: 2,
+  },
+  {
+    type: "source_component",
+    source_component_id: "source_component_0",
+    name: "U1",
+    ftype: "simple_chip",
+  },
+  {
+    type: "source_component",
+    source_component_id: "source_component_1",
+    name: "U2",
+    ftype: "simple_chip",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_component_0",
+    source_component_id: "source_component_0",
+    center: { x: -10, y: 0 },
+    width: 4,
+    height: 4,
+    layer: "top",
+    rotation: 0,
+    obstructs_within_bounds: true,
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_component_1",
+    source_component_id: "source_component_1",
+    center: { x: 10, y: 0 },
+    width: 4,
+    height: 4,
+    layer: "top",
+    rotation: 0,
+    obstructs_within_bounds: true,
+  },
+]
+
+test("snapshot command crops a PCB snapshot around a named chip", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitJsonPath = join(tmpDir, "two-chips.circuit.json")
+  await Bun.write(circuitJsonPath, JSON.stringify(focusedSnapshotCircuitJson))
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    "tsci snapshot two-chips.circuit.json --update --chip U1 --chip-padding 3",
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("Created snapshots")
+  expect(stdout).toContain(
+    `✅ ${join("__snapshots__", "two-chips.circuit-pcb-U1.snap.svg")}`,
+  )
+
+  const snapshotDir = join(tmpDir, "__snapshots__")
+  expect(
+    fs.existsSync(join(snapshotDir, "two-chips.circuit-pcb-U1.snap.svg")),
+  ).toBe(true)
+  expect(
+    fs.existsSync(join(snapshotDir, "two-chips.circuit-schematic.snap.svg")),
+  ).toBe(false)
+})
+
+test("snapshot command reports available components for an unknown chip", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await Bun.write(
+    join(tmpDir, "two-chips.circuit.json"),
+    JSON.stringify(focusedSnapshotCircuitJson),
+  )
+
+  const { stderr, exitCode } = await runCommand(
+    "tsci snapshot two-chips.circuit.json --update --chip U3",
+  )
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain(
+    'PCB component "U3" was not found. Available PCB components: U1, U2.',
+  )
+})

--- a/tests/shared/get-pcb-component-viewport.test.ts
+++ b/tests/shared/get-pcb-component-viewport.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getPcbComponentViewport } from "lib/shared/get-pcb-component-viewport"
+
+const circuitJson = [
+  {
+    type: "source_component",
+    source_component_id: "source_component_0",
+    name: "U1",
+    ftype: "simple_chip",
+  },
+  {
+    type: "source_component",
+    source_component_id: "source_component_1",
+    name: "U2",
+    ftype: "simple_chip",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_component_0",
+    source_component_id: "source_component_0",
+    center: { x: 10, y: 20 },
+    width: 4,
+    height: 2,
+    layer: "top",
+    rotation: 90,
+    obstructs_within_bounds: true,
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_component_1",
+    source_component_id: "source_component_1",
+    center: { x: -10, y: -20 },
+    width: 1,
+    height: 1,
+    layer: "top",
+    rotation: 0,
+    obstructs_within_bounds: true,
+  },
+] as AnyCircuitElement[]
+
+test("gets a padded viewport for a rotated PCB component", () => {
+  expect(getPcbComponentViewport(circuitJson, "U1", 2)).toEqual({
+    minX: 7,
+    minY: 16,
+    maxX: 13,
+    maxY: 24,
+  })
+})
+
+test("lists available components when the requested component is missing", () => {
+  expect(() => getPcbComponentViewport(circuitJson, "U3")).toThrow(
+    'PCB component "U3" was not found. Available PCB components: U1, U2.',
+  )
+})


### PR DESCRIPTION
## What

- add `tsci snapshot --chip <name>` to crop PCB snapshots around a named source component
- make `--chip` imply `--pcb-only` and retain nearby traces, vias, pads, and board geometry inside the viewport
- add `--chip-padding <millimeters>` with a 2 mm default
- support focused top/bottom layer snapshots through the existing `--layer` option
- write focused snapshots with distinct names such as `board-pcb-U1.snap.svg`
- report available PCB component names when the requested component cannot be found

## Why

Dense packages such as BGAs are difficult to inspect in whole-board snapshots. A component-focused viewport makes escape routing, clearance issues, and apparent layer crossings legible without post-processing the SVG.

## Impact

This is additive and does not change existing snapshot output unless `--chip` is supplied. The option is intentionally PCB-only; unsupported schematic, simulation, and 3D combinations fail with a clear message.

## Checks

- `bun test tests/shared/get-pcb-component-viewport.test.ts tests/cli/snapshot/snapshot-chip.test.ts`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`
- manually generated all-layer, top-only, and bottom-only focused snapshots for a 144-pin BGA autorouting result