### PR TITLE
Correct JLCPCB fabrication PnP rotations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@tscircuit/image-utils": "^0.0.8",
         "@tscircuit/krt-wasm": "^0.1.6",
         "@tscircuit/math-utils": "0.0.36",
-        "@tscircuit/props": "^0.0.592",
+        "@tscircuit/props": "^0.0.612",
         "@tscircuit/runframe": "^0.0.2349",
         "@tscircuit/schematic-match-adapt": "^0.0.22",
         "@tscircuit/solver-utils": "0.0.16",
@@ -32,14 +32,14 @@
         "@types/semver": "^7.5.8",
         "bun-match-svg": "^0.0.12",
         "chokidar": "4.0.1",
-        "circuit-json": "^0.0.455",
+        "circuit-json": "^0.0.464",
         "circuit-json-to-3d-png": "^0.0.6",
         "circuit-json-to-bom-csv": "^0.0.7",
         "circuit-json-to-connectivity-map": "^0.0.25",
         "circuit-json-to-footprinter": "^0.0.15",
         "circuit-json-to-gerber": "^0.0.83",
         "circuit-json-to-kicad": "0.0.157",
-        "circuit-json-to-pnp-csv": "^0.0.7",
+        "circuit-json-to-pnp-csv": "^0.0.9",
         "circuit-json-to-readable-netlist": "^0.0.15",
         "circuit-json-to-spice": "^0.0.45",
         "circuit-json-to-step": "^0.0.38",
@@ -84,7 +84,7 @@
         "zod": "^3.23.8",
       },
       "peerDependencies": {
-        "circuit-json": "^0.0.446",
+        "circuit-json": "^0.0.464",
         "tscircuit": "*",
       },
     },
@@ -362,7 +362,7 @@
 
     "@tscircuit/ngspice-spice-engine": ["@tscircuit/ngspice-spice-engine@0.0.19", "", { "peerDependencies": { "@tscircuit/props": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-HV/HrShlvQWSNJtjBJqBmFIvRUHOZYoIGjNdNaNhN7EvHpJ2MdVmqU/c4D+DzOVU/J7vg8R6yLvUHixXvH5LFg=="],
 
-    "@tscircuit/props": ["@tscircuit/props@0.0.592", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-XNladsKlcUi7jDMXU9XH4FibfUghMxRAsd4CiSnp8L3grmzZVg/WY5+i4nxP7XwNjxiq1BT7BHJ7yeHviNZ5eg=="],
+    "@tscircuit/props": ["@tscircuit/props@0.0.612", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-IGQbizDpQPXWXifdrmUEiU9W1tkyz98t6TeJhp+4gyfK405whQgvX4pjTFujV+ch2qy6zYt/TzHE+8A8RsdaFQ=="],
 
     "@tscircuit/runframe": ["@tscircuit/runframe@0.0.2349", "", { "dependencies": { "@tscircuit/eval": "^0.0.1124", "@tscircuit/solver-utils": "^0.0.7", "debug": "^4.4.0" } }, "sha512-nFhUY/FpXmaqTix+IJtTFqbDSSQCaFgI3YxLYImwtArHdumRI0XVJEN02sENloe0BbsY2JcBPlUGYIIaAPLB1g=="],
 
@@ -488,7 +488,7 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "circuit-json": ["circuit-json@0.0.455", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-QxlDaLTvPfjTfsdZFrPtUgA9V4TTOWrtKH+YGxq8IrcZVpqiaZzUpzHdvS426h8yCmi7hThxZsiBLTiuLUp7Rg=="],
+    "circuit-json": ["circuit-json@0.0.464", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-ZsiPAc1R8/mzm3ebRjmkfzu5qUVFsdAiS1ZPYKNuR9E5Jr321IzYc/IH1ce2ikVAAA4MY8uTKEb5SzuCFArCWQ=="],
 
     "circuit-json-to-3d-png": ["circuit-json-to-3d-png@0.0.6", "", { "dependencies": { "@resvg/resvg-js": "^2.6.2", "poppygl": "^0.0.24" }, "peerDependencies": { "circuit-json": "*", "circuit-json-to-gltf": "*", "typescript": "^5" } }, "sha512-zZSnhIjZrJGG9ITWvSlWRKSY/dksIPkggZQyaVaHv1No5o8uG0l0HsZlcwx+vtoN1bIdm8GVp8dSRKIza63JOA=="],
 
@@ -506,7 +506,7 @@
 
     "circuit-json-to-kicad": ["circuit-json-to-kicad@0.0.157", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Fm640ScrkVCtkx6KnpgJBjprC5PA4tsful2gZyhlEnKLKLGhYsIp6hrdh0jpJK8H+CItWt6TdeV9JcxYFhRrYw=="],
 
-    "circuit-json-to-pnp-csv": ["circuit-json-to-pnp-csv@0.0.7", "", { "dependencies": { "papaparse": "^5.4.1" }, "peerDependencies": { "@tscircuit/soup-util": "*", "typescript": "^5.0.0" } }, "sha512-WAdNRHtaPhQM8X5NN/43WMBKDCEKQSLShg/mHIZxMUzJviymnfbq6rJj/2WvDqm/bogey34PyTEHwF3mC7zxlQ=="],
+    "circuit-json-to-pnp-csv": ["circuit-json-to-pnp-csv@0.0.9", "", { "dependencies": { "papaparse": "^5.4.1" }, "peerDependencies": { "@tscircuit/soup-util": "*", "typescript": "^5.0.0" } }, "sha512-viHpZUlYX59jnMI0zG3mt3EDKtH/H1tM8g32q1lzONrHWSfOpCqdHUsWIaSrPk1Nt1fk/aECo1YwjBnUgL0Y+A=="],
 
     "circuit-json-to-readable-netlist": ["circuit-json-to-readable-netlist@0.0.15", "", { "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.0.0" } }, "sha512-mnWH1WIkH+BrMIYDRspWKlLa8fGB/mlGKBi5NsMBpV7UHNc3Bn2EC+KIKcEY9I3EhspfXXOW5GUI7leehdP3mA=="],
 

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -182,7 +182,7 @@ export const exportSnippet = async ({
     const fabricationPlatformConfig = isJlcpcbFabricationExport
       ? getPlatformConfigWithCliDefaults(
           mergePlatformConfigs(platformConfig, {
-            usePartOrientationAnalysis: true,
+            enablePartOrientationAnalysis: true,
           }),
         )
       : platformConfig

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -2,9 +2,17 @@ import fs from "node:fs"
 import path from "node:path"
 import { promisify } from "node:util"
 import type { PlatformConfig } from "@tscircuit/props"
-import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
-import { importFromUserLand } from "./importFromUserLand"
 import type { AnyCircuitElement } from "circuit-json"
+import {
+  convertBomRowsToCsv,
+  convertCircuitJsonToBomRows,
+} from "circuit-json-to-bom-csv"
+import {
+  convertSoupToExcellonDrillCommands,
+  convertSoupToGerberCommands,
+  stringifyExcellonDrill,
+  stringifyGerberCommandLayers,
+} from "circuit-json-to-gerber"
 import { convertCircuitJsonToGltf } from "circuit-json-to-gltf"
 import {
   CircuitJsonToKicadPcbConverter,
@@ -12,31 +20,26 @@ import {
   CircuitJsonToKicadSchConverter,
   resolveAndLoadKicad3dModelFiles,
 } from "circuit-json-to-kicad"
+import { convertCircuitJsonToPickAndPlaceCsv } from "circuit-json-to-pnp-csv"
 import { convertCircuitJsonToReadableNetlist } from "circuit-json-to-readable-netlist"
+import { circuitJsonToStep } from "circuit-json-to-step"
 import {
+  convertCircuitJsonToAssemblySvg,
   convertCircuitJsonToPcbSvg,
   convertCircuitJsonToSchematicSvg,
-  convertCircuitJsonToAssemblySvg,
 } from "circuit-to-svg"
 import { convertCircuitJsonToDsnString } from "dsn-converter"
 import JSZip from "jszip"
-import { circuitJsonToStep } from "circuit-json-to-step"
-import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-json"
+import type { PcbSnapshotSettings } from "lib/project-config/project-config-schema"
+import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { getCircuitJsonToGltfOptions } from "lib/shared/get-circuit-json-to-gltf-options"
+import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-json"
+import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import { loadLocalStepModelFsMap } from "lib/shared/load-local-step-model-fs-map"
+import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
 import { convertToKicadLibrary } from "./convert-to-kicad-library"
+import { importFromUserLand } from "./importFromUserLand"
 import { isCircuitJsonFile } from "./is-circuit-json-file"
-import {
-  convertSoupToGerberCommands,
-  stringifyGerberCommandLayers,
-  convertSoupToExcellonDrillCommands,
-  stringifyExcellonDrill,
-} from "circuit-json-to-gerber"
-import {
-  convertCircuitJsonToBomRows,
-  convertBomRowsToCsv,
-} from "circuit-json-to-bom-csv"
-import { convertCircuitJsonToPickAndPlaceCsv } from "circuit-json-to-pnp-csv"
 
 const writeFileAsync = promisify(fs.writeFile)
 
@@ -175,10 +178,21 @@ export const exportSnippet = async ({
       return onExit(1)
     }
   } else {
-    const circuitData = await getOrGenerateCircuitJson({
+    const isJlcpcbFabricationExport = format === "gerbers"
+    const fabricationPlatformConfig = isJlcpcbFabricationExport
+      ? getPlatformConfigWithCliDefaults(
+          mergePlatformConfigs(platformConfig, {
+            usePartOrientationAnalysis: true,
+          }),
+        )
+      : platformConfig
+    const generateCircuitData = isJlcpcbFabricationExport
+      ? generateCircuitJson
+      : getOrGenerateCircuitJson
+    const circuitData = await generateCircuitData({
       filePath,
       saveToFile: format === "circuit-json",
-      platformConfig,
+      platformConfig: fabricationPlatformConfig,
     }).catch((err) => {
       onError(`Error generating circuit JSON: ${err}`)
       return null
@@ -320,7 +334,9 @@ export const exportSnippet = async ({
       const bomCsv = await convertBomRowsToCsv(bomRows)
       zip.file("bom.csv", bomCsv)
 
-      const pnpCsv = await convertCircuitJsonToPickAndPlaceCsv(circuitJson)
+      const pnpCsv = await convertCircuitJsonToPickAndPlaceCsv(circuitJson, {
+        supplier: "jlcpcb",
+      })
       zip.file("pick_and_place.csv", pnpCsv)
 
       outputContent = await zip.generateAsync({ type: "nodebuffer" })

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/krt-wasm": "^0.1.6",
     "@tscircuit/math-utils": "0.0.36",
-    "@tscircuit/props": "^0.0.592",
+    "@tscircuit/props": "^0.0.612",
     "@tscircuit/runframe": "^0.0.2349",
     "@tscircuit/schematic-match-adapt": "^0.0.22",
     "@tscircuit/solver-utils": "0.0.16",
@@ -34,14 +34,14 @@
     "@types/semver": "^7.5.8",
     "bun-match-svg": "^0.0.12",
     "chokidar": "4.0.1",
-    "circuit-json": "^0.0.455",
+    "circuit-json": "^0.0.464",
     "circuit-json-to-3d-png": "^0.0.6",
     "circuit-json-to-bom-csv": "^0.0.7",
     "circuit-json-to-connectivity-map": "^0.0.25",
     "circuit-json-to-footprinter": "^0.0.15",
     "circuit-json-to-gerber": "^0.0.83",
     "circuit-json-to-kicad": "0.0.157",
-    "circuit-json-to-pnp-csv": "^0.0.7",
+    "circuit-json-to-pnp-csv": "^0.0.9",
     "circuit-json-to-readable-netlist": "^0.0.15",
     "circuit-json-to-spice": "^0.0.45",
     "circuit-json-to-step": "^0.0.38",
@@ -86,7 +86,7 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "circuit-json": "^0.0.446",
+    "circuit-json": "^0.0.464",
     "tscircuit": "*"
   },
   "bin": {

--- a/tests/shared/export-snippet-part-orientation.test.ts
+++ b/tests/shared/export-snippet-part-orientation.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import type { AnyCircuitElement } from "circuit-json"
+import JSZip from "jszip"
+import { exportSnippet } from "lib/shared/export-snippet"
+
+test("gerber export applies JLCPCB pin-1 orientation metadata to PnP rotation", async () => {
+  const temporaryDirectory = await mkdtemp(
+    path.join(tmpdir(), "tsci-part-orientation-"),
+  )
+  const circuitJsonPath = path.join(
+    temporaryDirectory,
+    "orientation.circuit.json",
+  )
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      center: { x: 10, y: 20 },
+      width: 4,
+      height: 4,
+      layer: "top",
+      rotation: 0,
+      obstructs_within_bounds: true,
+      pin1_location: "leftside_top",
+      supplier_pin1_location_map: {
+        jlcpcb: "bottomside_left",
+      },
+    },
+  ] as AnyCircuitElement[]
+
+  try {
+    await writeFile(circuitJsonPath, JSON.stringify(circuitJson))
+
+    let fabricationZip: Buffer | undefined
+    let exitCode: number | undefined
+    await exportSnippet({
+      filePath: circuitJsonPath,
+      format: "gerbers",
+      writeFile: false,
+      onExit: (code) => {
+        exitCode = code
+      },
+      onError: (message) => {
+        throw new Error(message)
+      },
+      onSuccess: ({ outputContent }) => {
+        fabricationZip = outputContent as Buffer
+      },
+    })
+
+    expect(exitCode).toBe(0)
+    const zip = await JSZip.loadAsync(fabricationZip!)
+    const pickAndPlaceCsv = await zip
+      .file("pick_and_place.csv")!
+      .async("string")
+    expect(pickAndPlaceCsv).toContain("U1,10.000,20.000,top,270")
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## What changed

- Enable part-orientation analysis when generating JLCPCB fabrication output.
- Force regeneration for fabrication exports so cached circuit JSON without orientation metadata is not reused.
- Pass `supplier: "jlcpcb"` to the PnP CSV converter.
- Add an export-level regression test covering a semantic pin-1 rotation correction.

## Why

JLCPCB footprints can use a different pin-1 frame from the authored tscircuit footprint. The fabrication export must render supplier orientation metadata and use it when producing the PnP rotation.

## Impact

JLCPCB fabrication ZIPs generated by the CLI will contain corrected pick-and-place rotations when both semantic pin-1 locations are available.

## Dependency

Draft pending publication of `circuit-json-to-pnp-csv` with supplier-aware conversion: tscircuit/circuit-json-to-pnp-csv#8. The npm dependency and lockfile will be updated after that release is available.

## Validation

- `bun test tests/shared/export-snippet-part-orientation.test.ts`
- `bunx tsc --noEmit`
- `git diff --check`
