### PR TITLE
Add schematic PDF export

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,7 @@
         "ky": "^1.7.4",
         "make-vfs": "^1.0.15",
         "md5": "^2.3.0",
+        "pdf-lib": "^1.17.1",
         "perfect-cli": "^1.0.21",
         "playwright": "^1.57.0",
         "polygon-clipping": "^0.15.7",
@@ -206,6 +207,10 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
+
+    "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
+
     "@react-hook/latest": ["@react-hook/latest@1.0.3", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg=="],
 
     "@react-hook/passive-layout-effect": ["@react-hook/passive-layout-effect@1.2.1", "", { "peerDependencies": { "react": ">=16.8" } }, "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg=="],
@@ -314,7 +319,7 @@
 
     "@tscircuit/capacity-autorouter": ["@tscircuit/capacity-autorouter@0.0.710", "", { "dependencies": { "fast-json-stable-stringify": "^2.1.0", "object-hash": "^3.0.0", "stack-svgs": "^0.0.1" } }, "sha512-+mK6pc8hQdo7G6iIRzvIV2EH6TOM215oQv12VObB2k0rl1m/5oiw9f66GlBGUYxGRbob7YVJZ2G5AH554nZ9/Q=="],
 
-    "@tscircuit/check-shorts": ["@tscircuit/check-shorts@https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.12.tgz", { "peerDependencies": { "@resvg/resvg-js": "^2.6.2", "@tscircuit/circuit-json-util": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "circuit-json-to-gerber": "*", "circuit-to-canvas": "*", "circuit-to-svg": "*", "fast-png": "^8.0.0", "gerber-to-svg": "*", "react": "^19.2.7", "transformation-matrix": "^2.16.1", "typescript": "^5" } }, "sha512-vtMbDVT9wiC69eg/kHcOYgRzU18oK8gR7pEvg/q5u/Zetzkmu1R/dulM0kj/HrfW32tjNg2+G6LHSY3UYoXwrg=="],
+    "@tscircuit/check-shorts": ["@tscircuit/check-shorts@https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.12.tgz", { "peerDependencies": { "@resvg/resvg-js": "^2.6.2", "@tscircuit/circuit-json-util": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "circuit-json-to-gerber": "*", "circuit-to-canvas": "*", "circuit-to-svg": "*", "fast-png": "^8.0.0", "gerber-to-svg": "*", "react": "^19.2.7", "transformation-matrix": "^2.16.1", "typescript": "^5" } }],
 
     "@tscircuit/checks": ["@tscircuit/checks@0.0.145", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-HKdugkjGSrx4HyyrrtDi4pXmORZGx9kA/4zKRUnk7qqqaIyF7OKXGSKW1nIxv+O2oSHOu4z9lpMCEYkHmPUdrQ=="],
 
@@ -322,7 +327,7 @@
 
     "@tscircuit/circuit-json-routing-analysis": ["@tscircuit/circuit-json-routing-analysis@0.0.6", "", { "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "sha512-JRmCqieAV7janGaDvWvwFEbFt8xjf5bf6cBDMb3qM3hgR0tv71Dk8P0ClZLJ1I6FWE/PwtIS8h+24ehDHfgW2A=="],
 
-    "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-bb0b41d", "sha512-L8P1Qs4rs9tBWosUJEFvNKSKwBKHHIArmJh+aDCGz5m9g5dP+STyadkTOb9BJRXuWXm1ndBD05VMfHMwb9F9JQ=="],
+    "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-bb0b41d"],
 
     "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
 
@@ -518,7 +523,7 @@
 
     "circuit-json-to-tscircuit": ["circuit-json-to-tscircuit@0.0.42", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HEQf1DP6y1pqunmZwNWu06EN36VgJln7cpchUitmyJwHPVhv2t6ABwHgKYzJuQwsVSmvLHc1/3QjdjP+1ekmqw=="],
 
-    "circuit-json-trace-length-analysis": ["circuit-json-trace-length-analysis@github:tscircuit/circuit-json-trace-length-analysis#2b44792", { "peerDependencies": { "typescript": "^5" } }, "tscircuit-circuit-json-trace-length-analysis-2b44792", "sha512-CTFqTc+F66tflCKmXC+Ge7kD1K2rrEH4Z5vHhUJa0OxmtKh6L1gM80xCJL1YtAL+9f2p7i26U9fO+Pq22NEypQ=="],
+    "circuit-json-trace-length-analysis": ["circuit-json-trace-length-analysis@github:tscircuit/circuit-json-trace-length-analysis#2b44792", { "peerDependencies": { "typescript": "^5" } }, "tscircuit-circuit-json-trace-length-analysis-2b44792"],
 
     "circuit-to-canvas": ["circuit-to-canvas@0.0.111", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-UueWYe8ZRtMql8FbT8BtFXiUFz35Fl5/wsh4hgmZ7AUU/3xeyS2jXGLc4E7HxnC6zvy4pyrTTRS0YQd2DjgvgA=="],
 
@@ -924,6 +929,8 @@
 
     "path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
 
+    "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
+
     "perfect-cli": ["perfect-cli@1.0.21", "", { "dependencies": { "commander": "^12.0.0", "minimist": "^1.2.8", "prompts": "^2.4.2" } }, "sha512-OFtzlURQqXXkBe6STMxqShWuUnL8CMaf9h/1GxW1okbfSTA/xFewDviJUOQbml8STEH63IZ9l2UEx8l2Hp2f6w=="],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
@@ -1110,7 +1117,7 @@
 
     "tscircuit": ["tscircuit@0.0.2142-libonly", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "@resvg/resvg-js": "^2.6.2", "@rollup/plugin-commonjs": "^29.0.0", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.3", "@rollup/plugin-typescript": "^12.3.0", "@tscircuit/alphabet": "0.0.25", "@tscircuit/capacity-autorouter": "^0.0.710", "@tscircuit/checks": "0.0.145", "@tscircuit/circuit-json-util": "^0.0.100", "@tscircuit/copper-pour-solver": "0.0.39", "@tscircuit/core": "^0.0.1495", "@tscircuit/create-fdm-enclosure": "0.0.3", "@tscircuit/eval": "^0.0.1050", "@tscircuit/footprinter": "^0.0.380", "@tscircuit/image-utils": "^0.0.8", "@tscircuit/infer-cable-insertion-point": "^0.0.2", "@tscircuit/infgrid-ijump-astar": "^0.0.35", "@tscircuit/internal-dynamic-import": "^0.0.11", "@tscircuit/krt-wasm": "^0.1.1", "@tscircuit/matchpack": "^0.0.43", "@tscircuit/math-utils": "^0.0.36", "@tscircuit/miniflex": "^0.0.4", "@tscircuit/ngspice-spice-engine": "^0.0.19", "@tscircuit/props": "^0.0.589", "@tscircuit/runframe": "^0.0.2263", "@tscircuit/schematic-match-adapt": "^0.0.18", "@tscircuit/schematic-trace-solver": "^0.0.106", "@tscircuit/simple-3d-svg": "^0.0.41", "@tscircuit/solver-utils": "^0.0.16", "@tscircuit/soup-util": "^0.0.41", "bpc-graph": "^0.0.57", "calculate-cell-boundaries": "^0.0.13", "calculate-elbow": "^0.0.12", "calculate-packing": "^0.0.79", "circuit-json": "^0.0.453", "circuit-json-to-bpc": "^0.0.13", "circuit-json-to-connectivity-map": "^0.0.23", "circuit-json-to-gltf": "^0.0.107", "circuit-json-to-simple-3d": "^0.0.9", "circuit-json-to-spice": "^0.0.43", "circuit-to-svg": "^0.0.391", "comlink": "^4.4.2", "connectivity-map": "^1.0.0", "css-select": "5.1.0", "debug": "^4.3.6", "flatbush": "^4.5.0", "format-si-unit": "^0.0.7", "graphics-debug": "^0.0.95", "jscad-planner": "^0.0.13", "kicad-component-converter": "^0.1.40", "kicad-to-circuit-json": "^0.0.113", "kicadts": "^0.0.51", "minicssgrid": "^0.0.9", "performance-now": "^2.1.0", "poppygl": "^0.0.26", "react": "^19.1.0", "react-dom": "^19.1.0", "rollup": "^4.53.2", "rollup-plugin-dts": "^6.2.3", "s-expression": "^3.1.1", "schematic-symbols": "^0.0.233", "spicets": "^0.0.2", "spicey": "^0.0.14", "sucrase": "^3.35.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "tslib": "^2.8.1", "zod": "^3.25.67" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-wKL3soRyqa6xuxuPJY4Y5AGA0KTtCMgwQsWYO6vJgw5sSQo2qAAJzxgKtqjmBs4S/sAU60dZ/+aSYDhXy/5C2A=="],
 
-    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+    "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
 
@@ -1178,6 +1185,8 @@
 
     "@babel/code-frame/picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
+    "@flatten-js/interval-tree/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@tscircuit/circuit-json-schematic-placement-analysis/@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.94", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-kEYV6LzcZbRuw43IxsZ1cZL2pUx4nF07MYAHHhY9s90UzKYaIYfZ1q11s+F2wNwKecCcSyTUoAwWeqazLQEyVQ=="],
 
     "@tscircuit/core/calculate-packing": ["calculate-packing@0.0.77", "", { "peerDependencies": { "@tscircuit/circuit-json-util": "*", "typescript": "^5" } }, "sha512-TGFUN5Di0hZTua+ReW1Kx1CjmN4KYSUl3aS0QW0jrgxcs1Ww45lwSGvAxFrXE06PyohKz4uQRz7j5R/UIv7PsA=="],
@@ -1197,6 +1206,8 @@
     "@types/prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "async-mutex/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
@@ -1311,6 +1322,8 @@
     "tscircuit/poppygl": ["poppygl@0.0.26", "", { "dependencies": { "fast-png": "^8.0.0", "gl-matrix": "^3.4.4", "pureimage": "^0.4.18", "readable-stream": "^4.7.0" }, "peerDependencies": { "typescript": "^5" } }, "sha512-5jnQuKpDCfFT0b9aCm/AidGdzwjw/I3obFpc10j66FY7ZtDPMRekHYU76BzfKDyV5iU8BBWQzxX+8lS9+EEkbg=="],
 
     "tscircuit/spicets": ["spicets@0.0.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Or30bFInG8QFfgQOj+84fsVMyKC6pFa879PnwyLy0EXWUF3KHKQlqMUSfjuD7KS9bTbGQCVe3eEVrfdHqS7TWQ=="],
+
+    "tscircuit/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/lib/shared/convert-circuit-json-to-schematic-pdf.ts
+++ b/lib/shared/convert-circuit-json-to-schematic-pdf.ts
@@ -1,0 +1,46 @@
+import type { AnyCircuitElement, SchematicSheet } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "circuit-to-svg"
+import { PDFDocument } from "pdf-lib"
+import { convertSvgToPngBuffer } from "./convert-svg-to-png"
+
+const A4_LANDSCAPE_WIDTH = 841.89
+const A4_LANDSCAPE_HEIGHT = 595.28
+const RENDER_SCALE = 2
+
+const getSchematicSheets = (
+  circuitJson: AnyCircuitElement[],
+): SchematicSheet[] =>
+  circuitJson
+    .filter(
+      (element): element is SchematicSheet =>
+        element.type === "schematic_sheet",
+    )
+    .sort((a, b) => (a.sheet_index ?? 0) - (b.sheet_index ?? 0))
+
+export const convertCircuitJsonToSchematicPdf = async (
+  circuitJson: AnyCircuitElement[],
+): Promise<Buffer> => {
+  const pdf = await PDFDocument.create()
+  const schematicSheets = getSchematicSheets(circuitJson)
+  const pages = schematicSheets.length > 0 ? schematicSheets : [undefined]
+
+  for (const schematicSheet of pages) {
+    const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson, {
+      width: Math.round(A4_LANDSCAPE_WIDTH * RENDER_SCALE),
+      height: Math.round(A4_LANDSCAPE_HEIGHT * RENDER_SCALE),
+      schematicSheetId: schematicSheet?.schematic_sheet_id,
+    })
+    const schematicPng = convertSvgToPngBuffer(schematicSvg)
+    const embeddedPng = await pdf.embedPng(schematicPng)
+    const page = pdf.addPage([A4_LANDSCAPE_WIDTH, A4_LANDSCAPE_HEIGHT])
+
+    page.drawImage(embeddedPng, {
+      x: 0,
+      y: 0,
+      width: A4_LANDSCAPE_WIDTH,
+      height: A4_LANDSCAPE_HEIGHT,
+    })
+  }
+
+  return Buffer.from(await pdf.save())
+}

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -37,6 +37,7 @@ import { getOrGenerateCircuitJson } from "lib/shared/get-or-generate-circuit-jso
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import { loadLocalStepModelFsMap } from "lib/shared/load-local-step-model-fs-map"
 import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
+import { convertCircuitJsonToSchematicPdf } from "./convert-circuit-json-to-schematic-pdf"
 import { convertToKicadLibrary } from "./convert-to-kicad-library"
 import { importFromUserLand } from "./importFromUserLand"
 import { isCircuitJsonFile } from "./is-circuit-json-file"
@@ -47,6 +48,7 @@ export const ALLOWED_EXPORT_FORMATS = [
   "json",
   "circuit-json",
   "schematic-svg",
+  "schematic-pdf",
   "pcb-svg",
   "gerbers",
   "readable-netlist",
@@ -68,6 +70,7 @@ const OUTPUT_EXTENSIONS: Record<ExportFormat, string> = {
   json: ".circuit.json",
   "circuit-json": ".circuit.json",
   "schematic-svg": "-schematic.svg",
+  "schematic-pdf": "-schematic.pdf",
   "pcb-svg": "-pcb.svg",
   "assembly-svg": "-assembly.svg",
   gerbers: "-gerbers.zip",
@@ -207,6 +210,9 @@ export const exportSnippet = async ({
   switch (format) {
     case "schematic-svg":
       outputContent = convertCircuitJsonToSchematicSvg(circuitJson)
+      break
+    case "schematic-pdf":
+      outputContent = await convertCircuitJsonToSchematicPdf(circuitJson)
       break
     case "pcb-svg":
       outputContent = convertCircuitJsonToPcbSvg(

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ky": "^1.7.4",
     "make-vfs": "^1.0.15",
     "md5": "^2.3.0",
+    "pdf-lib": "^1.17.1",
     "perfect-cli": "^1.0.21",
     "playwright": "^1.57.0",
     "polygon-clipping": "^0.15.7",

--- a/tests/cli/export/export-schematic-pdf.test.ts
+++ b/tests/cli/export/export-schematic-pdf.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test"
+import { PDFDocument } from "pdf-lib"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test(
+  "export schematic-pdf puts each schematic sheet on its own page",
+  async () => {
+    const { tmpDir, runCommand } = await getCliTestFixture()
+    const circuitPath = path.join(tmpDir, "multiple-sheets.circuit.tsx")
+
+    await Bun.write(
+      circuitPath,
+      `
+      export default () => (
+        <board width="20mm" height="10mm">
+          <schematicsheet
+            name="power"
+            displayName="Power"
+            sheetIndex={1}
+          />
+          <schematicsheet
+            name="control"
+            displayName="Control"
+            sheetIndex={0}
+          />
+          <resistor
+            name="R1"
+            resistance="1k"
+            footprint="0402"
+            schSheetName="power"
+          />
+          <capacitor
+            name="C1"
+            capacitance="1uF"
+            footprint="0402"
+            schSheetName="control"
+          />
+        </board>
+      )
+    `,
+    )
+
+    const { exitCode, stderr } = await runCommand(
+      `tsci export ${circuitPath} -f schematic-pdf`,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stderr).toBe("")
+
+    const outputPath = path.join(
+      tmpDir,
+      "multiple-sheets.circuit-schematic.pdf",
+    )
+    const pdfBytes = await Bun.file(outputPath).arrayBuffer()
+    const pdf = await PDFDocument.load(pdfBytes)
+
+    expect(pdf.getPageCount()).toBe(2)
+    expect(new Uint8Array(pdfBytes).slice(0, 5)).toEqual(
+      new TextEncoder().encode("%PDF-"),
+    )
+  },
+  { timeout: 15_000 },
+)
+
+test(
+  "export schematic-pdf creates one page without explicit sheets",
+  async () => {
+    const { tmpDir, runCommand } = await getCliTestFixture()
+    const circuitPath = path.join(tmpDir, "single-sheet.circuit.tsx")
+
+    await Bun.write(
+      circuitPath,
+      `
+      export default () => (
+        <board width="10mm" height="10mm">
+          <resistor name="R1" resistance="1k" footprint="0402" />
+        </board>
+      )
+    `,
+    )
+
+    const { exitCode, stderr } = await runCommand(
+      `tsci export ${circuitPath} -f schematic-pdf`,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stderr).toBe("")
+
+    const outputPath = path.join(tmpDir, "single-sheet.circuit-schematic.pdf")
+    const pdf = await PDFDocument.load(await Bun.file(outputPath).arrayBuffer())
+
+    expect(pdf.getPageCount()).toBe(1)
+  },
+  { timeout: 15_000 },
+)


### PR DESCRIPTION
## Summary

- add `schematic-pdf` as a supported `tsci export` format
- render explicit schematic sheets in `sheet_index` order, with one landscape A4 page per sheet
- preserve single-page PDF output for circuits without explicit schematic sheets
- add CLI integration coverage for multi-sheet and implicit single-sheet exports

## Why

Schematic exports were previously limited to SVG, which flattened the output into a single image-oriented artifact. PDF export makes schematics easier to print and share while preserving sheet boundaries as document pages.

## User impact

Users can now run:

```sh
tsci export path/to/design.circuit.tsx -f schematic-pdf
```

The default output is `design.circuit-schematic.pdf`.

## Validation

- `bun test tests/cli/export/export-schematic-pdf.test.ts tests/shared/export-snippet-part-orientation.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`