### PR TITLE
Add schematic PNG build output

### DIFF
--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -40,6 +40,7 @@ export interface BuildCommandOptions {
   svgs?: boolean
   pcbSvgs?: boolean
   pcbPng?: boolean
+  schematicPng?: boolean
   schematicSvgs?: boolean
   simulationSvgs?: boolean
   simulationSchematicSvgs?: boolean

--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -90,6 +90,20 @@ const generatePreviewAssets = async ({
     }
   }
 
+  if (imageFormats.schematicPngs) {
+    try {
+      console.log(`${prefix}Generating schematic PNG...`)
+      const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
+      fs.writeFileSync(
+        path.join(outputDir, "schematic.png"),
+        await convertSvgToPngBuffer(schematicSvg),
+      )
+      console.log(`${prefix}Written schematic.png`)
+    } catch (error) {
+      console.error(`${prefix}Failed to generate schematic PNG:`, error)
+    }
+  }
+
   if (imageFormats.simulationSvgs || imageFormats.simulationSchematicSvgs) {
     try {
       const wroteSimulationSvgs = writeSimulationSvgAssetsFromCircuitJson(

--- a/cli/build/image-format-selection.ts
+++ b/cli/build/image-format-selection.ts
@@ -3,6 +3,7 @@ import type { BuildCommandOptions } from "./build-ci"
 export type BuildImageFormatSelection = {
   threeDPngs: boolean
   pcbPngs: boolean
+  schematicPngs: boolean
   pcbSvgs: boolean
   schematicSvgs: boolean
   simulationSvgs: boolean
@@ -12,6 +13,7 @@ export type BuildImageFormatSelection = {
 export const DEFAULT_IMAGE_FORMAT_SELECTION: BuildImageFormatSelection = {
   threeDPngs: true,
   pcbPngs: false,
+  schematicPngs: false,
   pcbSvgs: true,
   schematicSvgs: true,
   simulationSvgs: false,
@@ -21,6 +23,7 @@ export const DEFAULT_IMAGE_FORMAT_SELECTION: BuildImageFormatSelection = {
 export const EMPTY_IMAGE_FORMAT_SELECTION: BuildImageFormatSelection = {
   threeDPngs: false,
   pcbPngs: false,
+  schematicPngs: false,
   pcbSvgs: false,
   schematicSvgs: false,
   simulationSvgs: false,
@@ -32,6 +35,7 @@ export const hasAnyImageFormatSelected = (
 ) =>
   selection.threeDPngs ||
   selection.pcbPngs ||
+  selection.schematicPngs ||
   selection.pcbSvgs ||
   selection.schematicSvgs ||
   selection.simulationSvgs ||
@@ -41,6 +45,7 @@ const hasNewOutputFlags = (options?: BuildCommandOptions) =>
   Boolean(
     options?.pngs ||
       options?.pcbPng ||
+      options?.schematicPng ||
       options?.svgs ||
       options?.pcbSvgs ||
       options?.simulationSvgs ||
@@ -77,6 +82,7 @@ export const resolveImageFormatSelection = (
     const selection: BuildImageFormatSelection = {
       threeDPngs: Boolean(options?.["3d"] || options?.["3dPng"]),
       pcbPngs: false,
+      schematicPngs: false,
       pcbSvgs: true,
       schematicSvgs: true,
       simulationSvgs: false,
@@ -109,6 +115,9 @@ export const resolveImageFormatSelection = (
   }
   if (options?.pcbPng) {
     selection.pcbPngs = true
+  }
+  if (options?.schematicPng) {
+    selection.schematicPngs = true
   }
   if (options?.schematicSvgs) {
     selection.schematicSvgs = true

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -132,6 +132,10 @@ export const registerBuild = (program: Command) => {
     )
     .option("--pngs", "Generate PNG outputs during build generation")
     .option("--pcb-png", "Generate PCB PNG outputs during build generation")
+    .option(
+      "--schematic-png",
+      "Generate schematic PNG outputs during build generation",
+    )
     .option("--svgs", "Generate SVG outputs during build generation")
     .option("--pcb-svgs", "Generate PCB SVG outputs during build generation")
     .option(
@@ -966,6 +970,7 @@ export const registerBuild = (program: Command) => {
           resolvedOptions?.allImages && "all-images",
           resolvedOptions?.pngs && "pngs",
           resolvedOptions?.pcbPng && "pcb-png",
+          resolvedOptions?.schematicPng && "schematic-png",
           resolvedOptions?.svgs && "svgs",
           resolvedOptions?.pcbSvgs && "pcb-svgs",
           resolvedOptions?.schematicSvgs && "schematic-svgs",

--- a/cli/build/worker-output-generators.ts
+++ b/cli/build/worker-output-generators.ts
@@ -124,6 +124,14 @@ export const writeImageAssetsFromCircuitJson = async (
     )
   }
 
+  if (imageFormats.schematicPngs) {
+    const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson)
+    fs.writeFileSync(
+      path.join(outputDir, "schematic.png"),
+      await convertSvgToPngBuffer(schematicSvg),
+    )
+  }
+
   writeSimulationSvgAssetsFromCircuitJson(circuitJson, outputDir, imageFormats)
 
   if (imageFormats.threeDPngs) {

--- a/tests/cli/build/build-output-flags.test.ts
+++ b/tests/cli/build/build-output-flags.test.ts
@@ -215,6 +215,34 @@ test("build --pcb-png generates only pcb.png", async () => {
   ).rejects.toBeTruthy()
 }, 30_000)
 
+test("build --schematic-png generates only schematic.png", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "preview.circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  await runCommand(`tsci build --schematic-png ${circuitPath}`)
+
+  const schematicPng = await readFile(
+    path.join(tmpDir, "dist", "preview", "schematic.png"),
+  )
+  expect(schematicPng.byteLength).toBeGreaterThan(0)
+  expect(schematicPng[0]).toBe(0x89)
+  expect(schematicPng[1]).toBe(0x50)
+  expect(schematicPng[2]).toBe(0x4e)
+  expect(schematicPng[3]).toBe(0x47)
+
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "pcb.svg")),
+  ).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "schematic.svg")),
+  ).rejects.toBeTruthy()
+  expect(
+    stat(path.join(tmpDir, "dist", "preview", "3d.png")),
+  ).rejects.toBeTruthy()
+}, 30_000)
+
 test("build --svgs generates only pcb.svg and schematic.svg", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "preview.circuit.tsx")

--- a/tests/cli/build/worker-output-courtyards-enabled.test.ts
+++ b/tests/cli/build/worker-output-courtyards-enabled.test.ts
@@ -23,6 +23,7 @@ test("writeImageAssetsFromCircuitJson includes courtyards when showCourtyards is
     imageFormats: {
       pcbSvgs: true,
       pcbPngs: false,
+      schematicPngs: false,
       schematicSvgs: false,
       simulationSvgs: false,
       simulationSchematicSvgs: false,


### PR DESCRIPTION
## Summary

- add `tsci build --schematic-png`
- generate `schematic.png` in both preview-image generation paths
- include the option in build summaries and image-format selection
- add end-to-end coverage that verifies a valid PNG is emitted without unrelated preview outputs

## Why

`tsci build` supports `--pcb-png` but did not provide the equivalent output selector for schematic PNGs. This adds the matching schematic workflow while preserving the existing explicit-output flag behavior.

## Validation

- `bun test tests/cli/build/build-output-flags.test.ts tests/cli/build/worker-output-courtyards-enabled.test.ts --timeout 30000` (15 passed)
- `bun run format:check`
- `bun run build`
- `bun ./cli/main.ts build --help`