### PR TITLE
Load shorts checker from latest jscdn release

### DIFF
--- a/cli/check/shorts/register.ts
+++ b/cli/check/shorts/register.ts
@@ -1,11 +1,11 @@
-import type { PlatformConfig } from "@tscircuit/props"
+import { mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
 import type {
   BitmapShort,
   FindBitmapShortsOptions,
 } from "@tscircuit/check-shorts"
+import type { PlatformConfig } from "@tscircuit/props"
 import type { Command } from "commander"
-import { mkdir, writeFile } from "node:fs/promises"
-import path from "node:path"
 import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
 
 interface CheckShortsOptions {
@@ -24,7 +24,44 @@ export interface CheckShortsResult {
   }>
 }
 
-const loadCheckShorts = async () => await import("@tscircuit/check-shorts")
+type CheckShortsModule = typeof import("@tscircuit/check-shorts")
+
+export const CHECK_SHORTS_CDN_URL =
+  "https://jscdn.tscircuit.com/@tscircuit/check-shorts/latest/+esm"
+
+const importCheckShortsFromCdn = async (
+  url: string,
+): Promise<CheckShortsModule> => await import(url)
+
+const importCheckShortsFromPackage = async (): Promise<CheckShortsModule> =>
+  await import("@tscircuit/check-shorts")
+
+export const loadCheckShorts = async (
+  options: {
+    importFromCdn?: (url: string) => Promise<CheckShortsModule>
+    preferCdn?: boolean
+  } = {},
+): Promise<CheckShortsModule> => {
+  const importFromCdn = options.importFromCdn ?? importCheckShortsFromCdn
+  const preferCdn =
+    options.preferCdn ??
+    (process.env.NODE_ENV !== "test" && process.env.TSCI_TEST_MODE !== "true")
+
+  if (!preferCdn) return importCheckShortsFromPackage()
+
+  try {
+    return await importFromCdn(CHECK_SHORTS_CDN_URL)
+  } catch (cdnError) {
+    try {
+      return await importCheckShortsFromPackage()
+    } catch (packageError) {
+      throw new AggregateError(
+        [cdnError, packageError],
+        "Failed to load @tscircuit/check-shorts from jscdn or the installed CLI package",
+      )
+    }
+  }
+}
 
 const parsePixelsPerMm = (value?: string): number | undefined => {
   if (!value) return undefined

--- a/tests/cli/check/check-shorts.test.ts
+++ b/tests/cli/check/check-shorts.test.ts
@@ -4,7 +4,11 @@ import path from "node:path"
 import { appendCopperBridgeTrace } from "@tscircuit/check-shorts"
 import { temporaryDirectory } from "tempy"
 import { getCircuitJsonForCheck } from "../../../cli/check/shared"
-import { checkShorts } from "../../../cli/check/shorts/register"
+import {
+  CHECK_SHORTS_CDN_URL,
+  checkShorts,
+  loadCheckShorts,
+} from "../../../cli/check/shorts/register"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
 const circuitCode = `
@@ -65,6 +69,36 @@ const pcbSnapshotSnapshotPath = path.join(
   snapshotDir,
   "check-shorts-pcb.snap.svg",
 )
+
+test("check shorts loads the latest checker from jscdn", async () => {
+  let requestedUrl: string | undefined
+  const expectedModule = {
+    renderBitmapShortDebug: () => ({ shorts: [] }),
+  } as unknown as typeof import("@tscircuit/check-shorts")
+
+  const loadedModule = await loadCheckShorts({
+    preferCdn: true,
+    importFromCdn: async (url) => {
+      requestedUrl = url
+      return expectedModule
+    },
+  })
+
+  expect(requestedUrl).toBe(CHECK_SHORTS_CDN_URL)
+  expect(requestedUrl).toContain("/latest/+esm")
+  expect(loadedModule).toBe(expectedModule)
+})
+
+test("check shorts falls back to the packaged checker when jscdn is unavailable", async () => {
+  const loadedModule = await loadCheckShorts({
+    preferCdn: true,
+    importFromCdn: async () => {
+      throw new Error("jscdn unavailable")
+    },
+  })
+
+  expect(loadedModule.renderBitmapShortDebug).toBeFunction()
+})
 
 test("check shorts reports no shorts for a clean board", async () => {
   const tmpDir = temporaryDirectory()


### PR DESCRIPTION
## Summary

- load `@tscircuit/check-shorts` from the official jscdn `latest/+esm` endpoint when `tsci check shorts` runs
- fall back to the packaged checker when the CDN is unavailable or the runtime cannot import network modules
- keep CLI tests offline and add focused coverage for the latest CDN URL and packaged fallback

## Root cause

The existing `import("@tscircuit/check-shorts")` is a dynamic package import, not a CDN loader. If a published CLI build leaves that import external, the module is unavailable because the checker is a development/build dependency rather than an installed runtime dependency.

Loading from jscdn makes the command use the current checker release without requiring the CLI package to bundle or install that exact version. The packaged import remains as a compatibility and offline fallback.

## Validation

- `bun test tests/cli/check/check-shorts.test.ts` — 5 passed
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- production CDN smoke test imported `latest/+esm` and executed `renderBitmapShortDebug` successfully