### PR TITLE
Share the project cache across CLI and RunFrame

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -55,6 +55,7 @@ export const buildFile = async (
     // Get complete platform config with kicad_mod support
     const platformConfigWithCliDefaults = getPlatformConfigWithCliDefaults(
       options?.platformConfig,
+      { projectDir },
     )
 
     if (!isPrebuiltCircuitJson) {

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -56,8 +56,10 @@ export const handleBuildFile = async (
       projectConfig?.platformConfig,
       options?.platformConfig as PlatformConfig,
     )
-    const platformConfigWithCliDefaults =
-      getPlatformConfigWithCliDefaults(platformConfig)
+    const platformConfigWithCliDefaults = getPlatformConfigWithCliDefaults(
+      platformConfig,
+      { projectDir },
+    )
 
     const normalizedInputPath = filePath.toLowerCase().replaceAll("\\", "/")
     const isPrebuiltCircuitJson =

--- a/cli/check/netlist/register.ts
+++ b/cli/check/netlist/register.ts
@@ -14,6 +14,7 @@ import {
   type CircuitJsonIssue,
 } from "lib/shared/circuit-json-diagnostics"
 import path from "node:path"
+import { findCircuitProjectDir } from "lib/shared/circuit-json-build-cache"
 
 const normalizeCategory = (category: string): DrcCategory =>
   category === "netlist" ||
@@ -45,11 +46,14 @@ const resolveInputFilePath = async (file?: string) => {
 export const checkNetlist = async (file?: string) => {
   const resolvedInputFilePath = await resolveInputFilePath(file)
 
-  const platformConfigWithCliDefaults = getPlatformConfigWithCliDefaults({
-    pcbDisabled: true,
-    routingDisabled: true,
-    placementDrcChecksDisabled: true,
-  } satisfies PlatformConfig)
+  const platformConfigWithCliDefaults = getPlatformConfigWithCliDefaults(
+    {
+      pcbDisabled: true,
+      routingDisabled: true,
+      placementDrcChecksDisabled: true,
+    } satisfies PlatformConfig,
+    { projectDir: findCircuitProjectDir(resolvedInputFilePath) },
+  )
 
   const { circuitJson } = await getOrGenerateCircuitJson({
     filePath: resolvedInputFilePath,

--- a/cli/check/shared.ts
+++ b/cli/check/shared.ts
@@ -7,6 +7,7 @@ import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-jso
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
 import { isCircuitJsonFile } from "lib/shared/is-circuit-json-file"
+import { findCircuitProjectDir } from "lib/shared/circuit-json-build-cache"
 
 export const resolveCheckInputFilePath = async (file?: string) => {
   if (file) {
@@ -40,8 +41,12 @@ export const getCircuitJsonForCheck = async ({
     return Array.isArray(parsedJson) ? parsedJson : []
   }
 
-  const platformConfigWithCliDefaults =
-    getPlatformConfigWithCliDefaults(platformConfig)
+  const platformConfigWithCliDefaults = getPlatformConfigWithCliDefaults(
+    platformConfig,
+    {
+      projectDir: findCircuitProjectDir(filePath),
+    },
+  )
 
   const { circuitJson } = await getOrGenerateCircuitJson({
     filePath,

--- a/cli/convert/load-circuit-json-for-footprinter.ts
+++ b/cli/convert/load-circuit-json-for-footprinter.ts
@@ -4,6 +4,7 @@ import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config
 import fs from "node:fs/promises"
 import path from "node:path"
 import { convertKicadFootprintToCircuitJson } from "./convert-kicad-footprint-to-circuit-json"
+import { findCircuitProjectDir } from "lib/shared/circuit-json-build-cache"
 
 const componentExtensions = new Set([".js", ".jsx", ".ts", ".tsx"])
 
@@ -25,7 +26,9 @@ export const loadCircuitJsonForFootprinter = async (inputPath: string) => {
     const { circuitJson } = await generateCircuitJson({
       filePath: inputPath,
       injectedProps: { name: "CONVERT" },
-      platformConfig: getPlatformConfigWithCliDefaults(),
+      platformConfig: getPlatformConfigWithCliDefaults(undefined, {
+        projectDir: findCircuitProjectDir(inputPath),
+      }),
     })
     const pcbComponentCount = circuitJson.filter(
       (element) => element.type === "pcb_component",

--- a/cli/export/register.ts
+++ b/cli/export/register.ts
@@ -12,6 +12,7 @@ import type { PlatformConfig } from "@tscircuit/props"
 import { loadRuntimeProjectConfig } from "lib/project-config"
 import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
+import { findCircuitProjectDir } from "lib/shared/circuit-json-build-cache"
 
 export const registerExport = (program: Command) => {
   program
@@ -46,11 +47,17 @@ export const registerExport = (program: Command) => {
           projectConfig?.platformConfig,
           commandPlatformConfig,
         )
+        const platformConfigWithCliDefaults = getPlatformConfigWithCliDefaults(
+          platformConfig,
+          {
+            projectDir: findCircuitProjectDir(file),
+          },
+        )
 
         if (formatOption === "spice") {
           const { circuitJson } = await getOrGenerateCircuitJson({
             filePath: file,
-            platformConfig: getPlatformConfigWithCliDefaults(platformConfig),
+            platformConfig: platformConfigWithCliDefaults,
           })
           if (circuitJson) {
             const spiceString = getSpiceWithPaddedSim(circuitJson as any)
@@ -87,7 +94,7 @@ export const registerExport = (program: Command) => {
           filePath: file,
           format,
           outputPath: options.output,
-          platformConfig,
+          platformConfig: platformConfigWithCliDefaults,
           pcbSnapshotSettings: options.showCourtyards
             ? { showCourtyards: true }
             : undefined,

--- a/cli/simulate/register.ts
+++ b/cli/simulate/register.ts
@@ -7,6 +7,7 @@ import type { PlatformConfig } from "@tscircuit/props"
 import { loadRuntimeProjectConfig } from "lib/project-config"
 import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
+import { findCircuitProjectDir } from "lib/shared/circuit-json-build-cache"
 
 export const registerSimulate = (program: Command) => {
   const simulateCommand = program
@@ -32,7 +33,9 @@ export const registerSimulate = (program: Command) => {
       const { circuitJson } = await getOrGenerateCircuitJson({
         filePath: file,
         saveToFile: false,
-        platformConfig: getPlatformConfigWithCliDefaults(platformConfig),
+        platformConfig: getPlatformConfigWithCliDefaults(platformConfig, {
+          projectDir: findCircuitProjectDir(file),
+        }),
       })
       if (!circuitJson) {
         console.log("error: Failed to generate circuit JSON")

--- a/lib/server/createHttpServer.ts
+++ b/lib/server/createHttpServer.ts
@@ -11,8 +11,69 @@ import pkg from "../../package.json"
 
 // @ts-ignore
 import winterspecBundle from "@tscircuit/file-server/dist/bundle.js"
+import { createLocalCacheEngine } from "../shared/get-platform-config-with-cli-defaults"
 import { getIndex } from "../site/getIndex"
 import { createKicadPcmProxy } from "./kicad-pcm-proxy"
+
+const RUNFRAME_CACHE_PATH = "/__tscircuit/cache"
+const RUNFRAME_EVAL_WORKER_PATH = "/__tscircuit/eval-webworker.js"
+const GLOBAL_LOCAL_CACHE_ENGINE_SYMBOL_KEY = "tscircuit.localCacheEngine"
+const cliRequire = createRequire(import.meta.url)
+
+const injectEvalWorkerPath = (standaloneContent: string): string => {
+  const propertyMarker = "evalWebWorkerBlobUrl:"
+  const propertyIndex = standaloneContent.lastIndexOf(propertyMarker)
+  if (propertyIndex === -1) return standaloneContent
+
+  const valueStart = propertyIndex + propertyMarker.length
+  const nextPropertyMatch = standaloneContent
+    .slice(valueStart)
+    .match(/,\s*enableFetchProxy\s*:/)
+  if (nextPropertyMatch?.index === undefined) return standaloneContent
+
+  const valueEnd = valueStart + nextPropertyMatch.index
+  return `${standaloneContent.slice(0, valueStart)}${JSON.stringify(
+    RUNFRAME_EVAL_WORKER_PATH,
+  )}${standaloneContent.slice(valueEnd)}`
+}
+
+const getCacheWorkerPrelude = (): string => `
+const tscircuitCacheFetch = globalThis.fetch.bind(globalThis)
+const tscircuitCacheApiUrl = new URL(${JSON.stringify(RUNFRAME_CACHE_PATH)}, globalThis.location.href)
+Reflect.set(globalThis, Symbol.for(${JSON.stringify(GLOBAL_LOCAL_CACHE_ENGINE_SYMBOL_KEY)}), {
+  getItem: async (key) => {
+    try {
+      const url = new URL(tscircuitCacheApiUrl)
+      url.searchParams.set("key", key)
+      const response = await tscircuitCacheFetch(url)
+      if (response.status === 404) return null
+      if (!response.ok) return null
+      return await response.text()
+    } catch {
+      return null
+    }
+  },
+  setItem: async (key, value) => {
+    try {
+      const url = new URL(tscircuitCacheApiUrl)
+      url.searchParams.set("key", key)
+      await tscircuitCacheFetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+        body: value,
+      })
+    } catch {}
+  },
+});
+`
+
+const resolveSiblingEvalWorkerPath = (
+  standalonePath?: string,
+): string | undefined => {
+  if (!standalonePath) return undefined
+  const workerPath = path.join(path.dirname(standalonePath), "webworker.min.js")
+  return fs.existsSync(workerPath) ? workerPath : undefined
+}
 
 /**
  * Resolves the standalone runframe + eval bundle (`dist/browser.min.js`) shipped
@@ -27,16 +88,20 @@ const resolveLocalTscircuitStandalonePath = (
   if (!projectDir) return undefined
   try {
     const projectRequire = createRequire(path.join(projectDir, "package.json"))
-    const browserBundlePath = path.join(
-      path.dirname(projectRequire.resolve("tscircuit/package.json")),
-      "dist",
-      "browser.min.js",
-    )
+    const browserBundlePath = projectRequire.resolve("tscircuit/browser")
     if (fs.existsSync(browserBundlePath)) return browserBundlePath
   } catch {
     // `tscircuit` isn't installed locally; fall back to the CLI-bundled runframe
   }
   return undefined
+}
+
+const readRequestBody = async (req: http.IncomingMessage): Promise<string> => {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks).toString("utf8")
 }
 
 export const createHttpServer = async ({
@@ -53,6 +118,9 @@ export const createHttpServer = async ({
   entryFile?: string
 }) => {
   const fileServerHandler = getNodeHandler(winterspecBundle as any, {})
+  const localCacheEngine = projectDir
+    ? createLocalCacheEngine(path.join(projectDir, ".tscircuit", "cache"))
+    : undefined
 
   // Create PCM proxy if enabled
   const pcmProxy =
@@ -63,6 +131,67 @@ export const createHttpServer = async ({
   const server = http.createServer(async (req, res) => {
     const requestHost = req.headers.host ?? `localhost:${port}`
     const url = new URL(req.url!, `http://${requestHost}`)
+
+    if (url.pathname === RUNFRAME_CACHE_PATH) {
+      const key = url.searchParams.get("key")
+      if (!localCacheEngine || !key) {
+        res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" })
+        res.end("A project directory and cache key are required")
+        return
+      }
+
+      if (req.method === "GET") {
+        const value = await localCacheEngine.getItem(key)
+        if (value === null) {
+          res.writeHead(404)
+          res.end()
+          return
+        }
+        res.writeHead(200, {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Cache-Control": "no-store",
+        })
+        res.end(value)
+        return
+      }
+
+      if (req.method === "POST") {
+        await localCacheEngine.setItem(key, await readRequestBody(req))
+        res.writeHead(204)
+        res.end()
+        return
+      }
+
+      res.writeHead(405, { Allow: "GET, POST" })
+      res.end()
+      return
+    }
+
+    if (url.pathname === RUNFRAME_EVAL_WORKER_PATH) {
+      const localStandalonePath =
+        resolveLocalTscircuitStandalonePath(projectDir)
+      const evalWorkerPath =
+        resolveSiblingEvalWorkerPath(localStandalonePath) ??
+        resolveSiblingEvalWorkerPath(
+          process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH,
+        ) ??
+        resolveSiblingEvalWorkerPath(
+          process.env.RUNFRAME_STANDALONE_FILE_PATH,
+        ) ??
+        cliRequire.resolve("@tscircuit/eval/worker-entrypoint")
+
+      try {
+        const workerContent = fs.readFileSync(evalWorkerPath, "utf8")
+        res.writeHead(200, {
+          "Content-Type": "application/javascript; charset=utf-8",
+        })
+        res.end(`${getCacheWorkerPrelude()}\n${workerContent}`)
+      } catch {
+        res.writeHead(404)
+        res.end("Eval worker not found")
+      }
+      return
+    }
 
     if (
       url.pathname === "/api/files/upsert-multipart" &&
@@ -147,7 +276,7 @@ export const createHttpServer = async ({
             res.writeHead(200, {
               "Content-Type": "application/javascript; charset=utf-8",
             })
-            res.end(content)
+            res.end(injectEvalWorkerPath(content))
             return
           } catch {
             // fall back to the global tscircuit bundle, then the CLI
@@ -164,7 +293,7 @@ export const createHttpServer = async ({
             res.writeHead(200, {
               "Content-Type": "application/javascript; charset=utf-8",
             })
-            res.end(content)
+            res.end(injectEvalWorkerPath(content))
             return
           } catch {
             // fall back to the CLI-bundled runframe standalone below
@@ -174,7 +303,7 @@ export const createHttpServer = async ({
         res.writeHead(200, {
           "Content-Type": "application/javascript; charset=utf-8",
         })
-        res.end(runFrameStandaloneBundleContent)
+        res.end(injectEvalWorkerPath(runFrameStandaloneBundleContent))
         return
       }
 
@@ -183,7 +312,7 @@ export const createHttpServer = async ({
         res.writeHead(200, {
           "Content-Type": "application/javascript; charset=utf-8",
         })
-        res.end(content)
+        res.end(injectEvalWorkerPath(content))
         return
       } catch (error) {
         console.info(

--- a/lib/server/createHttpServer.ts
+++ b/lib/server/createHttpServer.ts
@@ -17,7 +17,8 @@ import { createKicadPcmProxy } from "./kicad-pcm-proxy"
 
 const RUNFRAME_CACHE_PATH = "/__tscircuit/cache"
 const RUNFRAME_EVAL_WORKER_PATH = "/__tscircuit/eval-webworker.js"
-const GLOBAL_LOCAL_CACHE_ENGINE_SYMBOL_KEY = "tscircuit.localCacheEngine"
+const INHERITED_LOCAL_CACHE_ENGINE_SYMBOL_KEY =
+  "tscircuit.inheritedLocalCacheEngine"
 const cliRequire = createRequire(import.meta.url)
 
 const injectEvalWorkerPath = (standaloneContent: string): string => {
@@ -40,7 +41,7 @@ const injectEvalWorkerPath = (standaloneContent: string): string => {
 const getCacheWorkerPrelude = (): string => `
 const tscircuitCacheFetch = globalThis.fetch.bind(globalThis)
 const tscircuitCacheApiUrl = new URL(${JSON.stringify(RUNFRAME_CACHE_PATH)}, globalThis.location.href)
-Reflect.set(globalThis, Symbol.for(${JSON.stringify(GLOBAL_LOCAL_CACHE_ENGINE_SYMBOL_KEY)}), {
+Reflect.set(globalThis, Symbol.for(${JSON.stringify(INHERITED_LOCAL_CACHE_ENGINE_SYMBOL_KEY)}), {
   getItem: async (key) => {
     try {
       const url = new URL(tscircuitCacheApiUrl)

--- a/lib/server/createHttpServer.ts
+++ b/lib/server/createHttpServer.ts
@@ -15,66 +15,7 @@ import { createLocalCacheEngine } from "../shared/get-platform-config-with-cli-d
 import { getIndex } from "../site/getIndex"
 import { createKicadPcmProxy } from "./kicad-pcm-proxy"
 
-const RUNFRAME_CACHE_PATH = "/__tscircuit/cache"
-const RUNFRAME_EVAL_WORKER_PATH = "/__tscircuit/eval-webworker.js"
-const INHERITED_LOCAL_CACHE_ENGINE_SYMBOL_KEY =
-  "tscircuit.inheritedLocalCacheEngine"
-const cliRequire = createRequire(import.meta.url)
-
-const injectEvalWorkerPath = (standaloneContent: string): string => {
-  const propertyMarker = "evalWebWorkerBlobUrl:"
-  const propertyIndex = standaloneContent.lastIndexOf(propertyMarker)
-  if (propertyIndex === -1) return standaloneContent
-
-  const valueStart = propertyIndex + propertyMarker.length
-  const nextPropertyMatch = standaloneContent
-    .slice(valueStart)
-    .match(/,\s*enableFetchProxy\s*:/)
-  if (nextPropertyMatch?.index === undefined) return standaloneContent
-
-  const valueEnd = valueStart + nextPropertyMatch.index
-  return `${standaloneContent.slice(0, valueStart)}${JSON.stringify(
-    RUNFRAME_EVAL_WORKER_PATH,
-  )}${standaloneContent.slice(valueEnd)}`
-}
-
-const getCacheWorkerPrelude = (): string => `
-const tscircuitCacheFetch = globalThis.fetch.bind(globalThis)
-const tscircuitCacheApiUrl = new URL(${JSON.stringify(RUNFRAME_CACHE_PATH)}, globalThis.location.href)
-Reflect.set(globalThis, Symbol.for(${JSON.stringify(INHERITED_LOCAL_CACHE_ENGINE_SYMBOL_KEY)}), {
-  getItem: async (key) => {
-    try {
-      const url = new URL(tscircuitCacheApiUrl)
-      url.searchParams.set("key", key)
-      const response = await tscircuitCacheFetch(url)
-      if (response.status === 404) return null
-      if (!response.ok) return null
-      return await response.text()
-    } catch {
-      return null
-    }
-  },
-  setItem: async (key, value) => {
-    try {
-      const url = new URL(tscircuitCacheApiUrl)
-      url.searchParams.set("key", key)
-      await tscircuitCacheFetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "text/plain; charset=utf-8" },
-        body: value,
-      })
-    } catch {}
-  },
-});
-`
-
-const resolveSiblingEvalWorkerPath = (
-  standalonePath?: string,
-): string | undefined => {
-  if (!standalonePath) return undefined
-  const workerPath = path.join(path.dirname(standalonePath), "webworker.min.js")
-  return fs.existsSync(workerPath) ? workerPath : undefined
-}
+const RUNFRAME_CACHE_PATH = "/api/cache"
 
 /**
  * Resolves the standalone runframe + eval bundle (`dist/browser.min.js`) shipped
@@ -168,32 +109,6 @@ export const createHttpServer = async ({
       return
     }
 
-    if (url.pathname === RUNFRAME_EVAL_WORKER_PATH) {
-      const localStandalonePath =
-        resolveLocalTscircuitStandalonePath(projectDir)
-      const evalWorkerPath =
-        resolveSiblingEvalWorkerPath(localStandalonePath) ??
-        resolveSiblingEvalWorkerPath(
-          process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH,
-        ) ??
-        resolveSiblingEvalWorkerPath(
-          process.env.RUNFRAME_STANDALONE_FILE_PATH,
-        ) ??
-        cliRequire.resolve("@tscircuit/eval/worker-entrypoint")
-
-      try {
-        const workerContent = fs.readFileSync(evalWorkerPath, "utf8")
-        res.writeHead(200, {
-          "Content-Type": "application/javascript; charset=utf-8",
-        })
-        res.end(`${getCacheWorkerPrelude()}\n${workerContent}`)
-      } catch {
-        res.writeHead(404)
-        res.end("Eval worker not found")
-      }
-      return
-    }
-
     if (
       url.pathname === "/api/files/upsert-multipart" &&
       req.method === "POST"
@@ -277,7 +192,7 @@ export const createHttpServer = async ({
             res.writeHead(200, {
               "Content-Type": "application/javascript; charset=utf-8",
             })
-            res.end(injectEvalWorkerPath(content))
+            res.end(content)
             return
           } catch {
             // fall back to the global tscircuit bundle, then the CLI
@@ -294,7 +209,7 @@ export const createHttpServer = async ({
             res.writeHead(200, {
               "Content-Type": "application/javascript; charset=utf-8",
             })
-            res.end(injectEvalWorkerPath(content))
+            res.end(content)
             return
           } catch {
             // fall back to the CLI-bundled runframe standalone below
@@ -304,7 +219,7 @@ export const createHttpServer = async ({
         res.writeHead(200, {
           "Content-Type": "application/javascript; charset=utf-8",
         })
-        res.end(injectEvalWorkerPath(runFrameStandaloneBundleContent))
+        res.end(runFrameStandaloneBundleContent)
         return
       }
 
@@ -313,7 +228,7 @@ export const createHttpServer = async ({
         res.writeHead(200, {
           "Content-Type": "application/javascript; charset=utf-8",
         })
-        res.end(injectEvalWorkerPath(content))
+        res.end(content)
         return
       } catch (error) {
         console.info(

--- a/lib/shared/get-platform-config-with-cli-defaults.ts
+++ b/lib/shared/get-platform-config-with-cli-defaults.ts
@@ -40,6 +40,8 @@ export function createLocalCacheEngine(
 
 /**
  * Get a platform config with CLI defaults, KiCad parsing support, and any user overrides.
+ * The project directory keeps persistent caches stable across CLI commands and
+ * worker modes, even when they run with different working directories.
  * This handles the conversion of absolute file paths to file:// URLs for Bun's fetch.
  * When Bun imports a .kicad_mod file, it returns an absolute path like "/path/to/file.kicad_mod".
  * The default loadFromUrl expects a URL, so we wrap it to convert paths to file:// URLs.
@@ -47,12 +49,16 @@ export function createLocalCacheEngine(
  */
 export function getPlatformConfigWithCliDefaults(
   userConfig?: PlatformConfig,
+  options?: { projectDir?: string },
 ): PlatformConfig {
   const basePlatformConfig = getPlatformConfig()
+  const cacheDir = options?.projectDir
+    ? path.join(options.projectDir, ".tscircuit", "cache")
+    : undefined
 
   const defaultConfig: PlatformConfig = {
     ...basePlatformConfig,
-    localCacheEngine: createLocalCacheEngine(),
+    localCacheEngine: createLocalCacheEngine(cacheDir),
     // Override footprintFileParserMap to handle file paths from native imports
     footprintFileParserMap: {
       ...basePlatformConfig.footprintFileParserMap,

--- a/lib/shared/process-snapshot-file.ts
+++ b/lib/shared/process-snapshot-file.ts
@@ -76,8 +76,10 @@ export const processSnapshotFile = async ({
       const parsed = JSON.parse(fs.readFileSync(file, "utf-8"))
       circuitJson = Array.isArray(parsed) ? parsed : []
     } else {
-      const platformConfigWithCliDefaults =
-        getPlatformConfigWithCliDefaults(platformConfig)
+      const platformConfigWithCliDefaults = getPlatformConfigWithCliDefaults(
+        platformConfig,
+        { projectDir },
+      )
 
       const result = await getOrGenerateCircuitJson({
         filePath: file,

--- a/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
+++ b/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
@@ -123,7 +123,9 @@ test("RunFrame's worker reads and writes the CLI project cache", async () => {
     const worker = await fetch(`${origin}/__tscircuit/eval-webworker.js`).then(
       (res) => res.text(),
     )
-    expect(worker).toContain('Symbol.for("tscircuit.localCacheEngine")')
+    expect(worker).toContain(
+      'Symbol.for("tscircuit.inheritedLocalCacheEngine")',
+    )
     expect(worker).toContain("LOCAL_TSCIRCUIT_WORKER_SENTINEL")
 
     const cache = createLocalCacheEngine(join(tmpDir, ".tscircuit", "cache"))

--- a/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
+++ b/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
@@ -6,11 +6,8 @@ import getPort from "get-port"
 import { createLocalCacheEngine } from "lib/shared/get-platform-config-with-cli-defaults"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
-const LOCAL_BUNDLE =
-  'const config={evalWebWorkerBlobUrl:"embedded",enableFetchProxy:true};/* LOCAL_TSCIRCUIT_BUNDLE_SENTINEL */'
-const GLOBAL_BUNDLE =
-  'const config={evalWebWorkerBlobUrl:"embedded",enableFetchProxy:true};/* GLOBAL_TSCIRCUIT_BUNDLE_SENTINEL */'
-const LOCAL_WORKER = "/* LOCAL_TSCIRCUIT_WORKER_SENTINEL */"
+const LOCAL_BUNDLE = "LOCAL_TSCIRCUIT_BUNDLE_SENTINEL"
+const GLOBAL_BUNDLE = "GLOBAL_TSCIRCUIT_BUNDLE_SENTINEL"
 
 const writeProject = async (projectDir: string) => {
   await writeFile(
@@ -35,7 +32,6 @@ const installLocalTscircuit = async (projectDir: string, bundle: string) => {
     }),
   )
   await writeFile(join(tscircuitDir, "dist", "browser.min.js"), bundle)
-  await writeFile(join(tscircuitDir, "dist", "webworker.min.js"), LOCAL_WORKER)
 }
 
 const fetchStandalone = async (projectDir: string) => {
@@ -71,11 +67,7 @@ test("dev server serves the project-local tscircuit bundle, even when a global b
   process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = globalBundlePath
 
   try {
-    const standalone = await fetchStandalone(tmpDir)
-    expect(standalone).toContain("LOCAL_TSCIRCUIT_BUNDLE_SENTINEL")
-    expect(standalone).toContain(
-      'evalWebWorkerBlobUrl:"/__tscircuit/eval-webworker.js"',
-    )
+    expect(await fetchStandalone(tmpDir)).toBe(LOCAL_BUNDLE)
   } finally {
     process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = undefined
   }
@@ -95,17 +87,13 @@ test("dev server falls back to TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH when no loc
   process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = globalBundlePath
 
   try {
-    const standalone = await fetchStandalone(tmpDir)
-    expect(standalone).toContain("GLOBAL_TSCIRCUIT_BUNDLE_SENTINEL")
-    expect(standalone).toContain(
-      'evalWebWorkerBlobUrl:"/__tscircuit/eval-webworker.js"',
-    )
+    expect(await fetchStandalone(tmpDir)).toBe(GLOBAL_BUNDLE)
   } finally {
     process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = undefined
   }
 }, 30_000)
 
-test("RunFrame's worker reads and writes the CLI project cache", async () => {
+test("RunFrame's cache API reads and writes the CLI project cache", async () => {
   const { tmpDir } = await getCliTestFixture()
   await writeProject(tmpDir)
   await installLocalTscircuit(tmpDir, LOCAL_BUNDLE)
@@ -120,23 +108,15 @@ test("RunFrame's worker reads and writes the CLI project cache", async () => {
   try {
     await devServer.start()
     const origin = `http://localhost:${port}`
-    const worker = await fetch(`${origin}/__tscircuit/eval-webworker.js`).then(
-      (res) => res.text(),
-    )
-    expect(worker).toContain(
-      'Symbol.for("tscircuit.inheritedLocalCacheEngine")',
-    )
-    expect(worker).toContain("LOCAL_TSCIRCUIT_WORKER_SENTINEL")
-
     const cache = createLocalCacheEngine(join(tmpDir, ".tscircuit", "cache"))
     cache.setItem("written-by-cli", '{"source":"cli"}')
 
-    const cliValue = await fetch(
-      `${origin}/__tscircuit/cache?key=written-by-cli`,
-    ).then((res) => res.text())
+    const cliValue = await fetch(`${origin}/api/cache?key=written-by-cli`).then(
+      (res) => res.text(),
+    )
     expect(cliValue).toBe('{"source":"cli"}')
 
-    await fetch(`${origin}/__tscircuit/cache?key=written-by-runframe`, {
+    await fetch(`${origin}/api/cache?key=written-by-runframe`, {
       method: "POST",
       body: '{"source":"runframe"}',
     })

--- a/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
+++ b/tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts
@@ -1,12 +1,16 @@
 import { expect, test } from "bun:test"
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
 import { DevServer } from "cli/dev/DevServer"
 import getPort from "get-port"
-import { join } from "node:path"
-import { mkdir, writeFile } from "node:fs/promises"
+import { createLocalCacheEngine } from "lib/shared/get-platform-config-with-cli-defaults"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
-const LOCAL_BUNDLE = "LOCAL_TSCIRCUIT_BUNDLE_SENTINEL"
-const GLOBAL_BUNDLE = "GLOBAL_TSCIRCUIT_BUNDLE_SENTINEL"
+const LOCAL_BUNDLE =
+  'const config={evalWebWorkerBlobUrl:"embedded",enableFetchProxy:true};/* LOCAL_TSCIRCUIT_BUNDLE_SENTINEL */'
+const GLOBAL_BUNDLE =
+  'const config={evalWebWorkerBlobUrl:"embedded",enableFetchProxy:true};/* GLOBAL_TSCIRCUIT_BUNDLE_SENTINEL */'
+const LOCAL_WORKER = "/* LOCAL_TSCIRCUIT_WORKER_SENTINEL */"
 
 const writeProject = async (projectDir: string) => {
   await writeFile(
@@ -31,6 +35,7 @@ const installLocalTscircuit = async (projectDir: string, bundle: string) => {
     }),
   )
   await writeFile(join(tscircuitDir, "dist", "browser.min.js"), bundle)
+  await writeFile(join(tscircuitDir, "dist", "webworker.min.js"), LOCAL_WORKER)
 }
 
 const fetchStandalone = async (projectDir: string) => {
@@ -66,9 +71,13 @@ test("dev server serves the project-local tscircuit bundle, even when a global b
   process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = globalBundlePath
 
   try {
-    expect(await fetchStandalone(tmpDir)).toBe(LOCAL_BUNDLE)
+    const standalone = await fetchStandalone(tmpDir)
+    expect(standalone).toContain("LOCAL_TSCIRCUIT_BUNDLE_SENTINEL")
+    expect(standalone).toContain(
+      'evalWebWorkerBlobUrl:"/__tscircuit/eval-webworker.js"',
+    )
   } finally {
-    delete process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH
+    process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = undefined
   }
 }, 30_000)
 
@@ -86,8 +95,51 @@ test("dev server falls back to TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH when no loc
   process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = globalBundlePath
 
   try {
-    expect(await fetchStandalone(tmpDir)).toBe(GLOBAL_BUNDLE)
+    const standalone = await fetchStandalone(tmpDir)
+    expect(standalone).toContain("GLOBAL_TSCIRCUIT_BUNDLE_SENTINEL")
+    expect(standalone).toContain(
+      'evalWebWorkerBlobUrl:"/__tscircuit/eval-webworker.js"',
+    )
   } finally {
-    delete process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH
+    process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = undefined
+  }
+}, 30_000)
+
+test("RunFrame's worker reads and writes the CLI project cache", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  await writeProject(tmpDir)
+  await installLocalTscircuit(tmpDir, LOCAL_BUNDLE)
+
+  const port = await getPort()
+  const devServer = new DevServer({
+    port,
+    componentFilePath: join(tmpDir, "index.tsx"),
+    projectDir: tmpDir,
+  })
+
+  try {
+    await devServer.start()
+    const origin = `http://localhost:${port}`
+    const worker = await fetch(`${origin}/__tscircuit/eval-webworker.js`).then(
+      (res) => res.text(),
+    )
+    expect(worker).toContain('Symbol.for("tscircuit.localCacheEngine")')
+    expect(worker).toContain("LOCAL_TSCIRCUIT_WORKER_SENTINEL")
+
+    const cache = createLocalCacheEngine(join(tmpDir, ".tscircuit", "cache"))
+    cache.setItem("written-by-cli", '{"source":"cli"}')
+
+    const cliValue = await fetch(
+      `${origin}/__tscircuit/cache?key=written-by-cli`,
+    ).then((res) => res.text())
+    expect(cliValue).toBe('{"source":"cli"}')
+
+    await fetch(`${origin}/__tscircuit/cache?key=written-by-runframe`, {
+      method: "POST",
+      body: '{"source":"runframe"}',
+    })
+    expect(cache.getItem("written-by-runframe")).toBe('{"source":"runframe"}')
+  } finally {
+    await devServer.stop()
   }
 }, 30_000)

--- a/tests/shared/filesystem-cache.test.ts
+++ b/tests/shared/filesystem-cache.test.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "bun:test"
-import { createLocalCacheEngine } from "lib/shared/get-platform-config-with-cli-defaults"
+import {
+  createLocalCacheEngine,
+  getPlatformConfigWithCliDefaults,
+} from "lib/shared/get-platform-config-with-cli-defaults"
 import { createHash } from "node:crypto"
 import { temporaryDirectory } from "tempy"
 import fs from "node:fs"
@@ -75,4 +78,19 @@ test("filesystem cache different keys produce different files", () => {
 
   const files = fs.readdirSync(cacheDir)
   expect(files.length).toBe(2)
+})
+
+test("CLI defaults keep the cache in the resolved project directory", async () => {
+  const projectDir = temporaryDirectory()
+  const projectCacheDir = path.join(projectDir, ".tscircuit", "cache")
+  const platformConfig = getPlatformConfigWithCliDefaults(undefined, {
+    projectDir,
+  })
+
+  await platformConfig.localCacheEngine!.setItem(
+    "routes:core@test:srj:translated",
+    '{"traces":[]}',
+  )
+
+  expect(fs.readdirSync(projectCacheDir)).toHaveLength(1)
 })


### PR DESCRIPTION
## What

- anchor the default local cache at the resolved circuit project directory
- pass the project directory through build workers, snapshots, export, simulate, checks, and conversion flows
- apply CLI platform defaults consistently to non-SPICE exports
- expose the same filesystem cache to RunFrame through `/api/cache`
- resolve project-local `tscircuit` through its exported browser entry

## Why

The CLI created `.tscircuit/cache` relative to `process.cwd()`, so different command and worker paths could use different directories for the same project. CLI-hosted RunFrame also needs access to that project cache while its circuit executes in a browser worker.

RunFrame now owns the HTTP-backed `localCacheEngine` in tscircuit/runframe#4293. The CLI only provides persistent `getItem` and `setItem` storage backed by `<projectDir>/.tscircuit/cache`; no worker rewriting or global cache hook is required.

## Impact

CLI commands and autorouting inside RunFrame can read and commit the same persistent cache. Together with tscircuit/core#2993, identical translated subcircuits can reuse cached autorouting results.

## Checks

- `bun test tests/cli/dev/dev-server-local-tscircuit-standalone.test.ts tests/shared/filesystem-cache.test.ts`
- `bunx tsc --noEmit`
- `bun run build`

