### PR TITLE
Fix autorouter debug stage images

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,30 @@ The `build` command also accepts the following options:
 - `--ignore-placement-drc` - suppress placement DRC diagnostics
 - `--ignore-routing-drc` - suppress routing DRC diagnostics
 
+### Debug autorouting stages
+
+Use `--autorouter-debug` to log each autorouting stage and write visual
+artifacts while the circuit is being routed:
+
+```bash
+tsci build index.circuit.tsx \
+  --autorouter-debug \
+  --autorouter-debug-dir dist/autorouter-debug \
+  --autorouter-dump-srj all
+```
+
+The debug directory contains:
+
+- `placement-unrouted.png` — PCB placement before routing starts.
+- `phase-N-routed.png` — cumulative PCB routing after each zero-indexed stage.
+  A fanout router and its downstream router appear as separate stages.
+- `phase-N.input.simple-route.json` and `phase-N.output.traces.json` when
+  `--autorouter-dump-srj all` is enabled.
+- `board.meta.json` — phase timing and connection-count summary.
+
+Use `--autorouter-dump-srj failed` to keep only failed-stage routing data, or
+`--autorouter-dump-srj phase:N` to capture a single stage.
+
 ## Development
 
 This command will open the `index.tsx` file for editing.

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -186,7 +186,7 @@ export const registerBuild = (program: Command) => {
     )
     .option(
       "--autorouter-debug",
-      "Log autorouting phase diagnostics during circuit generation",
+      "Log autorouting phases and write unrouted/per-phase PNG artifacts",
     )
     .option(
       "--autorouter-timeout <duration>",

--- a/cli/check/trace-length/register.ts
+++ b/cli/check/trace-length/register.ts
@@ -85,7 +85,7 @@ export const registerCheckTraceLength = (program: Command) => {
     .argument("[file]", "Path to the entry file")
     .option(
       "--autorouter-debug",
-      "Log autorouting phase diagnostics during circuit generation",
+      "Log autorouting phases and write unrouted/per-phase PNG artifacts",
     )
     .option(
       "--autorouter-timeout <duration>",

--- a/lib/shared/autorouter-diagnostics.ts
+++ b/lib/shared/autorouter-diagnostics.ts
@@ -26,9 +26,22 @@ export type AutorouterDiagnosticsOptions = {
 type SimpleRouteJson = {
   connections?: Array<Record<string, unknown>>
   obstacles?: unknown[]
-  traces?: PcbTrace[]
+  traces?: AutorouterTrace[]
   jumpers?: unknown[]
   [key: string]: unknown
+}
+
+type ThroughObstacleRoutePoint = {
+  route_type: "through_obstacle"
+  start: { x: number; y: number }
+  end: { x: number; y: number }
+  from_layer: string
+  to_layer: string
+  width: number
+}
+
+type AutorouterTrace = Omit<PcbTrace, "route"> & {
+  route: Array<PcbTrace["route"][number] | ThroughObstacleRoutePoint>
 }
 
 type CircuitJsonLookup = {
@@ -133,7 +146,7 @@ export class AutorouterDiagnostics {
   private phaseOrdinalBySubcircuit = new Map<string, number>()
   private traceCountBySubcircuit = new Map<string, number>()
   private activePhase: ActivePhase | null = null
-  private completedPhaseTraces: PcbTrace[] = []
+  private completedPhaseTraces: AutorouterTrace[] = []
   private hasWrittenPlacementSnapshot = false
   private summary: Array<Record<string, unknown>> = []
   private rootCircuit: any
@@ -587,13 +600,24 @@ export class AutorouterDiagnostics {
   }
 
   private writePngSnapshot(fileName: string, circuitJson: CircuitJson) {
-    const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
-    const png = convertSvgToPngBuffer(pcbSvg)
-    const debugDir = path.resolve(this.options.debugDir ?? DEFAULT_DEBUG_DIR)
-    fs.mkdirSync(debugDir, { recursive: true })
-    const filePath = path.join(debugDir, fileName)
-    fs.writeFileSync(filePath, png)
-    this.logArtifact(filePath)
+    try {
+      const pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)
+      const png = convertSvgToPngBuffer(pcbSvg)
+      const debugDir = path.resolve(this.options.debugDir ?? DEFAULT_DEBUG_DIR)
+      fs.mkdirSync(debugDir, { recursive: true })
+      const filePath = path.join(debugDir, fileName)
+      fs.writeFileSync(filePath, png)
+      this.logArtifact(filePath)
+    } catch (error) {
+      const serializedError = this.serializeError(
+        error instanceof Error ? error : String(error),
+      )
+      this.log(
+        kleur.yellow(
+          `Could not write autorouter debug image ${fileName}: ${serializedError.message}`,
+        ),
+      )
+    }
   }
 
   private logArtifact(filePath: string) {
@@ -609,7 +633,8 @@ export class AutorouterDiagnostics {
       if (id) elementIndexById.set(id, index)
     }
 
-    for (const trace of this.completedPhaseTraces) {
+    for (const autorouterTrace of this.completedPhaseTraces) {
+      const trace = this.normalizeTraceForPcbSnapshot(autorouterTrace)
       if (!trace || typeof trace !== "object") continue
       const id = this.getCircuitElementId(trace)
       const existingIndex = id ? elementIndexById.get(id) : undefined
@@ -622,6 +647,23 @@ export class AutorouterDiagnostics {
     }
 
     return circuitJson
+  }
+
+  private normalizeTraceForPcbSnapshot(trace: AutorouterTrace): PcbTrace {
+    return {
+      ...trace,
+      route: trace.route.map((point) => {
+        if (point.route_type !== "through_obstacle") return point
+        return {
+          route_type: "through_pad",
+          start: point.start,
+          end: point.end,
+          start_layer: point.from_layer,
+          end_layer: point.to_layer,
+          width: point.width,
+        }
+      }),
+    }
   }
 
   private getCircuitElementId(element: AnyCircuitElement) {

--- a/lib/shared/autorouter-diagnostics.ts
+++ b/lib/shared/autorouter-diagnostics.ts
@@ -4,6 +4,7 @@ import type {
   AnyCircuitElement,
   CircuitJson,
   PcbTrace,
+  PcbTraceRoutePointThroughPad,
   SourcePort,
   SourceTrace,
 } from "circuit-json"
@@ -35,8 +36,8 @@ type ThroughObstacleRoutePoint = {
   route_type: "through_obstacle"
   start: { x: number; y: number }
   end: { x: number; y: number }
-  from_layer: string
-  to_layer: string
+  from_layer: PcbTraceRoutePointThroughPad["start_layer"]
+  to_layer: PcbTraceRoutePointThroughPad["end_layer"]
   width: number
 }
 

--- a/tests/shared/autorouter-diagnostics.test.ts
+++ b/tests/shared/autorouter-diagnostics.test.ts
@@ -81,6 +81,14 @@ describe("autorouter diagnostics", () => {
                 layer: "top",
               },
               {
+                route_type: "through_obstacle",
+                start: { x: 0, y: 0 },
+                end: { x: 0, y: 0 },
+                from_layer: "top",
+                to_layer: "bottom",
+                width: 0.2,
+              },
+              {
                 route_type: "wire",
                 x: 2,
                 y: 0,
@@ -128,6 +136,41 @@ describe("autorouter diagnostics", () => {
       fs.readFileSync(path.join(debugDir, "phase-0-routed.png")),
     ).not.toEqual(
       fs.readFileSync(path.join(debugDir, "placement-unrouted.png")),
+    )
+  })
+
+  test("debug image failures do not abort autorouting events", () => {
+    const debugDir = makeTempDir()
+    const logs: string[] = []
+    const root = new FakeRootCircuit()
+    const diagnostics = new AutorouterDiagnostics({
+      enabled: true,
+      debugDir,
+      log: (message) => logs.push(message),
+    })
+
+    diagnostics.attachToRootCircuit(root)
+    root.emit("autorouting:start", {
+      subcircuit_id: "subcircuit_source_group_0",
+      simpleRouteJson: { connections: [{ name: "GND" }] },
+    })
+
+    expect(() =>
+      root.emit("autorouting:end", {
+        subcircuit_id: "subcircuit_source_group_0",
+        simpleRouteJson: {
+          traces: [
+            {
+              type: "pcb_trace",
+              pcb_trace_id: "pcb_trace_invalid",
+              route: [{ route_type: "unsupported_debug_route_point" }],
+            },
+          ],
+        },
+      }),
+    ).not.toThrow()
+    expect(logs.join("\n")).toContain(
+      "Could not write autorouter debug image phase-0-routed.png",
     )
   })
 


### PR DESCRIPTION
## Summary

- document the `--autorouter-debug` stage-image workflow and related SRJ flags
- normalize autorouter `through_obstacle` route points before rendering cumulative stage PNGs
- keep debug-image rendering failures from aborting the actual autorouting run
- add regression coverage for both behaviors

## Root cause

Fanout followed by a downstream autorouter can return intermediate
`through_obstacle` route points. Core converts these to Circuit JSON
`through_pad` points before inserting final PCB traces, but the CLI diagnostics
renderer passed the raw points to `circuit-to-svg`. The resulting validation
error escaped the event listener and stopped all later routing phases.

## Validation

- `bun test tests/shared/autorouter-diagnostics.test.ts` — 9 passed
- `bun run format:check`
- `bun run build`
- exercised the patched CLI against the RK3326 fanout design; cumulative PNGs
  were produced through every successful fanout/downstream stage

The broader `bun test` run was also attempted, but this checkout lacks the
native Sharp binary used by unrelated snapshot tests and one init test hit its
existing 15-second timeout.
