### PR TITLE
Add solver input debug artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,24 @@ The debug directory contains:
 Use `--autorouter-dump-srj failed` to keep only failed-stage routing data, or
 `--autorouter-dump-srj phase:N` to capture a single stage.
 
+### Debug solver inputs
+
+Use `--solver-debug` to record the constructor inputs for every solver that
+the circuit reports while it renders:
+
+```bash
+tsci build index.circuit.tsx \
+  --solver-debug \
+  --solver-debug-dir dist/solver-debug
+```
+
+Each circuit writes a `solver-inputs.json` artifact beneath the debug
+directory. The file preserves solver event order, identifies the component
+that started each solver, and contains the full constructor argument tuple so
+the solver can be reproduced independently. Values that JSON cannot represent
+directly, such as `undefined`, `NaN`, maps, sets, or circular references, use
+explicit `value_type` records instead of being silently discarded.
+
 ## Development
 
 This command will open the `index.tsx` file for editing.

--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -32,6 +32,8 @@ export interface BuildCommandOptions {
   autorouterTimeout?: string
   autorouterDebugDir?: string
   autorouterDumpSrj?: string | boolean
+  solverDebug?: boolean
+  solverDebugDir?: string
   useCdnJavascript?: boolean
   concurrency?: string
   injectProps?: string

--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -7,6 +7,7 @@ import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import type { AutorouterDiagnosticsOptions } from "lib/shared/autorouter-diagnostics"
+import type { SolverDiagnosticsOptions } from "lib/shared/solver-diagnostics"
 import {
   type DrcIgnoreCounts,
   type DrcIgnoreOptions,
@@ -34,6 +35,7 @@ export const buildFile = async (
       platformConfig?: PlatformConfig
       injectedProps?: Record<string, unknown>
       autorouterDiagnostics?: AutorouterDiagnosticsOptions
+      solverDiagnostics?: SolverDiagnosticsOptions
     },
 ): Promise<BuildFileOutcome> => {
   try {
@@ -61,6 +63,7 @@ export const buildFile = async (
         platformConfig: platformConfigWithCliDefaults,
         injectedProps: options?.injectedProps,
         autorouterDiagnostics: options?.autorouterDiagnostics,
+        solverDiagnostics: options?.solverDiagnostics,
       })
       circuitJson = result.circuitJson
     }

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -11,6 +11,7 @@ import {
   parseAutorouterTimeout,
   type AutorouterDiagnosticsOptions,
 } from "lib/shared/autorouter-diagnostics"
+import type { SolverDiagnosticsOptions } from "lib/shared/solver-diagnostics"
 import { convertToKicadLibrary } from "lib/shared/convert-to-kicad-library"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
 import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
@@ -201,6 +202,14 @@ export const registerBuild = (program: Command) => {
       'Dump SimpleRouteJson inputs/outputs: "all", "failed", or "phase:<index>" (default: failed)',
     )
     .option(
+      "--solver-debug",
+      "Write constructor inputs for every solver event emitted during the build",
+    )
+    .option(
+      "--solver-debug-dir <path>",
+      "Directory for solver input artifacts (default: dist/solver-debug)",
+    )
+    .option(
       "--kicad-pcm",
       "Generate KiCad PCM (Plugin and Content Manager) assets in dist/pcm",
     )
@@ -338,6 +347,30 @@ export const registerBuild = (program: Command) => {
           logOnError: true,
           longRunningLogThresholdMs: 10_000,
         }
+        const solverDebugDir = resolvedOptions?.solverDebugDir
+          ? path.resolve(projectDir, resolvedOptions.solverDebugDir)
+          : path.join(distDir, "solver-debug")
+        const getSolverDiagnostics = ({
+          relativeEntrypoint,
+          outputDirName,
+          log,
+        }: {
+          relativeEntrypoint: string
+          outputDirName: string
+          log?: (message: string) => void
+        }): SolverDiagnosticsOptions | undefined =>
+          resolvedOptions?.solverDebug
+            ? {
+                enabled: true,
+                outputPath: path.join(
+                  solverDebugDir,
+                  outputDirName,
+                  "solver-inputs.json",
+                ),
+                entrypoint: relativeEntrypoint.split(path.sep).join("/"),
+                log,
+              }
+            : undefined
 
         // Parse concurrency option
         const concurrencyValue = Math.max(
@@ -566,6 +599,11 @@ export const registerBuild = (program: Command) => {
               {
                 ...buildOptions,
                 autorouterDiagnostics,
+                solverDiagnostics: getSolverDiagnostics({
+                  relativeEntrypoint: relative,
+                  outputDirName,
+                  log: (message) => console.log(kleur.cyan(message)),
+                }),
               },
             )
             if (resolvedOptions?.profile) {
@@ -625,6 +663,10 @@ export const registerBuild = (program: Command) => {
               glbOutputPath,
               stepOutputPath,
               previewOutputDir,
+              solverDiagnostics: getSolverDiagnostics({
+                relativeEntrypoint: relative,
+                outputDirName,
+              }),
               generatePreviewAssets,
             }
           })
@@ -991,6 +1033,7 @@ export const registerBuild = (program: Command) => {
           resolvedOptions?.autorouterDebug && "autorouter-debug",
           resolvedOptions?.autorouterTimeout && "autorouter-timeout",
           resolvedOptions?.autorouterDumpSrj && "autorouter-dump-srj",
+          resolvedOptions?.solverDebug && "solver-debug",
         ].filter(Boolean) as string[]
 
         if (resolvedOptions?.profile && profileEntries.length > 0) {

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -77,6 +77,12 @@ export const handleBuildFile = async (
                   log: (message) => workerLog(message),
                 }
               : undefined,
+            solverDiagnostics: options?.solverDiagnostics
+              ? {
+                  ...options.solverDiagnostics,
+                  log: (message) => workerLog(message),
+                }
+              : undefined,
             onAsyncEffectStatus: (asyncEffectName) => {
               workerStatus(`waiting on ${asyncEffectName}…`)
             },

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
 import type { AutorouterDiagnosticsOptions } from "lib/shared/autorouter-diagnostics"
+import type { SolverDiagnosticsOptions } from "lib/shared/solver-diagnostics"
 import { ThreadWorkerPool } from "lib/shared/thread-worker-pool"
 import type { DrcIgnoreOptions } from "./drc-diagnostic-filter"
 import type { BuildImageFormatSelection } from "./image-format-selection"
@@ -19,6 +20,7 @@ type BuildJob = {
   glbOutputPath?: string
   stepOutputPath?: string
   previewOutputDir?: string
+  solverDiagnostics?: SolverDiagnosticsOptions
   projectDir: string
   options?: {
     ignoreErrors?: boolean
@@ -28,6 +30,7 @@ type BuildJob = {
       profile?: boolean
       injectedProps?: Record<string, unknown>
       autorouterDiagnostics?: AutorouterDiagnosticsOptions
+      solverDiagnostics?: SolverDiagnosticsOptions
       generatePreviewAssets?: boolean
       imageFormats?: BuildImageFormatSelection
       pcbSnapshotSettings?: PcbSnapshotSettings
@@ -61,6 +64,7 @@ export async function buildFilesWithWorkerPool(options: {
     glbOutputPath?: string
     stepOutputPath?: string
     previewOutputDir?: string
+    solverDiagnostics?: SolverDiagnosticsOptions
     generatePreviewAssets?: boolean
   }>
   projectDir: string
@@ -73,6 +77,7 @@ export async function buildFilesWithWorkerPool(options: {
       profile?: boolean
       injectedProps?: Record<string, unknown>
       autorouterDiagnostics?: AutorouterDiagnosticsOptions
+      solverDiagnostics?: SolverDiagnosticsOptions
       generatePreviewAssets?: boolean
       imageFormats?: BuildImageFormatSelection
       pcbSnapshotSettings?: PcbSnapshotSettings
@@ -171,9 +176,12 @@ export async function buildFilesWithWorkerPool(options: {
         glbOutputPath: file.glbOutputPath,
         stepOutputPath: file.stepOutputPath,
         previewOutputDir: file.previewOutputDir,
+        solverDiagnostics: file.solverDiagnostics,
         projectDir: options.projectDir,
         options: {
           ...options.buildOptions,
+          solverDiagnostics:
+            file.solverDiagnostics ?? options.buildOptions?.solverDiagnostics,
           generatePreviewAssets:
             file.generatePreviewAssets ??
             options.buildOptions?.generatePreviewAssets,

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -1,5 +1,6 @@
 import type { PlatformConfig } from "@tscircuit/props"
 import type { AutorouterDiagnosticsOptions } from "lib/shared/autorouter-diagnostics"
+import type { SolverDiagnosticsOptions } from "lib/shared/solver-diagnostics"
 import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
 import type { DrcIgnoreCounts, DrcIgnoreOptions } from "./drc-diagnostic-filter"
 import type { BuildImageFormatSelection } from "./image-format-selection"
@@ -23,6 +24,7 @@ export type BuildFileMessage = {
       profile?: boolean
       injectedProps?: Record<string, unknown>
       autorouterDiagnostics?: AutorouterDiagnosticsOptions
+      solverDiagnostics?: SolverDiagnosticsOptions
       generatePreviewAssets?: boolean
       imageFormats?: BuildImageFormatSelection
       pcbSnapshotSettings?: PcbSnapshotSettings

--- a/lib/shared/generate-circuit-json.tsx
+++ b/lib/shared/generate-circuit-json.tsx
@@ -15,6 +15,10 @@ import {
   addSourceFilesystemHash,
   getSourceFilesystemMd5Hash,
 } from "./circuit-json-build-cache"
+import {
+  SolverDiagnostics,
+  type SolverDiagnosticsOptions,
+} from "./solver-diagnostics"
 
 const debug = Debug("tsci:generate-circuit-json")
 
@@ -43,6 +47,7 @@ type GenerateCircuitJsonOptions = {
   injectedProps?: Record<string, unknown>
   onAsyncEffectStatus?: (asyncEffectName: string) => void
   autorouterDiagnostics?: AutorouterDiagnosticsOptions
+  solverDiagnostics?: SolverDiagnosticsOptions
   sourceFilesystemMd5Hash?: string
 }
 
@@ -61,6 +66,7 @@ export async function generateCircuitJson({
   injectedProps,
   onAsyncEffectStatus,
   autorouterDiagnostics: autorouterDiagnosticsOptions,
+  solverDiagnostics: solverDiagnosticsOptions,
   sourceFilesystemMd5Hash,
 }: GenerateCircuitJsonOptions) {
   debug(`Generating circuit JSON for ${filePath}`)
@@ -81,6 +87,10 @@ export async function generateCircuitJson({
     autorouterDiagnosticsOptions,
   )
   autorouterDiagnostics.attachToRootCircuit(runner)
+  const solverDiagnostics = solverDiagnosticsOptions
+    ? new SolverDiagnostics(solverDiagnosticsOptions)
+    : null
+  solverDiagnostics?.attachToRootCircuit(runner)
   const absoluteFilePath = path.isAbsolute(filePath)
     ? filePath
     : path.resolve(process.cwd(), filePath)
@@ -175,6 +185,7 @@ export async function generateCircuitJson({
   }
 
   runner.emit("renderComplete")
+  solverDiagnostics?.finalize()
 
   // Get the circuit JSON
   const circuitJson = addSourceFilesystemHash(

--- a/lib/shared/solver-diagnostics.ts
+++ b/lib/shared/solver-diagnostics.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs"
+import path from "node:path"
+
+export type SolverDiagnosticsOptions = {
+  enabled?: boolean
+  outputPath: string
+  entrypoint: string
+  log?: (message: string) => void
+}
+
+type SolverStartedEventPayload = {
+  solverName?: unknown
+  componentName?: unknown
+  solverParams?: unknown
+  solverConstructorArgs?: unknown
+}
+
+const escapeJsonPointerSegment = (segment: string) =>
+  segment.replaceAll("~", "~0").replaceAll("/", "~1")
+
+const cloneAsJson = (
+  value: unknown,
+  ancestors = new WeakMap<object, string>(),
+  path = "#",
+): unknown => {
+  if (value === undefined) return { value_type: "undefined" }
+  if (typeof value === "bigint") {
+    return { value_type: "bigint", value: value.toString() }
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return { value_type: "number", value: value.toString() }
+  }
+  if (typeof value === "number" && Object.is(value, -0)) {
+    return { value_type: "number", value: "-0" }
+  }
+  if (typeof value === "symbol") {
+    return { value_type: "symbol", value: value.description ?? null }
+  }
+  if (typeof value === "function") {
+    return {
+      value_type: "function",
+      name: value.name || null,
+      source: value.toString(),
+    }
+  }
+  if (value === null || typeof value !== "object") return value
+
+  const ancestorPath = ancestors.get(value)
+  if (ancestorPath) {
+    return { value_type: "circular_reference", path: ancestorPath }
+  }
+  ancestors.set(value, path)
+
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item, index) =>
+        cloneAsJson(item, ancestors, `${path}/${index}`),
+      )
+    }
+    if (value instanceof Date) {
+      return { value_type: "date", value: value.toISOString() }
+    }
+    if (value instanceof RegExp) {
+      return {
+        value_type: "regexp",
+        source: value.source,
+        flags: value.flags,
+      }
+    }
+    if (value instanceof Map) {
+      return {
+        value_type: "map",
+        entries: Array.from(value.entries(), ([key, item], index) => [
+          cloneAsJson(key, ancestors, `${path}/entries/${index}/0`),
+          cloneAsJson(item, ancestors, `${path}/entries/${index}/1`),
+        ]),
+      }
+    }
+    if (value instanceof Set) {
+      return {
+        value_type: "set",
+        values: Array.from(value.values(), (item, index) =>
+          cloneAsJson(item, ancestors, `${path}/values/${index}`),
+        ),
+      }
+    }
+    if (value instanceof Error) {
+      return {
+        value_type: "error",
+        name: value.name,
+        message: value.message,
+        stack: value.stack,
+      }
+    }
+
+    const clonedObject: Record<string, unknown> = {}
+    for (const [key, item] of Object.entries(value)) {
+      clonedObject[key] = cloneAsJson(
+        item,
+        ancestors,
+        `${path}/${escapeJsonPointerSegment(key)}`,
+      )
+    }
+    return clonedObject
+  } finally {
+    ancestors.delete(value)
+  }
+}
+
+export class SolverDiagnostics {
+  private readonly options: SolverDiagnosticsOptions
+  private readonly solverInvocations: Array<{
+    sequence: number
+    solver_name: string
+    component_name: string | null
+    constructor_args: unknown
+  }> = []
+
+  constructor(options: SolverDiagnosticsOptions) {
+    this.options = options
+  }
+
+  attachToRootCircuit(rootCircuit: {
+    on?: (eventName: string, listener: (event: unknown) => void) => void
+  }) {
+    if (!this.options.enabled) return
+
+    rootCircuit.on?.("solver:started", (rawEvent) => {
+      const event = rawEvent as SolverStartedEventPayload
+      const constructorArgs = Array.isArray(event.solverConstructorArgs)
+        ? event.solverConstructorArgs
+        : [event.solverParams]
+
+      this.solverInvocations.push({
+        sequence: this.solverInvocations.length,
+        solver_name:
+          typeof event.solverName === "string"
+            ? event.solverName
+            : "unknown_solver",
+        component_name:
+          typeof event.componentName === "string" ? event.componentName : null,
+        constructor_args: cloneAsJson(constructorArgs),
+      })
+    })
+  }
+
+  finalize() {
+    if (!this.options.enabled) return
+
+    fs.mkdirSync(path.dirname(this.options.outputPath), { recursive: true })
+    fs.writeFileSync(
+      this.options.outputPath,
+      `${JSON.stringify(
+        {
+          format: "tscircuit_solver_debug_v1",
+          entrypoint: this.options.entrypoint,
+          solvers: this.solverInvocations,
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    this.options.log?.(`Solver inputs written to ${this.options.outputPath}`)
+  }
+}

--- a/tests/cli/build/build-solver-debug.test.ts
+++ b/tests/cli/build/build-solver-debug.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("build --solver-debug writes schematic solver constructor inputs", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "solver-debug.circuit.tsx")
+  await writeFile(
+    circuitPath,
+    `
+      export default () => (
+        <board width="12mm" height="8mm" routingDisabled>
+          <resistor
+            name="R1"
+            resistance="1k"
+            footprint="0402"
+            schX={-2}
+            pcbX={-2}
+          />
+          <led
+            name="D1"
+            footprint="0603"
+            schX={2}
+            pcbX={2}
+          />
+          <trace from=".R1 > .pin2" to=".D1 > .anode" />
+        </board>
+      )
+    `,
+  )
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout } = await runCommand(
+    "tsci build solver-debug.circuit.tsx --solver-debug",
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stdout).toContain("Solver inputs written to")
+  const artifact = JSON.parse(
+    await readFile(
+      path.join(
+        tmpDir,
+        "dist",
+        "solver-debug",
+        "solver-debug",
+        "solver-inputs.json",
+      ),
+      "utf8",
+    ),
+  )
+  expect(artifact.format).toBe("tscircuit_solver_debug_v1")
+  expect(artifact.entrypoint).toBe("solver-debug.circuit.tsx")
+  const schematicSolver = artifact.solvers.find(
+    ({ solver_name }: { solver_name: string }) =>
+      solver_name === "SchematicTracePipelineSolver",
+  )
+  expect(schematicSolver).toBeDefined()
+  expect(schematicSolver.constructor_args[0]).toMatchObject({
+    chips: expect.any(Array),
+    directConnections: expect.any(Array),
+    netConnections: expect.any(Array),
+  })
+})

--- a/tests/shared/solver-diagnostics.test.ts
+++ b/tests/shared/solver-diagnostics.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import { EventEmitter } from "node:events"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { SolverDiagnostics } from "lib/shared/solver-diagnostics"
+
+test("solver diagnostics records full constructor inputs in event order", () => {
+  const debugDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsci-solver-diagnostics-"),
+  )
+  const outputPath = path.join(debugDir, "solver-inputs.json")
+  const rootCircuit = new EventEmitter()
+  const diagnostics = new SolverDiagnostics({
+    enabled: true,
+    outputPath,
+    entrypoint: "sample.circuit.tsx",
+  })
+  const sharedInput = { connection_count: 2 }
+  const circularInput: { self?: unknown } = {}
+  circularInput.self = circularInput
+
+  diagnostics.attachToRootCircuit(rootCircuit)
+  rootCircuit.emit("solver:started", {
+    solverName: "SchematicTracePipelineSolver",
+    componentName: "<board# />",
+    solverParams: { legacy_input: true },
+    solverConstructorArgs: [
+      {
+        net_ids: new Set(["GND", "LOGIC_3V3"]),
+        optional_value: undefined,
+        invalid_number: Number.NaN,
+        shared_input_a: sharedInput,
+        shared_input_b: sharedInput,
+        circular_input: circularInput,
+      },
+      { hideRatsNet: false },
+    ],
+  })
+  rootCircuit.emit("solver:started", {
+    solverName: "LegacySolver",
+    componentName: "<group# />",
+    solverParams: { input_problem: { connections: 2 } },
+  })
+  diagnostics.finalize()
+
+  const artifact = JSON.parse(fs.readFileSync(outputPath, "utf8"))
+  expect(artifact).toEqual({
+    format: "tscircuit_solver_debug_v1",
+    entrypoint: "sample.circuit.tsx",
+    solvers: [
+      {
+        sequence: 0,
+        solver_name: "SchematicTracePipelineSolver",
+        component_name: "<board# />",
+        constructor_args: [
+          {
+            net_ids: {
+              value_type: "set",
+              values: ["GND", "LOGIC_3V3"],
+            },
+            optional_value: { value_type: "undefined" },
+            invalid_number: { value_type: "number", value: "NaN" },
+            shared_input_a: { connection_count: 2 },
+            shared_input_b: { connection_count: 2 },
+            circular_input: {
+              self: {
+                value_type: "circular_reference",
+                path: "#/0/circular_input",
+              },
+            },
+          },
+          { hideRatsNet: false },
+        ],
+      },
+      {
+        sequence: 1,
+        solver_name: "LegacySolver",
+        component_name: "<group# />",
+        constructor_args: [{ input_problem: { connections: 2 } }],
+      },
+    ],
+  })
+})


### PR DESCRIPTION
## Summary

- add `tsci build --solver-debug`
- add `--solver-debug-dir <path>` with a default beneath `dist/solver-debug`
- watch `solver:started` circuit events and write an ordered `solver-inputs.json` artifact for each circuit
- preserve the full solver constructor tuple when core supplies `solverConstructorArgs`, with a backward-compatible `solverParams` fallback
- encode values JSON cannot represent directly with explicit `value_type` records instead of silently dropping them
- propagate per-circuit diagnostics through sequential and worker build paths

The artifact uses the `tscircuit_solver_debug_v1` format and records the entrypoint, solver name, component name, sequence number, and constructor arguments.

## Validation

- solver diagnostics unit test
- end-to-end `tsci build --solver-debug` test with a real schematic trace solver event
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format`
- `git diff --check`
