### PR TITLE
Support KiCad 6–10 PCM license compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ The `build` command also accepts the following options:
 - `--ignore-placement-drc` - suppress placement DRC diagnostics
 - `--ignore-routing-drc` - suppress routing DRC diagnostics
 
+### KiCad PCM compatibility
+
+`tsci build --kicad-pcm` uses the package license from `package.json` and
+selects the oldest compatible PCM schema by default. Licenses accepted by PCM
+schema v1 produce a feed for KiCad 6–10. Other non-empty license strings use
+schema v2 and require KiCad 10 or newer.
+
+Projects can select a schema or declare a distribution-specific PCM license in
+`tscircuit.config.json`:
+
+```json
+{
+  "kicadPcm": {
+    "schemaVersion": "auto",
+    "license": "CC-BY-ND-4.0"
+  }
+}
+```
+
+Set `schemaVersion` to `1` or `2` to force a schema. Forcing v1 rejects licenses
+that are not in KiCad's v1 license list instead of substituting another license.
+
 ### Debug autorouting stages
 
 Use `--autorouter-debug` to log each autorouting stage and write visual

--- a/cli/build/build-kicad-pcm.ts
+++ b/cli/build/build-kicad-pcm.ts
@@ -9,7 +9,7 @@ import { generatePcmAssets } from "lib/shared/generate-pcm-assets"
 import { getPackageAuthor } from "lib/utils/get-package-author"
 import { loadProjectConfig } from "lib/project-config"
 import { resolveKicadLibraryName } from "lib/utils/resolve-kicad-library-name"
-import { assertValidKicadPcmV2License } from "lib/shared/kicad-pcm-license"
+import { resolveKicadPcmSchemaVersion } from "lib/shared/kicad-pcm-license"
 
 export interface BuildKicadPcmOptions {
   entryFile: string
@@ -47,8 +47,12 @@ export async function buildKicadPcm({
   const version = packageJson.version || "1.0.0"
   const author = getPackageAuthor(packageJson.name || "") || "tscircuit"
   const description = packageJson.description || ""
-  assertValidKicadPcmV2License(packageJson.license)
-  const license = packageJson.license.trim()
+  const license = projectConfig?.kicadPcm?.license ?? packageJson.license
+  const schemaVersion = resolveKicadPcmSchemaVersion({
+    license,
+    preference: projectConfig?.kicadPcm?.schemaVersion,
+  })
+  const normalizedLicense = license.trim()
 
   const libraryName =
     kicadLibraryNameOption ?? resolveKicadLibraryName({ projectDir })
@@ -91,7 +95,8 @@ export async function buildKicadPcm({
     version,
     author,
     description,
-    license,
+    license: normalizedLicense,
+    schemaVersion,
     kicadLibraryPath: kicadLibOutputDir,
     outputDir: pcmOutputDir,
     baseUrl,

--- a/lib/project-config/project-config-schema.ts
+++ b/lib/project-config/project-config-schema.ts
@@ -6,6 +6,13 @@ export const pcbSnapshotSettingsSchema = z.object({
   showFabricationNotes: z.boolean().optional(),
 })
 
+export const kicadPcmSettingsSchema = z.object({
+  schemaVersion: z
+    .union([z.literal("auto"), z.literal(1), z.literal(2)])
+    .optional(),
+  license: z.string().trim().min(1).optional(),
+})
+
 export type PcbSnapshotSettings = z.infer<typeof pcbSnapshotSettingsSchema>
 
 export const projectConfigSchema = z.object({
@@ -22,6 +29,7 @@ export const projectConfigSchema = z.object({
   kicadProjectEntrypointPath: z.string().optional(),
   kicadLibraryEntrypointPath: z.string().optional(),
   kicadLibraryName: z.string().optional(),
+  kicadPcm: kicadPcmSettingsSchema.optional(),
   alwaysUseLatestTscircuitOnCloud: z.boolean().optional(),
   build: z
     .object({

--- a/lib/shared/generate-pcm-assets.ts
+++ b/lib/shared/generate-pcm-assets.ts
@@ -3,9 +3,10 @@ import path from "node:path"
 import crypto from "node:crypto"
 import JSZip from "jszip"
 import {
-  assertValidKicadPcmV2License,
-  KICAD_PCM_SCHEMA_URL,
-  KICAD_PCM_SCHEMA_VERSION,
+  KICAD_PCM_SCHEMA_URLS,
+  type KicadPcmSchemaVersion,
+  type KicadPcmSchemaVersionPreference,
+  resolveKicadPcmSchemaVersion,
 } from "./kicad-pcm-license"
 
 export interface GeneratePcmAssetsOptions {
@@ -21,6 +22,8 @@ export interface GeneratePcmAssetsOptions {
   descriptionFull?: string
   /** License under which the package is distributed */
   license: string
+  /** PCM schema to emit. Auto selects v1 when the package license supports it. */
+  schemaVersion?: KicadPcmSchemaVersionPreference
   /** Path to the kicad-library output directory */
   kicadLibraryPath: string
   /** Output directory for PCM assets (e.g., "dist/pcm") */
@@ -38,6 +41,7 @@ export interface GeneratePcmAssetsResult {
   packageZipPath: string
   packageZipSha256: string
   packageZipSize: number
+  schemaVersion: KicadPcmSchemaVersion
 }
 
 /**
@@ -54,13 +58,18 @@ export async function generatePcmAssets(
     description = "",
     descriptionFull = `Visit https://tscircuit.com/${author}/${packageName} for more information.`,
     license,
+    schemaVersion: schemaVersionPreference = "auto",
     kicadLibraryPath,
     outputDir,
     baseUrl,
     displayName = `${author}/${packageName}`,
   } = options
 
-  assertValidKicadPcmV2License(license)
+  const schemaVersion = resolveKicadPcmSchemaVersion({
+    license,
+    preference: schemaVersionPreference,
+  })
+  const schemaUrl = KICAD_PCM_SCHEMA_URLS[schemaVersion]
   const normalizedLicense = license.trim()
 
   // Create PCM identifier (must be alphanumeric with dots/dashes, 2-50 chars)
@@ -75,7 +84,7 @@ export async function generatePcmAssets(
   console.log("Creating metadata.json...")
   // Create metadata.json for inside the ZIP
   const metadata = {
-    $schema: KICAD_PCM_SCHEMA_URL,
+    $schema: schemaUrl,
     name: displayName,
     description: description.slice(0, 500),
     description_full: descriptionFull.slice(0, 5000),
@@ -166,8 +175,8 @@ export async function generatePcmAssets(
     : "./packages.json"
 
   const repositoryJson = {
-    $schema: KICAD_PCM_SCHEMA_URL,
-    schema_version: KICAD_PCM_SCHEMA_VERSION,
+    $schema: schemaUrl,
+    ...(schemaVersion === 2 ? { schema_version: 2 } : {}),
     name: displayName,
     maintainer: {
       name: author,
@@ -192,6 +201,7 @@ export async function generatePcmAssets(
     packageZipPath: zipFilePath,
     packageZipSha256: sha256,
     packageZipSize: zipSize,
+    schemaVersion,
   }
 }
 

--- a/lib/shared/kicad-pcm-license.ts
+++ b/lib/shared/kicad-pcm-license.ts
@@ -1,12 +1,129 @@
+export const KICAD_PCM_SCHEMA_URLS = {
+  1: "https://go.kicad.org/pcm/schemas/v1",
+  2: "https://go.kicad.org/pcm/schemas/v2",
+} as const
+
+export type KicadPcmSchemaVersion = keyof typeof KICAD_PCM_SCHEMA_URLS
+export type KicadPcmSchemaVersionPreference = "auto" | KicadPcmSchemaVersion
+
+// Retain the v2 constants for callers that explicitly target the open schema.
 export const KICAD_PCM_SCHEMA_VERSION = 2 as const
-export const KICAD_PCM_SCHEMA_URL =
-  "https://go.kicad.org/pcm/schemas/v2" as const
+export const KICAD_PCM_SCHEMA_URL = KICAD_PCM_SCHEMA_URLS[2]
 
 /**
- * KiCad PCM schema v2 accepts an open license string instead of the fixed v1
- * license enum. We additionally require useful content rather than emitting a
- * missing or whitespace-only declaration.
+ * License identifiers accepted by KiCad PCM schema v1 (KiCad 6+).
+ * Source: https://go.kicad.org/pcm/schemas/v1#/definitions/License
  */
+export const KICAD_PCM_V1_LICENSES = [
+  "public-domain",
+  "Apache",
+  "Apache-1.0",
+  "Apache-2.0",
+  "Artistic",
+  "Artistic-1.0",
+  "Artistic-2.0",
+  "BSD",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSD-4-Clause",
+  "ISC",
+  "CC-BY",
+  "CC-BY-1.0",
+  "CC-BY-2.0",
+  "CC-BY-2.5",
+  "CC-BY-3.0",
+  "CC-BY-4.0",
+  "CC-BY-SA",
+  "CC-BY-SA-1.0",
+  "CC-BY-SA-2.0",
+  "CC-BY-SA-2.5",
+  "CC-BY-SA-3.0",
+  "CC-BY-SA-4.0",
+  "CC-BY-ND",
+  "CC-BY-ND-1.0",
+  "CC-BY-ND-2.0",
+  "CC-BY-ND-2.5",
+  "CC-BY-ND-3.0",
+  "CC-BY-ND-4.0",
+  "CC-BY-NC",
+  "CC-BY-NC-1.0",
+  "CC-BY-NC-2.0",
+  "CC-BY-NC-2.5",
+  "CC-BY-NC-3.0",
+  "CC-BY-NC-4.0",
+  "CC-BY-NC-SA",
+  "CC-BY-NC-SA-1.0",
+  "CC-BY-NC-SA-2.0",
+  "CC-BY-NC-SA-2.5",
+  "CC-BY-NC-SA-3.0",
+  "CC-BY-NC-SA-4.0",
+  "CC-BY-NC-ND",
+  "CC-BY-NC-ND-1.0",
+  "CC-BY-NC-ND-2.0",
+  "CC-BY-NC-ND-2.5",
+  "CC-BY-NC-ND-3.0",
+  "CC-BY-NC-ND-4.0",
+  "CC0-1.0",
+  "CDDL-1.0",
+  "CPL",
+  "EFL",
+  "EFL-1.0",
+  "EFL-2.0",
+  "MIT",
+  "GPL",
+  "GPL-1.0",
+  "GPL-2.0",
+  "GPL-3.0",
+  "LGPL",
+  "LGPL-2.1",
+  "LGPL-3.0",
+  "GNU-LGPL-2.0",
+  "GFDL",
+  "GFDL-1.0",
+  "GFDL-1.1",
+  "GFDL-1.2",
+  "GFDL-1.3",
+  "GFDL-NIV",
+  "LPPL",
+  "LPPL-1.0",
+  "LPPL-1.1",
+  "LPPL-1.2",
+  "LPPL-1.3",
+  "MPL-1.1",
+  "Perl",
+  "Python-2.0",
+  "QPL-1.0",
+  "W3C",
+  "Zlib",
+  "Zope",
+  "Zope-1.0",
+  "Zope-1.1",
+  "Zope-2.0",
+  "Zope-2.1",
+  "CERN-OHL",
+  "WTFPL",
+  "Unlicense",
+  "open-source",
+  "unrestricted",
+] as const
+
+const kicadPcmV1LicenseSet = new Set<string>(KICAD_PCM_V1_LICENSES)
+
+export const isValidKicadPcmV1License = (license: unknown): license is string =>
+  typeof license === "string" && kicadPcmV1LicenseSet.has(license.trim())
+
+export function assertValidKicadPcmV1License(
+  license: unknown,
+): asserts license is string {
+  if (!isValidKicadPcmV1License(license)) {
+    const value = typeof license === "string" ? license.trim() : ""
+    throw new Error(
+      `Invalid KiCad PCM v1 license "${value || "(empty)"}". Choose a license allowed by ${KICAD_PCM_SCHEMA_URLS[1]} or use schema version 2 for KiCad 10+`,
+    )
+  }
+}
+
+/** KiCad PCM schema v2 accepts any non-empty license string. */
 export const isValidKicadPcmV2License = (license: unknown): license is string =>
   typeof license === "string" && license.trim().length > 0
 
@@ -15,7 +132,26 @@ export function assertValidKicadPcmV2License(
 ): asserts license is string {
   if (!isValidKicadPcmV2License(license)) {
     throw new Error(
-      `Invalid KiCad PCM v2 license "(empty)". License must be a non-empty string allowed by ${KICAD_PCM_SCHEMA_URL}`,
+      `Invalid KiCad PCM v2 license "(empty)". License must be a non-empty string allowed by ${KICAD_PCM_SCHEMA_URLS[2]}`,
     )
   }
+}
+
+export function resolveKicadPcmSchemaVersion({
+  license,
+  preference = "auto",
+}: {
+  license: unknown
+  preference?: KicadPcmSchemaVersionPreference
+}): KicadPcmSchemaVersion {
+  assertValidKicadPcmV2License(license)
+
+  if (preference === 1) {
+    assertValidKicadPcmV1License(license)
+    return 1
+  }
+
+  if (preference === 2) return 2
+
+  return isValidKicadPcmV1License(license) ? 1 : 2
 }

--- a/tests/cli/build/build-config-options.test.ts
+++ b/tests/cli/build/build-config-options.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test"
 import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises"
 import path from "node:path"
+import JSZip from "jszip"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
 const circuitCode = `
@@ -49,7 +50,7 @@ test("build uses config build.kicadLibrary setting", async () => {
   expect(fileList.some((f) => f.includes("footprints"))).toBe(true)
 }, 60_000)
 
-test("build uses config build.kicadPcm setting", async () => {
+test("build uses config build.kicadPcm and kicadPcm settings", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   await mkdir(path.join(tmpDir, "lib"), { recursive: true })
   await writeFile(path.join(tmpDir, "lib", "index.tsx"), libraryCode)
@@ -57,13 +58,17 @@ test("build uses config build.kicadPcm setting", async () => {
     path.join(tmpDir, "package.json"),
     JSON.stringify({
       name: "test-kicad-library",
-      license: "CC-BY-ND-4.0",
+      license: "MIT",
     }),
   )
   await writeFile(
     path.join(tmpDir, "tscircuit.config.json"),
     JSON.stringify({
       mainEntrypoint: "./lib/index.tsx",
+      kicadPcm: {
+        schemaVersion: 1,
+        license: "CC-BY-ND-4.0",
+      },
       build: {
         kicadPcm: true,
       },
@@ -75,6 +80,23 @@ test("build uses config build.kicadPcm setting", async () => {
   const pcmDir = path.join(tmpDir, "dist", "pcm")
   const pcmDirStat = await stat(pcmDir)
   expect(pcmDirStat.isDirectory()).toBe(true)
+
+  const repositoryJson = JSON.parse(
+    await readFile(path.join(pcmDir, "repository.json"), "utf-8"),
+  )
+  const packagesJson = JSON.parse(
+    await readFile(path.join(pcmDir, "packages.json"), "utf-8"),
+  )
+  expect(repositoryJson.$schema).toBe("https://go.kicad.org/pcm/schemas/v1")
+  expect(repositoryJson.schema_version).toBeUndefined()
+  expect(packagesJson.packages[0].license).toBe("CC-BY-ND-4.0")
+
+  const zipName = (await readdir(pcmDir)).find((file) => file.endsWith(".zip"))
+  expect(zipName).toBeDefined()
+  const zip = await JSZip.loadAsync(await readFile(path.join(pcmDir, zipName!)))
+  const metadata = JSON.parse(await zip.files["metadata.json"].async("string"))
+  expect(metadata.$schema).toBe("https://go.kicad.org/pcm/schemas/v1")
+  expect(metadata.license).toBe("CC-BY-ND-4.0")
 }, 60_000)
 
 test("build uses config build.previewImages setting", async () => {

--- a/tests/lib/kicad-pcm-license.test.ts
+++ b/tests/lib/kicad-pcm-license.test.ts
@@ -1,8 +1,18 @@
 import { expect, test } from "bun:test"
 import {
+  assertValidKicadPcmV1License,
   assertValidKicadPcmV2License,
+  isValidKicadPcmV1License,
   isValidKicadPcmV2License,
+  resolveKicadPcmSchemaVersion,
 } from "lib/shared/kicad-pcm-license"
+
+test("accepts licenses from the KiCad PCM v1 schema", () => {
+  expect(isValidKicadPcmV1License("CC-BY-ND-4.0")).toBe(true)
+  expect(isValidKicadPcmV1License("MIT")).toBe(true)
+  expect(isValidKicadPcmV1License("LicenseRef-Custom")).toBe(false)
+  expect(() => assertValidKicadPcmV1License("CC-BY-ND-4.0")).not.toThrow()
+})
 
 test("accepts open license strings from the KiCad PCM v2 schema", () => {
   expect(isValidKicadPcmV2License("CC-BY-ND-4.0")).toBe(true)
@@ -10,7 +20,22 @@ test("accepts open license strings from the KiCad PCM v2 schema", () => {
   expect(() => assertValidKicadPcmV2License("LicenseRef-Custom")).not.toThrow()
 })
 
-test("rejects missing and blank KiCad PCM v2 licenses", () => {
+test("auto selects the oldest compatible PCM schema", () => {
+  expect(resolveKicadPcmSchemaVersion({ license: "CC-BY-ND-4.0" })).toBe(1)
+  expect(resolveKicadPcmSchemaVersion({ license: "LicenseRef-Custom" })).toBe(2)
+})
+
+test("forced v1 rejects licenses that only schema v2 supports", () => {
+  expect(() =>
+    resolveKicadPcmSchemaVersion({
+      license: "LicenseRef-Custom",
+      preference: 1,
+    }),
+  ).toThrow('Invalid KiCad PCM v1 license "LicenseRef-Custom"')
+})
+
+test("rejects missing and blank KiCad PCM licenses", () => {
+  expect(isValidKicadPcmV1License(undefined)).toBe(false)
   expect(isValidKicadPcmV2License(undefined)).toBe(false)
   expect(isValidKicadPcmV2License("")).toBe(false)
   expect(isValidKicadPcmV2License("   ")).toBe(false)

--- a/types/tscircuit.config.schema.json
+++ b/types/tscircuit.config.schema.json
@@ -83,6 +83,22 @@
       "type": "string",
       "description": "Name for the generated KiCad library. Falls back to package.json name, then directory name."
     },
+    "kicadPcm": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schemaVersion": {
+          "enum": ["auto", 1, 2],
+          "description": "KiCad PCM schema version. Auto uses v1 when compatible for KiCad 6-10 support, otherwise v2 for KiCad 10+."
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Distribution-specific license for KiCad PCM output. Falls back to package.json license."
+        }
+      },
+      "description": "KiCad PCM output settings."
+    },
     "alwaysUseLatestTscircuitOnCloud": {
       "type": "boolean",
       "description": "Always use the latest TSCircuit version when building on the cloud."


### PR DESCRIPTION
## Summary

- validate licenses against KiCad's exact PCM v1 license enum
- emit the oldest compatible schema automatically: v1 for KiCad 6–10, v2 for open/custom license strings on KiCad 10+
- preserve the declared license and reject an incompatible forced-v1 build instead of substituting a license
- add `kicadPcm.schemaVersion` and `kicadPcm.license` project settings

## Context

This fixes packages such as Adom's `CC-BY-ND-4.0` library being published under the wrong license while retaining legacy KiCad support. The schema selection follows [KiCad's PCM schema versioning guidance](https://dev-docs.kicad.org/en/addons/index.html#schema-versioning).

## Validation

- `bun test tests/lib/kicad-pcm-license.test.ts tests/cli/build/build-kicad-pcm.test.ts tests/cli/build/build-config-options.test.ts` (16 passed)
- `bunx tsc --noEmit`
- `bun run format:check`
- `git diff --check`
