### PR TITLE
Add named autorouter phase debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ The debug directory contains:
 Use `--autorouter-dump-srj failed` to keep only failed-stage routing data, or
 `--autorouter-dump-srj phase:N` to capture a single stage.
 
+Use `--autorouter-phase <name>` to enable the debugger automatically and keep
+debugging through the named `<autoroutingphase name="..." />`. Later phases
+are left out of the debug artifacts.
+
 ### Debug solver inputs
 
 Use `--solver-debug` to record the constructor inputs for every solver that

--- a/cli/build/build-ci.ts
+++ b/cli/build/build-ci.ts
@@ -29,6 +29,7 @@ export interface BuildCommandOptions {
   step?: boolean
   profile?: boolean
   autorouterDebug?: boolean
+  autorouterPhase?: string
   autorouterTimeout?: string
   autorouterDebugDir?: string
   autorouterDumpSrj?: string | boolean

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -8,6 +8,7 @@ import { getCircuitJsonOutputDirName } from "lib/shared/circuit-json-build-cache
 import { loadRuntimeProjectConfig } from "lib/project-config"
 import {
   parseAutorouterDumpSrjMode,
+  parseAutorouterPhaseName,
   parseAutorouterTimeout,
   type AutorouterDiagnosticsOptions,
 } from "lib/shared/autorouter-diagnostics"
@@ -190,6 +191,10 @@ export const registerBuild = (program: Command) => {
       "Log autorouting phases and write unrouted/per-phase PNG artifacts",
     )
     .option(
+      "--autorouter-phase <name>",
+      "Enable autorouting debugging through the named phase",
+    )
+    .option(
       "--autorouter-timeout <duration>",
       'Abort an autorouting phase after a duration, e.g. "120s" or "2m"',
     )
@@ -333,6 +338,10 @@ export const registerBuild = (program: Command) => {
         const autorouterTimeoutMs = resolvedOptions?.autorouterTimeout
           ? parseAutorouterTimeout(resolvedOptions.autorouterTimeout)
           : undefined
+        const autorouterPhaseName =
+          resolvedOptions?.autorouterPhase !== undefined
+            ? parseAutorouterPhaseName(resolvedOptions.autorouterPhase)
+            : undefined
         const autorouterDumpSrj = parseAutorouterDumpSrjMode(
           resolvedOptions?.autorouterDumpSrj,
         )
@@ -340,7 +349,10 @@ export const registerBuild = (program: Command) => {
           ? path.resolve(projectDir, resolvedOptions.autorouterDebugDir)
           : path.join(distDir, "autorouter-debug")
         const autorouterDiagnostics: AutorouterDiagnosticsOptions = {
-          enabled: resolvedOptions?.autorouterDebug,
+          enabled:
+            resolvedOptions?.autorouterDebug ||
+            autorouterPhaseName !== undefined,
+          phaseName: autorouterPhaseName,
           timeoutMs: autorouterTimeoutMs,
           debugDir: autorouterDebugDir,
           dumpSrj: autorouterDumpSrj,
@@ -1031,6 +1043,7 @@ export const registerBuild = (program: Command) => {
           resolvedOptions?.previewGltf && "preview-gltf",
           resolvedOptions?.profile && "profile",
           resolvedOptions?.autorouterDebug && "autorouter-debug",
+          resolvedOptions?.autorouterPhase && "autorouter-phase",
           resolvedOptions?.autorouterTimeout && "autorouter-timeout",
           resolvedOptions?.autorouterDumpSrj && "autorouter-dump-srj",
           resolvedOptions?.solverDebug && "solver-debug",

--- a/cli/check/trace-length/register.ts
+++ b/cli/check/trace-length/register.ts
@@ -4,6 +4,7 @@ import type { Command } from "commander"
 import path from "node:path"
 import {
   parseAutorouterDumpSrjMode,
+  parseAutorouterPhaseName,
   parseAutorouterTimeout,
   type AutorouterDiagnosticsOptions,
 } from "lib/shared/autorouter-diagnostics"
@@ -26,6 +27,7 @@ const loadTraceLengthAnalyzer = async (): Promise<TraceLengthAnalyzer> => {
 
 type CheckTraceLengthOptions = {
   autorouterDebug?: boolean
+  autorouterPhase?: string
   autorouterTimeout?: string
   autorouterDebugDir?: string
   autorouterDumpSrj?: string | boolean
@@ -37,13 +39,18 @@ const getAutorouterDiagnosticsOptions = (
   const timeoutMs = options.autorouterTimeout
     ? parseAutorouterTimeout(options.autorouterTimeout)
     : undefined
+  const phaseName =
+    options.autorouterPhase !== undefined
+      ? parseAutorouterPhaseName(options.autorouterPhase)
+      : undefined
   const dumpSrj = parseAutorouterDumpSrjMode(options.autorouterDumpSrj)
   const debugDir = options.autorouterDebugDir
     ? path.resolve(process.cwd(), options.autorouterDebugDir)
     : path.resolve(process.cwd(), "dist", "autorouter-debug")
 
   return {
-    enabled: options.autorouterDebug,
+    enabled: options.autorouterDebug || phaseName !== undefined,
+    phaseName,
     timeoutMs,
     debugDir,
     dumpSrj,
@@ -86,6 +93,10 @@ export const registerCheckTraceLength = (program: Command) => {
     .option(
       "--autorouter-debug",
       "Log autorouting phases and write unrouted/per-phase PNG artifacts",
+    )
+    .option(
+      "--autorouter-phase <name>",
+      "Enable autorouting debugging through the named phase",
     )
     .option(
       "--autorouter-timeout <duration>",

--- a/cli/dev/register.ts
+++ b/cli/dev/register.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander"
 import * as fs from "node:fs"
 import * as net from "node:net"
 import * as path from "node:path"
+import { parseAutorouterPhaseName } from "lib/shared/autorouter-diagnostics"
 import { resolveDevTarget } from "./resolve-dev-target"
 import kleur from "kleur"
 import { DevServer } from "lib/dev/DevServer"
@@ -51,6 +52,10 @@ export const registerDev = (program: Command) => {
       "Log autorouting diagnostics emitted by the dev runframe",
     )
     .option(
+      "--autorouter-phase <name>",
+      "Log autorouting diagnostics through the named phase",
+    )
+    .option(
       "--autorouter-timeout <duration>",
       "Accepted for parity with build; dev autorouting timeouts are handled in the browser runframe",
     )
@@ -69,6 +74,7 @@ export const registerDev = (program: Command) => {
           port: string
           kicadPcm?: boolean
           autorouterDebug?: boolean
+          autorouterPhase?: string
           autorouterTimeout?: string
           autorouterDebugDir?: string
           autorouterDumpSrj?: string | boolean
@@ -88,6 +94,10 @@ export const registerDev = (program: Command) => {
         if (!target) return
 
         const { absolutePath, projectDir } = target
+        const autorouterPhase =
+          options.autorouterPhase !== undefined
+            ? parseAutorouterPhaseName(options.autorouterPhase)
+            : undefined
 
         warnIfTsconfigMissingTscircuitType(projectDir)
 
@@ -96,7 +106,9 @@ export const registerDev = (program: Command) => {
           componentFilePath: absolutePath,
           projectDir,
           kicadPcm: options.kicadPcm,
-          autorouterDebug: options.autorouterDebug,
+          autorouterDebug:
+            options.autorouterDebug || autorouterPhase !== undefined,
+          autorouterPhase,
         })
 
         await server.start()
@@ -124,7 +136,8 @@ export const registerDev = (program: Command) => {
         if (
           options.autorouterTimeout ||
           options.autorouterDebugDir ||
-          options.autorouterDumpSrj
+          options.autorouterDumpSrj ||
+          autorouterPhase
         ) {
           console.log(
             kleur.gray(

--- a/lib/dev/DevServer.ts
+++ b/lib/dev/DevServer.ts
@@ -35,6 +35,9 @@ export const formatAutorouterDebugEvent = (
     typeof event.componentDisplayName === "string"
       ? `component=${event.componentDisplayName}`
       : null,
+    typeof event.phaseName === "string"
+      ? `autorouter_phase=${event.phaseName}`
+      : null,
     typeof event.phase === "string" ? `phase=${event.phase}` : null,
     typeof event.solverName === "string" ? `solver=${event.solverName}` : null,
     typeof event.connectionCount === "number"
@@ -96,6 +99,7 @@ export class DevServer {
   /** Whether to enable the KiCad PCM proxy server */
   kicadPcm: boolean
   autorouterDebug: boolean
+  autorouterPhase?: string
 
   /**
    * The HTTP server that hosts the file server and event bus. You can use
@@ -120,6 +124,7 @@ export class DevServer {
    * Cache of node_modules that have already been uploaded to avoid re-uploading
    */
   private uploadedNodeModules: Set<string> = new Set()
+  private autorouterPhaseReached = false
 
   constructor({
     port,
@@ -127,18 +132,21 @@ export class DevServer {
     projectDir,
     kicadPcm,
     autorouterDebug,
+    autorouterPhase,
   }: {
     port: number
     componentFilePath: string
     projectDir?: string
     kicadPcm?: boolean
     autorouterDebug?: boolean
+    autorouterPhase?: string
   }) {
     this.port = port
     this.componentFilePath = componentFilePath
     this.projectDir = projectDir ?? path.dirname(componentFilePath)
     this.kicadPcm = kicadPcm ?? false
     this.autorouterDebug = autorouterDebug ?? false
+    this.autorouterPhase = autorouterPhase?.trim() || undefined
     const projectConfig = loadProjectConfig(this.projectDir)
     this.ignoredFiles = projectConfig?.ignoredFiles ?? []
     this.fsKy = ky.create({
@@ -188,7 +196,17 @@ export class DevServer {
     if (this.autorouterDebug) {
       this.eventsWatcher.on("*", (event) => {
         if (!String(event.event_type).startsWith("autorouting:")) return
+        if (this.autorouterPhaseReached) return
         console.log(kleur.cyan(formatAutorouterDebugEvent(event)))
+        if (
+          event.event_type === "autorouting:end" &&
+          event.phaseName === this.autorouterPhase &&
+          (event.phaseStageIndex === undefined ||
+            event.phaseStageCount === undefined ||
+            event.phaseStageIndex >= event.phaseStageCount - 1)
+        ) {
+          this.autorouterPhaseReached = true
+        }
       })
     }
 
@@ -220,6 +238,7 @@ export class DevServer {
 
   async handleFileUpdatedEventFromServer(ev: FileUpdatedEvent) {
     if (ev.initiator === "filesystem_change") return
+    this.autorouterPhaseReached = false
 
     const { file } = await this.fsKy
       .get("api/files/get", {
@@ -258,6 +277,7 @@ export class DevServer {
     if (relativeFilePath.includes("manual-edits.json")) return
     // Skip files inside the .git directory
     if (shouldIgnorePath(relativeFilePath, this.ignoredFiles)) return
+    this.autorouterPhaseReached = false
 
     const filePayload = this.createFileUploadPayload(
       absoluteFilePath,
@@ -320,6 +340,7 @@ export class DevServer {
     const relativeFilePath = path.relative(this.projectDir, absoluteFilePath)
 
     if (shouldIgnorePath(relativeFilePath, this.ignoredFiles)) return
+    this.autorouterPhaseReached = false
 
     // Check if the path is empty or just whitespace
     if (!relativeFilePath || relativeFilePath.trim() === "") {

--- a/lib/shared/autorouter-diagnostics.ts
+++ b/lib/shared/autorouter-diagnostics.ts
@@ -16,6 +16,8 @@ export type AutorouterDumpSrjMode = "all" | "failed" | `phase:${number}`
 
 export type AutorouterDiagnosticsOptions = {
   enabled?: boolean
+  /** Enable debugging through the autorouting phase with this name. */
+  phaseName?: string
   timeoutMs?: number
   debugDir?: string
   dumpSrj?: AutorouterDumpSrjMode
@@ -54,6 +56,9 @@ type AutoroutingEventPayload = {
   subcircuit_id?: string
   subcircuitId?: string
   componentDisplayName?: string
+  phaseName?: string
+  phaseStageIndex?: number
+  phaseStageCount?: number
   routingPhaseIndex?: number | null
   phaseOrdinal?: number
   phaseCount?: number
@@ -78,6 +83,9 @@ type AutoroutingEventPayload = {
 type ActivePhase = {
   subcircuitId: string
   componentDisplayName: string
+  phaseName?: string
+  phaseStageIndex?: number
+  phaseStageCount?: number
   routingPhaseIndex: number
   phaseOrdinal: number
   phaseCount?: number
@@ -118,6 +126,16 @@ export const parseAutorouterTimeout = (duration: string): number => {
   return timeoutMs
 }
 
+export const parseAutorouterPhaseName = (value: string): string => {
+  const phaseName = value.trim()
+  if (!phaseName) {
+    throw new Error(
+      "Invalid --autorouter-phase value. The phase name must not be empty.",
+    )
+  }
+  return phaseName
+}
+
 export const parseAutorouterDumpSrjMode = (
   value: string | boolean | undefined,
 ): AutorouterDumpSrjMode | undefined => {
@@ -149,12 +167,16 @@ export class AutorouterDiagnostics {
   private activePhase: ActivePhase | null = null
   private completedPhaseTraces: AutorouterTrace[] = []
   private hasWrittenPlacementSnapshot = false
+  private targetPhaseReached = false
   private summary: Array<Record<string, unknown>> = []
   private rootCircuit: any
 
   constructor(options: AutorouterDiagnosticsOptions = {}) {
+    const phaseName = options.phaseName?.trim() || undefined
     this.options = {
       ...options,
+      enabled: options.enabled || phaseName !== undefined,
+      phaseName,
       debugDir: options.debugDir ?? DEFAULT_DEBUG_DIR,
       log: options.log ?? console.log,
     }
@@ -163,6 +185,7 @@ export class AutorouterDiagnostics {
   get isActive() {
     return Boolean(
       this.options.enabled ||
+        this.options.phaseName ||
         this.options.timeoutMs ||
         this.options.dumpSrj ||
         this.options.logOnError ||
@@ -218,10 +241,14 @@ export class AutorouterDiagnostics {
       phaseCount: this.summary.length,
       phases: this.summary,
       circuitJsonElementCount: circuitJson?.length,
+      targetPhaseName: this.options.phaseName,
+      targetPhaseReached: this.targetPhaseReached,
     })
   }
 
   private handleStart(event: AutoroutingEventPayload) {
+    if (this.targetPhaseReached) return
+
     const simpleRouteJson = event.simpleRouteJson
     const subcircuitId =
       event.subcircuit_id ?? event.subcircuitId ?? "unknown-subcircuit"
@@ -241,6 +268,9 @@ export class AutorouterDiagnostics {
     this.activePhase = {
       subcircuitId,
       componentDisplayName: event.componentDisplayName ?? "subcircuit",
+      phaseName: event.phaseName,
+      phaseStageIndex: event.phaseStageIndex,
+      phaseStageCount: event.phaseStageCount,
       routingPhaseIndex,
       phaseOrdinal,
       phaseCount: event.phaseCount,
@@ -313,6 +343,9 @@ export class AutorouterDiagnostics {
     this.summary.push({
       subcircuit_id: activePhase.subcircuitId,
       componentDisplayName: activePhase.componentDisplayName,
+      phaseName: activePhase.phaseName,
+      phaseStageIndex: activePhase.phaseStageIndex,
+      phaseStageCount: activePhase.phaseStageCount,
       routingPhaseIndex: activePhase.routingPhaseIndex,
       phaseOrdinal: activePhase.phaseOrdinal,
       phaseCount: activePhase.phaseCount,
@@ -356,6 +389,10 @@ export class AutorouterDiagnostics {
       )
     }
 
+    if (this.isFinalTargetPhaseStage(activePhase)) {
+      this.targetPhaseReached = true
+    }
+
     if (this.activePhase === activePhase) {
       this.activePhase = null
     }
@@ -370,6 +407,9 @@ export class AutorouterDiagnostics {
     this.summary.push({
       subcircuit_id: activePhase.subcircuitId,
       componentDisplayName: activePhase.componentDisplayName,
+      phaseName: activePhase.phaseName,
+      phaseStageIndex: activePhase.phaseStageIndex,
+      phaseStageCount: activePhase.phaseStageCount,
       routingPhaseIndex: activePhase.routingPhaseIndex,
       phaseOrdinal: activePhase.phaseOrdinal,
       phaseCount: activePhase.phaseCount,
@@ -400,6 +440,9 @@ export class AutorouterDiagnostics {
         type: "autorouter_phase_error",
         subcircuit_id: activePhase.subcircuitId,
         routingPhaseIndex: activePhase.routingPhaseIndex,
+        phaseName: activePhase.phaseName,
+        phaseStageIndex: activePhase.phaseStageIndex,
+        phaseStageCount: activePhase.phaseStageCount,
         phaseOrdinal: activePhase.phaseOrdinal,
         phaseCount: activePhase.phaseCount,
         elapsedMs: Math.round(elapsedMs),
@@ -408,6 +451,10 @@ export class AutorouterDiagnostics {
         previousTraceCount: activePhase.previousTraceCount,
         error,
       })
+    }
+
+    if (this.isFinalTargetPhaseStage(activePhase)) {
+      this.targetPhaseReached = true
     }
 
     if (this.activePhase === activePhase) {
@@ -436,6 +483,9 @@ export class AutorouterDiagnostics {
       subcircuit_id: activePhase.subcircuitId,
       componentDisplayName: activePhase.componentDisplayName,
       routingPhaseIndex: activePhase.routingPhaseIndex,
+      phaseName: activePhase.phaseName,
+      phaseStageIndex: activePhase.phaseStageIndex,
+      phaseStageCount: activePhase.phaseStageCount,
       phaseOrdinal: activePhase.phaseOrdinal,
       phaseCount: activePhase.phaseCount,
       elapsedMs: Math.round(elapsedMs),
@@ -686,10 +736,29 @@ export class AutorouterDiagnostics {
   }
 
   private getPhaseLabel(activePhase: ActivePhase) {
+    const phaseName = activePhase.phaseName ? ` "${activePhase.phaseName}"` : ""
+    const stageLabel =
+      activePhase.phaseStageIndex !== undefined &&
+      activePhase.phaseStageCount !== undefined &&
+      activePhase.phaseStageCount > 1
+        ? ` stage ${activePhase.phaseStageIndex + 1}/${activePhase.phaseStageCount}`
+        : ""
     if (activePhase.phaseCount) {
-      return `phase ${activePhase.phaseOrdinal}/${activePhase.phaseCount}`
+      return `phase ${activePhase.phaseOrdinal}/${activePhase.phaseCount}${phaseName}${stageLabel}`
     }
-    return `phase ${activePhase.phaseOrdinal}`
+    return `phase ${activePhase.phaseOrdinal}${phaseName}${stageLabel}`
+  }
+
+  private isFinalTargetPhaseStage(activePhase: ActivePhase) {
+    if (!this.options.phaseName) return false
+    if (activePhase.phaseName !== this.options.phaseName) return false
+    if (
+      activePhase.phaseStageIndex === undefined ||
+      activePhase.phaseStageCount === undefined
+    ) {
+      return true
+    }
+    return activePhase.phaseStageIndex >= activePhase.phaseStageCount - 1
   }
 
   private formatElapsed(elapsedMs: number) {

--- a/tests/shared/autorouter-diagnostics.test.ts
+++ b/tests/shared/autorouter-diagnostics.test.ts
@@ -8,6 +8,7 @@ import {
   AutorouterDiagnostics,
   AutorouterPhaseTimeoutError,
   parseAutorouterDumpSrjMode,
+  parseAutorouterPhaseName,
   parseAutorouterTimeout,
 } from "lib/shared/autorouter-diagnostics"
 
@@ -43,6 +44,96 @@ const makeTempDir = () =>
   fs.mkdtempSync(path.join(os.tmpdir(), "tsci-autorouter-diagnostics-"))
 
 describe("autorouter diagnostics", () => {
+  test("phase targeting enables debugging through the named phase", () => {
+    const debugDir = makeTempDir()
+    const logs: string[] = []
+    const root = new FakeRootCircuit()
+    const diagnostics = new AutorouterDiagnostics({
+      phaseName: "route-power",
+      debugDir,
+      log: (message) => logs.push(message),
+    })
+
+    diagnostics.attachToRootCircuit(root)
+
+    root.emit("autorouting:start", {
+      subcircuit_id: "subcircuit_source_group_0",
+      componentDisplayName: "board main",
+      phaseName: "route-power",
+      phaseStageIndex: 0,
+      phaseStageCount: 2,
+      routingPhaseIndex: 0,
+      simpleRouteJson: { connections: [{ name: "VCC" }] },
+    })
+    root.emit("autorouting:end", {
+      subcircuit_id: "subcircuit_source_group_0",
+      phaseName: "route-power",
+      phaseStageIndex: 0,
+      phaseStageCount: 2,
+      routingPhaseIndex: 0,
+      simpleRouteJson: { traces: [] },
+    })
+    root.emit("autorouting:start", {
+      subcircuit_id: "subcircuit_source_group_0",
+      componentDisplayName: "board main",
+      phaseName: "route-power",
+      phaseStageIndex: 1,
+      phaseStageCount: 2,
+      routingPhaseIndex: 1,
+      simpleRouteJson: { connections: [{ name: "VCC" }] },
+    })
+    root.emit("autorouting:end", {
+      subcircuit_id: "subcircuit_source_group_0",
+      phaseName: "route-power",
+      phaseStageIndex: 1,
+      phaseStageCount: 2,
+      routingPhaseIndex: 1,
+      simpleRouteJson: { traces: [] },
+    })
+    root.emit("autorouting:start", {
+      subcircuit_id: "subcircuit_source_group_0",
+      componentDisplayName: "board main",
+      phaseName: "route-signal",
+      phaseStageIndex: 0,
+      phaseStageCount: 1,
+      routingPhaseIndex: 2,
+      simpleRouteJson: { connections: [{ name: "DATA" }] },
+    })
+    root.emit("autorouting:end", {
+      subcircuit_id: "subcircuit_source_group_0",
+      phaseName: "route-signal",
+      phaseStageIndex: 0,
+      phaseStageCount: 1,
+      routingPhaseIndex: 2,
+      simpleRouteJson: { traces: [] },
+    })
+
+    diagnostics.finalize([])
+
+    expect(logs.join("\n")).toContain('phase 1 "route-power"')
+    expect(logs.join("\n")).toContain('phase 2 "route-power"')
+    expect(logs.join("\n")).not.toContain("route-signal")
+    expect(fs.existsSync(path.join(debugDir, "placement-unrouted.png"))).toBe(
+      true,
+    )
+    expect(fs.existsSync(path.join(debugDir, "phase-0-routed.png"))).toBe(true)
+    expect(fs.existsSync(path.join(debugDir, "phase-1-routed.png"))).toBe(true)
+    expect(fs.existsSync(path.join(debugDir, "phase-2-routed.png"))).toBe(false)
+
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(debugDir, "board.meta.json"), "utf8"),
+    )
+    expect(summary.targetPhaseName).toBe("route-power")
+    expect(summary.targetPhaseReached).toBe(true)
+    expect(summary.phases).toHaveLength(2)
+  })
+
+  test("phase names cannot be empty", () => {
+    expect(() => parseAutorouterPhaseName("  ")).toThrow(
+      "The phase name must not be empty",
+    )
+  })
+
   test("logs phase start/end and writes SRJ and PNG artifacts", async () => {
     const debugDir = makeTempDir()
     const logs: string[] = []

--- a/tests/shared/dev-server-autorouter-debug.test.ts
+++ b/tests/shared/dev-server-autorouter-debug.test.ts
@@ -6,6 +6,7 @@ test("dev autorouter debug events omit circuit JSON ids", () => {
     event_type: "autorouting:progress",
     subcircuit_id: "subcircuit_source_group_0",
     componentDisplayName: "board main",
+    phaseName: "route-power",
     phase: "capacity-depth",
     steps: 12,
     progress: 0.25,
@@ -23,6 +24,7 @@ test("dev autorouter debug events omit circuit JSON ids", () => {
   })
 
   expect(output).toContain("component=board main")
+  expect(output).toContain("autorouter_phase=route-power")
   expect(output).toContain("phase=capacity-depth")
   expect(output).toContain("steps=12")
   expect(output).toContain("progress=25%")


### PR DESCRIPTION
## Summary

- Add `--autorouter-phase <name>` to `build`, `check trace-length`, and `dev`.
- Automatically enable autorouter diagnostics when a target phase is supplied.
- Capture and log autorouter events through the named phase, including multi-stage phase progress, while omitting later phases.
- Add validation, tests, and CLI documentation.

Routing itself continues normally; the phase target limits debugger capture and diagnostics output.

## Dependency

This CLI behavior relies on `tscircuit-core` emitting `phaseName` and stage metadata for events originating from `<autoroutingphase name="...">`. The corresponding core change is being developed separately; without it, the target cannot match named phases end to end.

## Verification

- `bun test tests/shared/autorouter-diagnostics.test.ts tests/shared/dev-server-autorouter-debug.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
