### PR TITLE
fix: bridge require("@tscircuit/core") for registry components published before core went ESM-only

### DIFF
--- a/lib/shared/generate-circuit-json.tsx
+++ b/lib/shared/generate-circuit-json.tsx
@@ -10,6 +10,7 @@ import {
   type AutorouterDiagnosticsOptions,
 } from "./autorouter-diagnostics"
 import { importFromUserLand } from "./importFromUserLand"
+import { registerEsmOnlyCoreRequireBridge } from "./register-esm-only-core-require-bridge"
 import { registerStaticAssetLoaders } from "./register-static-asset-loaders"
 import {
   addSourceFilesystemHash,
@@ -95,6 +96,7 @@ export async function generateCircuitJson({
     ? filePath
     : path.resolve(process.cwd(), filePath)
   const projectDir = path.dirname(absoluteFilePath)
+  registerEsmOnlyCoreRequireBridge(projectDir)
   const resolvedOutputDir = outputDir ?? projectDir
 
   // Get the relative path to the component from the project directory

--- a/lib/shared/register-esm-only-core-require-bridge.ts
+++ b/lib/shared/register-esm-only-core-require-bridge.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs"
+import { createRequire } from "node:module"
+import path from "node:path"
+
+let registered = false
+
+const findCorePackageDir = (startDir: string): string | null => {
+  let dir = startDir
+  while (true) {
+    const candidate = path.join(dir, "node_modules", "@tscircuit", "core")
+    if (fs.existsSync(path.join(candidate, "package.json"))) return candidate
+    const parent = path.dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+const getCoreEsmEntry = (corePackageDir: string): string | null => {
+  const packageJsonPath = path.join(corePackageDir, "package.json")
+  if (!fs.existsSync(packageJsonPath)) return null
+
+  const corePkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
+
+  let entry: unknown = corePkg.exports
+  if (entry && typeof entry === "object" && "." in (entry as any)) {
+    entry = (entry as any)["."]
+  }
+  if (entry && typeof entry === "object") {
+    entry = (entry as any).import ?? (entry as any).default
+  }
+  if (typeof entry !== "string") {
+    entry = corePkg.module ?? corePkg.main
+  }
+  if (typeof entry !== "string") return null
+
+  const entryPath = path.join(corePackageDir, entry)
+  return fs.existsSync(entryPath) ? entryPath : null
+}
+
+/**
+ * Registry components published before @tscircuit/core went ESM-only ship CJS
+ * builds that start with `require("@tscircuit/core")`. Core's exports map only
+ * declares an `import` condition, so that require can never resolve and the
+ * build fails with "Cannot find module '@tscircuit/core'" (#3982).
+ *
+ * When requiring core from the project would fail, this registers a virtual
+ * module that serves the project's ESM build of core to both `require()` and
+ * `import` consumers, so every component shares the same core instance.
+ */
+export const registerEsmOnlyCoreRequireBridge = (projectDir: string) => {
+  if (registered) return
+  if (typeof Bun === "undefined") return
+
+  const requireFromProject = createRequire(
+    path.join(projectDir, "node_modules", "noop.cjs"),
+  )
+  try {
+    requireFromProject.resolve("@tscircuit/core")
+    return
+  } catch {}
+
+  const corePackageDir = findCorePackageDir(projectDir)
+  if (!corePackageDir) return
+
+  const coreEsmEntry = getCoreEsmEntry(corePackageDir)
+  if (!coreEsmEntry) return
+
+  Bun.plugin({
+    name: "esm-only-core-require-bridge",
+    setup(build) {
+      build.module("@tscircuit/core", () => ({
+        exports: requireFromProject(coreEsmEntry),
+        loader: "object",
+      }))
+    },
+  })
+  registered = true
+}

--- a/tests/cli/build/build-stale-cjs-registry-component.test.ts
+++ b/tests/cli/build/build-stale-cjs-registry-component.test.ts
@@ -1,0 +1,78 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { mkdir, symlink, writeFile, stat } from "node:fs/promises"
+import path from "node:path"
+
+const stalePartCjs = `"use strict";
+var core = require("@tscircuit/core");
+if (!core || typeof core !== "object" || Object.keys(core).length === 0) {
+  throw new Error("@tscircuit/core resolved but has no exports");
+}
+exports.StaleChip = function StaleChip(props) {
+  return globalThis.React.createElement("chip", {
+    name: props.name || "U1",
+    footprint: "soic8",
+  });
+};
+`
+
+const circuitCode = `import { StaleChip } from "@tsci/testuser.stale-part"
+
+export default () => (
+  <board width="20mm" height="20mm">
+    <StaleChip name="U1" />
+  </board>
+)
+`
+
+test("build succeeds for registry components whose CJS build requires ESM-only @tscircuit/core", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+
+  // Give the project the same ESM-only @tscircuit/core build the CLI ships
+  // with (exports map only declares an `import` condition)
+  const realCoreDir = path.resolve(
+    import.meta.dir,
+    "../../../node_modules/@tscircuit/core",
+  )
+  const tscircuitScopeDir = path.join(tmpDir, "node_modules", "@tscircuit")
+  await mkdir(tscircuitScopeDir, { recursive: true })
+  await symlink(realCoreDir, path.join(tscircuitScopeDir, "core"), "dir")
+  await symlink(
+    path.resolve(import.meta.dir, "../../../node_modules/react"),
+    path.join(tmpDir, "node_modules", "react"),
+    "dir",
+  )
+
+  // A registry component published before core went ESM-only: its CJS build
+  // requires @tscircuit/core at load time (#3982)
+  const stalePartDir = path.join(
+    tmpDir,
+    "node_modules",
+    "@tsci",
+    "testuser.stale-part",
+  )
+  await mkdir(stalePartDir, { recursive: true })
+  await writeFile(
+    path.join(stalePartDir, "package.json"),
+    JSON.stringify({
+      name: "@tsci/testuser.stale-part",
+      version: "1.0.0",
+      main: "index.cjs",
+    }),
+  )
+  await writeFile(path.join(stalePartDir, "index.cjs"), stalePartCjs)
+
+  const circuitPath = path.join(tmpDir, "circuit.tsx")
+  await writeFile(circuitPath, circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { stdout, exitCode } = await runCommand(`tsci build ${circuitPath}`)
+
+  expect(stdout).not.toContain("Cannot find module '@tscircuit/core'")
+  expect(exitCode).toBe(0)
+
+  const circuitJsonStat = await stat(
+    path.join(tmpDir, "dist", "circuit", "circuit.json"),
+  )
+  expect(circuitJsonStat.isFile()).toBe(true)
+}, 120_000)


### PR DESCRIPTION
Fixes #3982 (same failure as #1657, which was closed stale but still reproduces)

### Problem

In a fresh `tsci init` project, `tsci build` fatals when the circuit imports a registry component whose published CJS build starts with `require("@tscircuit/core")`:

```
error: Cannot find module '@tscircuit/core' from '.../node_modules/@tsci/Anshgrover23.AMS1117_3_3/index.cjs'
Fatal error [circuit_generation_failed]: ResolveMessage: Cannot find module '@tscircuit/core'
```

`@tscircuit/core` is ESM-only — its exports map declares only an `import` condition — so that `require()` can never resolve. Every component whose registry build predates core going ESM-only is unusable from `tsci build`, and the error points users at their own setup rather than the stale published artifact.

### Fix

`generateCircuitJson` now registers a small Bun plugin (same registration pattern as `register-static-asset-loaders`) before importing the user's circuit file:

- **Gated:** it first tries `require.resolve("@tscircuit/core")` from the project. If that succeeds (e.g. core ships a `require` condition in the future), the plugin is never registered and nothing changes.
- **Bridge:** when the require is broken, `build.module("@tscircuit/core", ...)` serves the project's ESM build of core to both `require()` and `import` consumers — Bun can require ESM synchronously — so stale CJS registry builds and current ESM code share one core instance.

No behavior change for projects that build fine today: the bridge only registers when resolution is already fatally broken. Under the tsx/Node fallback runtime the function is a no-op (`typeof Bun` guard).

### Test

`tests/cli/build/build-stale-cjs-registry-component.test.ts` reproduces the report: a project with the real ESM-only core symlinked in, plus a minimal `@tsci` package whose CJS entry `require`s core at load time. Without the fix the build fatals with `Cannot find module '@tscircuit/core'`; with it the build exits 0 and emits circuit JSON.

Verified locally: new test passes, `bunx tsc --noEmit` clean, `biome format` clean, `build-transpile` + `build-output-flags` suites still pass (19/19).
