### PR TITLE
refactor: implement smart entrypoint fallback in getEntrypoint across all CLI commands

### DIFF
--- a/lib/shared/get-entrypoint.ts
+++ b/lib/shared/get-entrypoint.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import { loadRuntimeProjectConfig } from "lib/project-config"
 import kleur from "kleur"
+import { findBoardFiles } from "./find-board-files"
 
 type EntrypointOptions = {
   filePath?: string
@@ -107,6 +108,16 @@ const validateFilePath = (
   return fs.existsSync(absolutePath) ? absolutePath : null
 }
 
+const findSelectableFiles = (projectDir: string): string[] => {
+  return findBoardFiles({ projectDir })
+    .filter((file) => {
+      const isTypeScript = file.endsWith(".ts") || file.endsWith(".tsx")
+      const isDist = file.includes("/dist/") || file.includes("\\dist\\")
+      return isTypeScript && !isDist && fs.existsSync(file)
+    })
+    .sort()
+}
+
 export const getEntrypoint = async ({
   filePath,
   projectDir = process.cwd(),
@@ -198,6 +209,26 @@ export const getEntrypoint = async ({
         onSuccess(`Detected entrypoint: '${relativePath}'`)
         return entrypoint
       }
+    }
+
+    // Fallback: match dev behavior by finding available board files via standard findBoardFiles utility
+    const selectableFiles = findSelectableFiles(validatedProjectDir)
+    if (selectableFiles.length > 0) {
+      const chosenEntrypoint = path.relative(
+        validatedProjectDir,
+        selectableFiles[0],
+      )
+      if (selectableFiles.length > 1) {
+        const ignoredEntrypoints = selectableFiles
+          .slice(1)
+          .map((entrypoint) => path.relative(validatedProjectDir, entrypoint))
+        onWarning(
+          `Multiple potential entrypoint files found. Choosing '${chosenEntrypoint}' and ignoring: ${ignoredEntrypoints.map((e) => `'${e}'`).join(", ")}.`,
+        )
+      } else {
+        onSuccess(`Detected fallback entrypoint: '${chosenEntrypoint}'`)
+      }
+      return selectableFiles[0]
     }
 
     onError(

--- a/tests/cli/push/push15-custom-entrypoint-fallback.test.ts
+++ b/tests/cli/push/push15-custom-entrypoint-fallback.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+test("should push a package using fallback entrypoint discovery when no index.circuit.tsx or mainEntrypoint exists (Issue #2797)", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture({
+    loggedIn: true,
+  })
+
+  fs.writeFileSync(
+    path.resolve(tmpDir, "package.json"),
+    JSON.stringify({ name: "@tsci/test-user.test-package", version: "1.0.0" }),
+  )
+  fs.writeFileSync(
+    path.resolve(tmpDir, "my-custom-circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm" />',
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand("tsci push")
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("⬆︎ package.json")
+  expect(stdout).toContain("⬆︎ my-custom-circuit.tsx")
+  expect(stdout).toContain('"@tsci/test-user.test-package@1.0.0" published!')
+}, 30_000)

--- a/tests/get-entrypoint.test.ts
+++ b/tests/get-entrypoint.test.ts
@@ -519,3 +519,70 @@ test("getEntrypoint warns when multiple common locations exist", async () => {
   expect(warnings[0]).toContain("Choosing 'index.tsx'")
   expect(warnings[0]).toContain("'src/index.tsx'")
 })
+
+test("getEntrypoint falls back to finding available board/tsx files when standard names are missing (Issue #2797)", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  await fs.writeFile(
+    path.join(tmpDir, "my-custom-board.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const messages: string[] = []
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    onSuccess: (msg) => messages.push(msg),
+  })
+
+  expect(entrypoint).toBe(path.join(tmpDir, "my-custom-board.circuit.tsx"))
+  expect(messages[0]).toBe(
+    "Detected fallback entrypoint: 'my-custom-board.circuit.tsx'",
+  )
+})
+
+test("getEntrypoint fallback ignores generic scripts and selects valid circuit files", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  // Because fallback relies on findBoardFiles, non-board utility files are automatically ignored.
+  await fs.writeFile(
+    path.join(tmpDir, "a-helper.ts"),
+    "export const helper = 42;",
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "utils.ts"),
+    "export const noop = () => {};",
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "my-circuit.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+  })
+
+  expect(entrypoint).toBe(path.join(tmpDir, "my-circuit.circuit.tsx"))
+})
+
+test("getEntrypoint fallback warns when multiple circuit entrypoint files are found", async () => {
+  const { tmpDir } = await getCliTestFixture()
+
+  await fs.writeFile(
+    path.join(tmpDir, "board-a.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+  await fs.writeFile(
+    path.join(tmpDir, "board-b.circuit.tsx"),
+    'export default () => <board width="10mm" height="10mm"></board>',
+  )
+
+  const warnings: string[] = []
+  const entrypoint = await getEntrypoint({
+    projectDir: tmpDir,
+    onWarning: (w) => warnings.push(w),
+  })
+
+  expect(entrypoint).toBe(path.join(tmpDir, "board-a.circuit.tsx"))
+  expect(warnings[0]).toContain("Multiple potential entrypoint files found")
+  expect(warnings[0]).toContain("Choosing 'board-a.circuit.tsx'")
+})


### PR DESCRIPTION
## Terminal screenshot : ( Before Vs After) 
<img width="1920" height="536" alt="area_2026-07-29_00-36-29" src="https://github.com/user-attachments/assets/a80b33b5-0ea0-4908-af92-4147a93cf72a" />

## Verification & Testing
- **Unit Testing:** Added full fallback discovery test coverage in `tests/get-entrypoint.test.ts`.
- **Heuristic Ranking Validation:** Added multi-candidate test proving that board files (`my-circuit.circuit.tsx`) are selected over alphabetically earlier helper modules (`a-helper.ts`, `utils.ts`).
- **E2E Publish Verification:** Created integration test in `tests/cli/push/push15-custom-entrypoint-fallback.test.ts` verifying seamless publishing when standard filenames are absent.
- **CI Readiness:** Verified clean execution across all unit and integration testing suites!