### PR TITLE
Stack multi-sheet schematic snapshots

### DIFF
--- a/lib/shared/process-snapshot-file.ts
+++ b/lib/shared/process-snapshot-file.ts
@@ -6,7 +6,7 @@ import type { AnyCircuitElement, VisibleLayerRef } from "circuit-json"
 import { renderCircuitJsonTo3dPng } from "circuit-json-to-3d-png"
 import {
   convertCircuitJsonToPcbSvg,
-  convertCircuitJsonToSchematicSvg,
+  convertCircuitJsonToStackedSchematicSheetsSvg,
 } from "circuit-to-svg"
 import kleur from "kleur"
 import type { CameraPreset } from "circuit-json-to-3d-png"
@@ -123,7 +123,7 @@ export const processSnapshotFile = async ({
     }
 
     try {
-      schSvg = convertCircuitJsonToSchematicSvg(circuitJson)
+      schSvg = convertCircuitJsonToStackedSchematicSheetsSvg(circuitJson)
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error)

--- a/tests/cli/snapshot/snapshot-multiple-schematic-sheets.test.ts
+++ b/tests/cli/snapshot/snapshot-multiple-schematic-sheets.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { join } from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("snapshot stacks multiple schematic sheets into one SVG", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  await Bun.write(
+    join(tmpDir, "multiple-sheets.circuit.tsx"),
+    `
+      export default () => (
+        <board width="20mm" height="10mm">
+          <schematicsheet
+            name="power"
+            displayName="Power Sheet"
+            sheetIndex={0}
+          />
+          <schematicsheet
+            name="control"
+            displayName="Control Sheet"
+            sheetIndex={1}
+          />
+          <resistor
+            name="R1"
+            resistance="1k"
+            footprint="0402"
+            schSheetName="power"
+          />
+          <capacitor
+            name="C1"
+            capacitance="1uF"
+            footprint="0402"
+            schSheetName="control"
+          />
+        </board>
+      )
+    `,
+  )
+
+  const { exitCode } = await runCommand(
+    "tsci snapshot --update --schematic-only",
+  )
+  expect(exitCode).toBe(0)
+
+  const schematicSvg = await Bun.file(
+    join(tmpDir, "__snapshots__", "multiple-sheets.circuit-schematic.snap.svg"),
+  ).text()
+
+  expect(schematicSvg).toContain('class="tscircuit-stacked-schematic"')
+  expect(schematicSvg.match(/class="stacked-sheet-label"/g)).toHaveLength(2)
+  expect(schematicSvg).toContain("Power Sheet")
+  expect(schematicSvg).toContain("Control Sheet")
+})


### PR DESCRIPTION
## Summary

- render `tsci snapshot` schematic output with `convertCircuitJsonToStackedSchematicSheetsSvg`
- preserve existing single-sheet behavior through `circuit-to-svg`'s fallback
- add an end-to-end regression test for circuits with multiple `<schematicsheet />` elements

## Why

`tsci snapshot` used the single-sheet schematic renderer, so a circuit containing multiple schematic sheets produced a snapshot with only one sheet and silently omitted the rest. The stacked renderer emits every sheet into one SVG, making the snapshot complete while retaining the same output path and single-sheet behavior.

## Validation

- `bun test tests/cli/snapshot/snapshot-multiple-schematic-sheets.test.ts`
- `bun run build`
- `git diff --check`