### PR TITLE
Propagate package licenses into KiCad PCM v2

### DIFF
--- a/cli/build/build-kicad-pcm.ts
+++ b/cli/build/build-kicad-pcm.ts
@@ -9,6 +9,7 @@ import { generatePcmAssets } from "lib/shared/generate-pcm-assets"
 import { getPackageAuthor } from "lib/utils/get-package-author"
 import { loadProjectConfig } from "lib/project-config"
 import { resolveKicadLibraryName } from "lib/utils/resolve-kicad-library-name"
+import { assertValidKicadPcmV1License } from "lib/shared/kicad-pcm-license"
 
 export interface BuildKicadPcmOptions {
   entryFile: string
@@ -49,11 +50,7 @@ export async function buildKicadPcm({
   const license =
     typeof packageJson.license === "string" ? packageJson.license.trim() : ""
 
-  if (!license) {
-    throw new Error(
-      'KiCad PCM generation requires a non-empty "license" in package.json',
-    )
-  }
+  assertValidKicadPcmV1License(license)
 
   const libraryName =
     kicadLibraryNameOption ?? resolveKicadLibraryName({ projectDir })

--- a/cli/build/build-kicad-pcm.ts
+++ b/cli/build/build-kicad-pcm.ts
@@ -46,6 +46,14 @@ export async function buildKicadPcm({
   const version = packageJson.version || "1.0.0"
   const author = getPackageAuthor(packageJson.name || "") || "tscircuit"
   const description = packageJson.description || ""
+  const license =
+    typeof packageJson.license === "string" ? packageJson.license.trim() : ""
+
+  if (!license) {
+    throw new Error(
+      'KiCad PCM generation requires a non-empty "license" in package.json',
+    )
+  }
 
   const libraryName =
     kicadLibraryNameOption ?? resolveKicadLibraryName({ projectDir })
@@ -88,6 +96,7 @@ export async function buildKicadPcm({
     version,
     author,
     description,
+    license,
     kicadLibraryPath: kicadLibOutputDir,
     outputDir: pcmOutputDir,
     baseUrl,

--- a/cli/build/build-kicad-pcm.ts
+++ b/cli/build/build-kicad-pcm.ts
@@ -9,7 +9,7 @@ import { generatePcmAssets } from "lib/shared/generate-pcm-assets"
 import { getPackageAuthor } from "lib/utils/get-package-author"
 import { loadProjectConfig } from "lib/project-config"
 import { resolveKicadLibraryName } from "lib/utils/resolve-kicad-library-name"
-import { assertValidKicadPcmV1License } from "lib/shared/kicad-pcm-license"
+import { assertValidKicadPcmV2License } from "lib/shared/kicad-pcm-license"
 
 export interface BuildKicadPcmOptions {
   entryFile: string
@@ -47,10 +47,8 @@ export async function buildKicadPcm({
   const version = packageJson.version || "1.0.0"
   const author = getPackageAuthor(packageJson.name || "") || "tscircuit"
   const description = packageJson.description || ""
-  const license =
-    typeof packageJson.license === "string" ? packageJson.license.trim() : ""
-
-  assertValidKicadPcmV1License(license)
+  assertValidKicadPcmV2License(packageJson.license)
+  const license = packageJson.license.trim()
 
   const libraryName =
     kicadLibraryNameOption ?? resolveKicadLibraryName({ projectDir })

--- a/lib/shared/generate-pcm-assets.ts
+++ b/lib/shared/generate-pcm-assets.ts
@@ -3,8 +3,9 @@ import path from "node:path"
 import crypto from "node:crypto"
 import JSZip from "jszip"
 import {
-  assertValidKicadPcmV1License,
-  type KicadPcmV1License,
+  assertValidKicadPcmV2License,
+  KICAD_PCM_SCHEMA_URL,
+  KICAD_PCM_SCHEMA_VERSION,
 } from "./kicad-pcm-license"
 
 export interface GeneratePcmAssetsOptions {
@@ -19,7 +20,7 @@ export interface GeneratePcmAssetsOptions {
   /** Full description of the package */
   descriptionFull?: string
   /** License under which the package is distributed */
-  license: KicadPcmV1License
+  license: string
   /** Path to the kicad-library output directory */
   kicadLibraryPath: string
   /** Output directory for PCM assets (e.g., "dist/pcm") */
@@ -59,7 +60,8 @@ export async function generatePcmAssets(
     displayName = `${author}/${packageName}`,
   } = options
 
-  assertValidKicadPcmV1License(license)
+  assertValidKicadPcmV2License(license)
+  const normalizedLicense = license.trim()
 
   // Create PCM identifier (must be alphanumeric with dots/dashes, 2-50 chars)
   const identifier = `com.tscircuit.${author}.${packageName}`
@@ -73,7 +75,7 @@ export async function generatePcmAssets(
   console.log("Creating metadata.json...")
   // Create metadata.json for inside the ZIP
   const metadata = {
-    $schema: "https://go.kicad.org/pcm/schemas/v1",
+    $schema: KICAD_PCM_SCHEMA_URL,
     name: displayName,
     description: description.slice(0, 500),
     description_full: descriptionFull.slice(0, 5000),
@@ -85,7 +87,7 @@ export async function generatePcmAssets(
         web: `https://tscircuit.com/${author}`,
       },
     },
-    license,
+    license: normalizedLicense,
     resources: {},
     versions: [
       {
@@ -131,7 +133,7 @@ export async function generatePcmAssets(
             web: `https://tscircuit.com/${author}`,
           },
         },
-        license,
+        license: normalizedLicense,
         resources: {},
         versions: [
           {
@@ -164,7 +166,8 @@ export async function generatePcmAssets(
     : "./packages.json"
 
   const repositoryJson = {
-    $schema: "https://go.kicad.org/pcm/schemas/v1",
+    $schema: KICAD_PCM_SCHEMA_URL,
+    schema_version: KICAD_PCM_SCHEMA_VERSION,
     name: displayName,
     maintainer: {
       name: author,

--- a/lib/shared/generate-pcm-assets.ts
+++ b/lib/shared/generate-pcm-assets.ts
@@ -2,6 +2,10 @@ import fs from "node:fs"
 import path from "node:path"
 import crypto from "node:crypto"
 import JSZip from "jszip"
+import {
+  assertValidKicadPcmV1License,
+  type KicadPcmV1License,
+} from "./kicad-pcm-license"
 
 export interface GeneratePcmAssetsOptions {
   /** Name of the package (e.g., "a555timer") */
@@ -15,7 +19,7 @@ export interface GeneratePcmAssetsOptions {
   /** Full description of the package */
   descriptionFull?: string
   /** License under which the package is distributed */
-  license: string
+  license: KicadPcmV1License
   /** Path to the kicad-library output directory */
   kicadLibraryPath: string
   /** Output directory for PCM assets (e.g., "dist/pcm") */
@@ -55,9 +59,7 @@ export async function generatePcmAssets(
     displayName = `${author}/${packageName}`,
   } = options
 
-  if (!license.trim()) {
-    throw new Error("KiCad PCM generation requires a non-empty license")
-  }
+  assertValidKicadPcmV1License(license)
 
   // Create PCM identifier (must be alphanumeric with dots/dashes, 2-50 chars)
   const identifier = `com.tscircuit.${author}.${packageName}`

--- a/lib/shared/generate-pcm-assets.ts
+++ b/lib/shared/generate-pcm-assets.ts
@@ -14,8 +14,8 @@ export interface GeneratePcmAssetsOptions {
   description?: string
   /** Full description of the package */
   descriptionFull?: string
-  /** License (default: "MIT") */
-  license?: string
+  /** License under which the package is distributed */
+  license: string
   /** Path to the kicad-library output directory */
   kicadLibraryPath: string
   /** Output directory for PCM assets (e.g., "dist/pcm") */
@@ -48,12 +48,16 @@ export async function generatePcmAssets(
     author,
     description = "",
     descriptionFull = `Visit https://tscircuit.com/${author}/${packageName} for more information.`,
-    license = "MIT",
+    license,
     kicadLibraryPath,
     outputDir,
     baseUrl,
     displayName = `${author}/${packageName}`,
   } = options
+
+  if (!license.trim()) {
+    throw new Error("KiCad PCM generation requires a non-empty license")
+  }
 
   // Create PCM identifier (must be alphanumeric with dots/dashes, 2-50 chars)
   const identifier = `com.tscircuit.${author}.${packageName}`

--- a/lib/shared/kicad-pcm-license.ts
+++ b/lib/shared/kicad-pcm-license.ts
@@ -1,0 +1,116 @@
+/**
+ * License identifiers accepted by the KiCad PCM v1 schema.
+ *
+ * Source: https://go.kicad.org/pcm/schemas/v1
+ */
+export const KICAD_PCM_V1_LICENSES = [
+  "public-domain",
+  "Apache",
+  "Apache-1.0",
+  "Apache-2.0",
+  "Artistic",
+  "Artistic-1.0",
+  "Artistic-2.0",
+  "BSD",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSD-4-Clause",
+  "ISC",
+  "CC-BY",
+  "CC-BY-1.0",
+  "CC-BY-2.0",
+  "CC-BY-2.5",
+  "CC-BY-3.0",
+  "CC-BY-4.0",
+  "CC-BY-SA",
+  "CC-BY-SA-1.0",
+  "CC-BY-SA-2.0",
+  "CC-BY-SA-2.5",
+  "CC-BY-SA-3.0",
+  "CC-BY-SA-4.0",
+  "CC-BY-ND",
+  "CC-BY-ND-1.0",
+  "CC-BY-ND-2.0",
+  "CC-BY-ND-2.5",
+  "CC-BY-ND-3.0",
+  "CC-BY-ND-4.0",
+  "CC-BY-NC",
+  "CC-BY-NC-1.0",
+  "CC-BY-NC-2.0",
+  "CC-BY-NC-2.5",
+  "CC-BY-NC-3.0",
+  "CC-BY-NC-4.0",
+  "CC-BY-NC-SA",
+  "CC-BY-NC-SA-1.0",
+  "CC-BY-NC-SA-2.0",
+  "CC-BY-NC-SA-2.5",
+  "CC-BY-NC-SA-3.0",
+  "CC-BY-NC-SA-4.0",
+  "CC-BY-NC-ND",
+  "CC-BY-NC-ND-1.0",
+  "CC-BY-NC-ND-2.0",
+  "CC-BY-NC-ND-2.5",
+  "CC-BY-NC-ND-3.0",
+  "CC-BY-NC-ND-4.0",
+  "CC0-1.0",
+  "CDDL-1.0",
+  "CPL",
+  "EFL",
+  "EFL-1.0",
+  "EFL-2.0",
+  "MIT",
+  "GPL",
+  "GPL-1.0",
+  "GPL-2.0",
+  "GPL-3.0",
+  "LGPL",
+  "LGPL-2.1",
+  "LGPL-3.0",
+  "GNU-LGPL-2.0",
+  "GFDL",
+  "GFDL-1.0",
+  "GFDL-1.1",
+  "GFDL-1.2",
+  "GFDL-1.3",
+  "GFDL-NIV",
+  "LPPL",
+  "LPPL-1.0",
+  "LPPL-1.1",
+  "LPPL-1.2",
+  "LPPL-1.3",
+  "MPL-1.1",
+  "Perl",
+  "Python-2.0",
+  "QPL-1.0",
+  "W3C",
+  "Zlib",
+  "Zope",
+  "Zope-1.0",
+  "Zope-1.1",
+  "Zope-2.0",
+  "Zope-2.1",
+  "CERN-OHL",
+  "WTFPL",
+  "Unlicense",
+  "open-source",
+  "unrestricted",
+] as const
+
+export type KicadPcmV1License = (typeof KICAD_PCM_V1_LICENSES)[number]
+
+const kicadPcmV1LicenseSet = new Set<string>(KICAD_PCM_V1_LICENSES)
+
+export const isValidKicadPcmV1License = (
+  license: string,
+): license is KicadPcmV1License => kicadPcmV1LicenseSet.has(license)
+
+export function assertValidKicadPcmV1License(
+  license: string,
+): asserts license is KicadPcmV1License {
+  if (!isValidKicadPcmV1License(license)) {
+    const displayLicense = license || "(empty)"
+    throw new Error(
+      `Invalid KiCad PCM v1 license "${displayLicense}". Use a license allowed by https://go.kicad.org/pcm/schemas/v1`,
+    )
+  }
+}

--- a/lib/shared/kicad-pcm-license.ts
+++ b/lib/shared/kicad-pcm-license.ts
@@ -1,116 +1,21 @@
+export const KICAD_PCM_SCHEMA_VERSION = 2 as const
+export const KICAD_PCM_SCHEMA_URL =
+  "https://go.kicad.org/pcm/schemas/v2" as const
+
 /**
- * License identifiers accepted by the KiCad PCM v1 schema.
- *
- * Source: https://go.kicad.org/pcm/schemas/v1
+ * KiCad PCM schema v2 accepts an open license string instead of the fixed v1
+ * license enum. We additionally require useful content rather than emitting a
+ * missing or whitespace-only declaration.
  */
-export const KICAD_PCM_V1_LICENSES = [
-  "public-domain",
-  "Apache",
-  "Apache-1.0",
-  "Apache-2.0",
-  "Artistic",
-  "Artistic-1.0",
-  "Artistic-2.0",
-  "BSD",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "BSD-4-Clause",
-  "ISC",
-  "CC-BY",
-  "CC-BY-1.0",
-  "CC-BY-2.0",
-  "CC-BY-2.5",
-  "CC-BY-3.0",
-  "CC-BY-4.0",
-  "CC-BY-SA",
-  "CC-BY-SA-1.0",
-  "CC-BY-SA-2.0",
-  "CC-BY-SA-2.5",
-  "CC-BY-SA-3.0",
-  "CC-BY-SA-4.0",
-  "CC-BY-ND",
-  "CC-BY-ND-1.0",
-  "CC-BY-ND-2.0",
-  "CC-BY-ND-2.5",
-  "CC-BY-ND-3.0",
-  "CC-BY-ND-4.0",
-  "CC-BY-NC",
-  "CC-BY-NC-1.0",
-  "CC-BY-NC-2.0",
-  "CC-BY-NC-2.5",
-  "CC-BY-NC-3.0",
-  "CC-BY-NC-4.0",
-  "CC-BY-NC-SA",
-  "CC-BY-NC-SA-1.0",
-  "CC-BY-NC-SA-2.0",
-  "CC-BY-NC-SA-2.5",
-  "CC-BY-NC-SA-3.0",
-  "CC-BY-NC-SA-4.0",
-  "CC-BY-NC-ND",
-  "CC-BY-NC-ND-1.0",
-  "CC-BY-NC-ND-2.0",
-  "CC-BY-NC-ND-2.5",
-  "CC-BY-NC-ND-3.0",
-  "CC-BY-NC-ND-4.0",
-  "CC0-1.0",
-  "CDDL-1.0",
-  "CPL",
-  "EFL",
-  "EFL-1.0",
-  "EFL-2.0",
-  "MIT",
-  "GPL",
-  "GPL-1.0",
-  "GPL-2.0",
-  "GPL-3.0",
-  "LGPL",
-  "LGPL-2.1",
-  "LGPL-3.0",
-  "GNU-LGPL-2.0",
-  "GFDL",
-  "GFDL-1.0",
-  "GFDL-1.1",
-  "GFDL-1.2",
-  "GFDL-1.3",
-  "GFDL-NIV",
-  "LPPL",
-  "LPPL-1.0",
-  "LPPL-1.1",
-  "LPPL-1.2",
-  "LPPL-1.3",
-  "MPL-1.1",
-  "Perl",
-  "Python-2.0",
-  "QPL-1.0",
-  "W3C",
-  "Zlib",
-  "Zope",
-  "Zope-1.0",
-  "Zope-1.1",
-  "Zope-2.0",
-  "Zope-2.1",
-  "CERN-OHL",
-  "WTFPL",
-  "Unlicense",
-  "open-source",
-  "unrestricted",
-] as const
+export const isValidKicadPcmV2License = (license: unknown): license is string =>
+  typeof license === "string" && license.trim().length > 0
 
-export type KicadPcmV1License = (typeof KICAD_PCM_V1_LICENSES)[number]
-
-const kicadPcmV1LicenseSet = new Set<string>(KICAD_PCM_V1_LICENSES)
-
-export const isValidKicadPcmV1License = (
-  license: string,
-): license is KicadPcmV1License => kicadPcmV1LicenseSet.has(license)
-
-export function assertValidKicadPcmV1License(
-  license: string,
-): asserts license is KicadPcmV1License {
-  if (!isValidKicadPcmV1License(license)) {
-    const displayLicense = license || "(empty)"
+export function assertValidKicadPcmV2License(
+  license: unknown,
+): asserts license is string {
+  if (!isValidKicadPcmV2License(license)) {
     throw new Error(
-      `Invalid KiCad PCM v1 license "${displayLicense}". Use a license allowed by https://go.kicad.org/pcm/schemas/v1`,
+      `Invalid KiCad PCM v2 license "(empty)". License must be a non-empty string allowed by ${KICAD_PCM_SCHEMA_URL}`,
     )
   }
 }

--- a/lib/shared/push-snippet.ts
+++ b/lib/shared/push-snippet.ts
@@ -141,7 +141,12 @@ export const pushSnippet = async ({
     return onExit(1)
   }
 
-  let packageJson: { name?: string; author?: string; version?: string } = {}
+  let packageJson: {
+    name?: string
+    author?: string
+    version?: string
+    license?: string
+  } = {}
   if (fs.existsSync(packageJsonPath)) {
     try {
       packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString())
@@ -497,6 +502,9 @@ export const pushSnippet = async ({
     json: {
       package_name_with_version: `${scopedPackageName}@${releaseVersion}`,
       ready_to_build: true,
+      ...(typeof packageJson.license === "string" && packageJson.license.trim()
+        ? { license: packageJson.license.trim() }
+        : {}),
     },
   })
 

--- a/tests/cli/build/build-config-options.test.ts
+++ b/tests/cli/build/build-config-options.test.ts
@@ -55,7 +55,10 @@ test("build uses config build.kicadPcm setting", async () => {
   await writeFile(path.join(tmpDir, "lib", "index.tsx"), libraryCode)
   await writeFile(
     path.join(tmpDir, "package.json"),
-    JSON.stringify({ name: "test-kicad-library" }),
+    JSON.stringify({
+      name: "test-kicad-library",
+      license: "CC-BY-ND-4.0",
+    }),
   )
   await writeFile(
     path.join(tmpDir, "tscircuit.config.json"),

--- a/tests/cli/build/build-kicad-pcm-paths.test.ts
+++ b/tests/cli/build/build-kicad-pcm-paths.test.ts
@@ -80,6 +80,7 @@ export const MySwitch = () => (
       name: "@tsci/testauthor.my-switch-lib",
       version: "1.0.0",
       description: "A test switch component",
+      license: "CC-BY-ND-4.0",
       type: "module",
       dependencies: {
         react: "^19.1.0",

--- a/tests/cli/build/build-kicad-pcm.test.ts
+++ b/tests/cli/build/build-kicad-pcm.test.ts
@@ -59,7 +59,7 @@ export const MyResistor = () => (
       name: "@tsci/testuser.my-resistor",
       version: "1.0.0",
       description: "A test resistor component",
-      license: "CC-BY-ND-4.0",
+      license: "Unknown",
       type: "module",
       dependencies: {
         react: "^19.1.0",
@@ -113,11 +113,13 @@ export const MyResistor = () => (
   expect(repositoryJson.packages.url).toContain(
     "testuser--my-resistor.tscircuit.app/pcm/packages.json",
   )
+  expect(repositoryJson.$schema).toBe("https://go.kicad.org/pcm/schemas/v2")
+  expect(repositoryJson.schema_version).toBe(2)
 
   const packagesJson = JSON.parse(
     await readFile(path.join(pcmDir, "packages.json"), "utf-8"),
   )
-  expect(packagesJson.packages[0].license).toBe("CC-BY-ND-4.0")
+  expect(packagesJson.packages[0].license).toBe("Unknown")
 
   // Verify ZIP exists in pcm folder and check its contents
   const files = await readdir(pcmDir)
@@ -128,7 +130,8 @@ export const MyResistor = () => (
   const zip = await JSZip.loadAsync(zipBuffer)
   const zipPaths = Object.keys(zip.files).sort()
   const metadata = JSON.parse(await zip.files["metadata.json"].async("string"))
-  expect(metadata.license).toBe("CC-BY-ND-4.0")
+  expect(metadata.$schema).toBe("https://go.kicad.org/pcm/schemas/v2")
+  expect(metadata.license).toBe("Unknown")
   expect(zipPaths).toMatchInlineSnapshot(`
     [
       "3dmodels/",

--- a/tests/cli/build/build-kicad-pcm.test.ts
+++ b/tests/cli/build/build-kicad-pcm.test.ts
@@ -59,6 +59,7 @@ export const MyResistor = () => (
       name: "@tsci/testuser.my-resistor",
       version: "1.0.0",
       description: "A test resistor component",
+      license: "CC-BY-ND-4.0",
       type: "module",
       dependencies: {
         react: "^19.1.0",
@@ -113,6 +114,11 @@ export const MyResistor = () => (
     "testuser--my-resistor.tscircuit.app/pcm/packages.json",
   )
 
+  const packagesJson = JSON.parse(
+    await readFile(path.join(pcmDir, "packages.json"), "utf-8"),
+  )
+  expect(packagesJson.packages[0].license).toBe("CC-BY-ND-4.0")
+
   // Verify ZIP exists in pcm folder and check its contents
   const files = await readdir(pcmDir)
   const zipFile = files.find((f) => f.endsWith(".zip"))
@@ -121,6 +127,8 @@ export const MyResistor = () => (
   const zipBuffer = await readFile(path.join(pcmDir, zipFile!))
   const zip = await JSZip.loadAsync(zipBuffer)
   const zipPaths = Object.keys(zip.files).sort()
+  const metadata = JSON.parse(await zip.files["metadata.json"].async("string"))
+  expect(metadata.license).toBe("CC-BY-ND-4.0")
   expect(zipPaths).toMatchInlineSnapshot(`
     [
       "3dmodels/",

--- a/tests/cli/push/push4-create-package.test.ts
+++ b/tests/cli/push/push4-create-package.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 
 test("should create package if it does not exist", async () => {
-  const { tmpDir, runCommand } = await getCliTestFixture({
+  const { tmpDir, runCommand, registryDb } = await getCliTestFixture({
     loggedIn: true,
   })
 
@@ -13,9 +13,23 @@ test("should create package if it does not exist", async () => {
   fs.writeFileSync(snippetFilePath, "// Snippet content")
   fs.writeFileSync(
     path.resolve(tmpDir, "package.json"),
-    JSON.stringify({ name: "test-package", version: "1.0.0" }),
+    JSON.stringify({
+      name: "test-package",
+      version: "1.0.0",
+      license: "CC-BY-ND-4.0",
+    }),
   )
 
   const { stdout } = await runCommand(`tsci push ${snippetFilePath}`)
   expect(stdout).toContain("published!")
+
+  const publishedPackage = registryDb.packages.find(
+    (pkg) => pkg.name === "test-user/test-package",
+  )
+  const release = registryDb.packageReleases.find(
+    (release) =>
+      release.package_id === publishedPackage?.package_id &&
+      release.version === "1.0.0",
+  )
+  expect(release?.license).toBe("CC-BY-ND-4.0")
 })

--- a/tests/lib/convert-to-kicad-library-with-custom-module.test.ts
+++ b/tests/lib/convert-to-kicad-library-with-custom-module.test.ts
@@ -240,6 +240,7 @@ export const MyInductor = () => (
         name: "@tsci/testuser.pcm-custom-module",
         version: "1.0.0",
         description: "A test component for PCM with custom module",
+        license: "CC-BY-ND-4.0",
         type: "module",
         dependencies: {
           react: "^19.1.0",

--- a/tests/lib/kicad-pcm-license.test.ts
+++ b/tests/lib/kicad-pcm-license.test.ts
@@ -1,20 +1,20 @@
 import { expect, test } from "bun:test"
 import {
-  assertValidKicadPcmV1License,
-  isValidKicadPcmV1License,
+  assertValidKicadPcmV2License,
+  isValidKicadPcmV2License,
 } from "lib/shared/kicad-pcm-license"
 
-test("accepts licenses from the KiCad PCM v1 schema", () => {
-  expect(isValidKicadPcmV1License("CC-BY-ND-4.0")).toBe(true)
-  expect(() => assertValidKicadPcmV1License("CC-BY-ND-4.0")).not.toThrow()
+test("accepts open license strings from the KiCad PCM v2 schema", () => {
+  expect(isValidKicadPcmV2License("CC-BY-ND-4.0")).toBe(true)
+  expect(isValidKicadPcmV2License("Unknown")).toBe(true)
+  expect(() => assertValidKicadPcmV2License("LicenseRef-Custom")).not.toThrow()
 })
 
-test("rejects licenses outside the KiCad PCM v1 schema", () => {
-  expect(isValidKicadPcmV1License("Unknown")).toBe(false)
-  expect(() => assertValidKicadPcmV1License("Unknown")).toThrow(
-    'Invalid KiCad PCM v1 license "Unknown"',
-  )
-  expect(() => assertValidKicadPcmV1License("")).toThrow(
-    'Invalid KiCad PCM v1 license "(empty)"',
+test("rejects missing and blank KiCad PCM v2 licenses", () => {
+  expect(isValidKicadPcmV2License(undefined)).toBe(false)
+  expect(isValidKicadPcmV2License("")).toBe(false)
+  expect(isValidKicadPcmV2License("   ")).toBe(false)
+  expect(() => assertValidKicadPcmV2License("")).toThrow(
+    'Invalid KiCad PCM v2 license "(empty)"',
   )
 })

--- a/tests/lib/kicad-pcm-license.test.ts
+++ b/tests/lib/kicad-pcm-license.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import {
+  assertValidKicadPcmV1License,
+  isValidKicadPcmV1License,
+} from "lib/shared/kicad-pcm-license"
+
+test("accepts licenses from the KiCad PCM v1 schema", () => {
+  expect(isValidKicadPcmV1License("CC-BY-ND-4.0")).toBe(true)
+  expect(() => assertValidKicadPcmV1License("CC-BY-ND-4.0")).not.toThrow()
+})
+
+test("rejects licenses outside the KiCad PCM v1 schema", () => {
+  expect(isValidKicadPcmV1License("Unknown")).toBe(false)
+  expect(() => assertValidKicadPcmV1License("Unknown")).toThrow(
+    'Invalid KiCad PCM v1 license "Unknown"',
+  )
+  expect(() => assertValidKicadPcmV1License("")).toThrow(
+    'Invalid KiCad PCM v1 license "(empty)"',
+  )
+})


### PR DESCRIPTION
## Summary

- propagate `package.json.license` into PCM `packages.json` and archive `metadata.json`
- emit KiCad PCM schema v2 and declare `schema_version: 2` in `repository.json`
- accept schema v2's open license strings while rejecting missing or whitespace-only licenses
- include the declared license when `tsci push` marks a registry release ready to build
- add regression coverage for `CC-BY-ND-4.0`, open-string `Unknown`, missing licenses, and generated v2 metadata

## Root cause

`buildKicadPcm` read the project manifest but did not pass its license to `generatePcmAssets`, whose fallback was `MIT`. The publish path independently omitted the license from `package_releases/update`, leaving the API release at `unset`.

## Impact

Publisher-declared licenses are preserved across PCM artifacts and registry release metadata. PCM output now uses schema v2, whose license field accepts arbitrary strings, and the repository explicitly selects v2 so KiCad validates package metadata with the matching schema. Projects without an explicit license fail with an actionable error instead of being implicitly relicensed.

Schema v2 requires a KiCad version that supports PCM v2 repositories; older KiCad releases that only support v1 cannot consume this feed.

## Validation

- `bun test tests/lib/kicad-pcm-license.test.ts tests/lib/convert-to-kicad-library-with-custom-module.test.ts tests/cli/build/build-kicad-pcm.test.ts tests/cli/build/build-kicad-pcm-paths.test.ts tests/cli/push/push4-create-package.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`