### PR TITLE
Add source diagnostic checks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@tscircuit/circuit-json-placement-analysis": "^0.0.6",
         "@tscircuit/circuit-json-routing-analysis": "^0.0.6",
         "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
+        "@tscircuit/circuit-json-util": "^0.0.104",
         "@tscircuit/eval": "^0.0.1016",
         "@tscircuit/fake-snippets": "^0.0.182",
         "@tscircuit/file-server": "^0.0.32",
@@ -329,7 +330,7 @@
 
     "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-bb0b41d", "sha512-L8P1Qs4rs9tBWosUJEFvNKSKwBKHHIArmJh+aDCGz5m9g5dP+STyadkTOb9BJRXuWXm1ndBD05VMfHMwb9F9JQ=="],
 
-    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.97", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-qg0R/X4mCwb43f53+W3FkxUNRvgGz1WNjpQfKi+QXnoqISw6EZ1Y7VcSynO8S2d8hPGV9Mk5DUOjTPjlEUrrGA=="],
+    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.104", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-mJM4s29CHZLGpQvt49PaDk6l7QWv2xZUXYNRby1sqrEoMvEQAs4kqa5cVPRRwtfMkb7K9VKX03HAFBFaHZPmhA=="],
 
     "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.39", "", { "dependencies": { "@tscircuit/manifold-2d": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Z8+3UrK919QbwJkGyHsb8DGuHqE66iCylpbF/v132PuvrRbHo+phmOfP9nEQjI63ldh976EsT26qw535H15M1g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@tscircuit/circuit-json-placement-analysis": "^0.0.6",
         "@tscircuit/circuit-json-routing-analysis": "^0.0.6",
         "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
-        "@tscircuit/circuit-json-util": "^0.0.104",
+        "@tscircuit/circuit-json-util": "^0.0.105",
         "@tscircuit/eval": "^0.0.1016",
         "@tscircuit/fake-snippets": "^0.0.182",
         "@tscircuit/file-server": "^0.0.32",
@@ -330,7 +330,7 @@
 
     "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-bb0b41d", "sha512-L8P1Qs4rs9tBWosUJEFvNKSKwBKHHIArmJh+aDCGz5m9g5dP+STyadkTOb9BJRXuWXm1ndBD05VMfHMwb9F9JQ=="],
 
-    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.104", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-mJM4s29CHZLGpQvt49PaDk6l7QWv2xZUXYNRby1sqrEoMvEQAs4kqa5cVPRRwtfMkb7K9VKX03HAFBFaHZPmhA=="],
+    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.105", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-zyAP7AkfARgw8Bsme6D9AmffA03swTYDKg0ypDASMMR3aGghR5MET+IswugfOuAa019gnBOV6Q1an4kaIOKdCw=="],
 
     "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.39", "", { "dependencies": { "@tscircuit/manifold-2d": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Z8+3UrK919QbwJkGyHsb8DGuHqE66iCylpbF/v132PuvrRbHo+phmOfP9nEQjI63ldh976EsT26qw535H15M1g=="],
 

--- a/cli/build/drc-diagnostic-filter.ts
+++ b/cli/build/drc-diagnostic-filter.ts
@@ -18,6 +18,7 @@ const EMPTY_IGNORE_COUNTS = (): DrcIgnoreCounts => ({
   pin_specification: 0,
   placement: 0,
   routing: 0,
+  source: 0,
   unknown: 0,
 })
 
@@ -25,7 +26,8 @@ const normalizeCategory = (category: string): DrcCategory =>
   category === "netlist" ||
   category === "pin_specification" ||
   category === "placement" ||
-  category === "routing"
+  category === "routing" ||
+  category === "source"
     ? category
     : "unknown"
 
@@ -112,6 +114,7 @@ export const formatIgnoredDrcCounts = (counts: DrcIgnoreCounts): string =>
       ["pin_specification", counts.pin_specification],
       ["placement", counts.placement],
       ["routing", counts.routing],
+      ["source", counts.source],
       ["unknown", counts.unknown],
     ] as const
   )

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -405,6 +405,7 @@ export const registerBuild = (program: Command) => {
           pin_specification: 0,
           placement: 0,
           routing: 0,
+          source: 0,
           unknown: 0,
         }
         const staticFileReferences: StaticBuildFileReference[] = []

--- a/cli/check/register.ts
+++ b/cli/check/register.ts
@@ -1,7 +1,33 @@
+import type { AnyCircuitElement } from "circuit-json"
 import type { Command } from "commander"
+import {
+  analyzeCircuitJson,
+  formatCircuitJsonDiagnostics,
+} from "lib/shared/circuit-json-diagnostics"
+import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "./shared"
+
+export const check = async (file?: string) => {
+  const resolvedInputFilePath = await resolveCheckInputFilePath(file)
+  const circuitJson = (await getCircuitJsonForCheck({
+    filePath: resolvedInputFilePath,
+    platformConfig: {},
+    allowPrebuiltCircuitJson: true,
+  })) as AnyCircuitElement[]
+
+  return formatCircuitJsonDiagnostics(analyzeCircuitJson(circuitJson))
+}
 
 export const registerCheck = (program: Command) => {
   program
     .command("check")
     .description("Partially build and validate circuit artifacts")
+    .argument("[file]", "Path to the entry file")
+    .action(async (file?: string) => {
+      try {
+        console.log(await check(file))
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exit(1)
+      }
+    })
 }

--- a/cli/check/source/register.ts
+++ b/cli/check/source/register.ts
@@ -1,0 +1,48 @@
+import { categorizeErrorOrWarning } from "@tscircuit/circuit-json-util"
+import type { PlatformConfig } from "@tscircuit/props"
+import type { AnyCircuitElement } from "circuit-json"
+import type { Command } from "commander"
+import {
+  type CircuitJsonIssue,
+  analyzeCircuitJson,
+  formatCircuitJsonDiagnostics,
+} from "lib/shared/circuit-json-diagnostics"
+import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
+
+export const isSourceDiagnostic = (issue: CircuitJsonIssue) =>
+  categorizeErrorOrWarning(issue) === "source"
+
+export const checkSource = async (file?: string) => {
+  const resolvedInputFilePath = await resolveCheckInputFilePath(file)
+  const circuitJson = (await getCircuitJsonForCheck({
+    filePath: resolvedInputFilePath,
+    platformConfig: {
+      pcbDisabled: true,
+      routingDisabled: true,
+      placementDrcChecksDisabled: true,
+    } satisfies PlatformConfig,
+    allowPrebuiltCircuitJson: true,
+  })) as AnyCircuitElement[]
+  const diagnostics = analyzeCircuitJson(circuitJson)
+
+  return formatCircuitJsonDiagnostics({
+    errors: diagnostics.errors.filter(isSourceDiagnostic),
+    warnings: diagnostics.warnings.filter(isSourceDiagnostic),
+  })
+}
+
+export const registerCheckSource = (program: Command) => {
+  program.commands
+    .find((command) => command.name() === "check")!
+    .command("source")
+    .description("Partially build and validate source diagnostics")
+    .argument("[file]", "Path to the entry file")
+    .action(async (file?: string) => {
+      try {
+        console.log(await checkSource(file))
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exit(1)
+      }
+    })
+}

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -20,6 +20,7 @@ import { registerCheck } from "./check/register"
 import { registerCheckRoutingDifficulty } from "./check/routing-difficulty/register"
 import { registerCheckSchematicPlacement } from "./check/schematic-placement/register"
 import { registerCheckShorts } from "./check/shorts/register"
+import { registerCheckSource } from "./check/source/register"
 import { registerCheckTraceLength } from "./check/trace-length/register"
 import { registerClone } from "./clone/register"
 import { registerConfigPrint } from "./config/print/register"
@@ -89,6 +90,7 @@ registerCheckPlacement(program)
 registerCheckRoutingDifficulty(program)
 registerCheckSchematicPlacement(program)
 registerCheckShorts(program)
+registerCheckSource(program)
 registerCheckTraceLength(program)
 
 registerRegistry(program)

--- a/lib/shared/circuit-json-diagnostics.ts
+++ b/lib/shared/circuit-json-diagnostics.ts
@@ -21,15 +21,33 @@ export function analyzeCircuitJson(circuitJson: any[]): {
     const isTypedError = typeof t === "string" && t.endsWith("_error")
     const isTypedWarning = typeof t === "string" && t.endsWith("_warning")
 
-    if (hasErrorType || isTypedError) {
-      errors.push(item as CircuitJsonIssue)
+    if (hasWarningType || isTypedWarning) {
+      warnings.push(item as CircuitJsonIssue)
       continue
     }
 
-    if (hasWarningType || isTypedWarning) {
-      warnings.push(item as CircuitJsonIssue)
+    if (hasErrorType || isTypedError) {
+      errors.push(item as CircuitJsonIssue)
     }
   }
 
   return { errors, warnings }
+}
+
+export function formatCircuitJsonDiagnostics({
+  errors,
+  warnings,
+}: {
+  errors: CircuitJsonIssue[]
+  warnings: CircuitJsonIssue[]
+}): string {
+  const lines = [`Errors: ${errors.length}`, `Warnings: ${warnings.length}`]
+
+  for (const issue of [...errors, ...warnings]) {
+    const issueType =
+      issue.warning_type ?? issue.error_type ?? issue.type ?? "unknown_issue"
+    lines.push(`- ${issueType}: ${issue.message ?? ""}`)
+  }
+
+  return lines.join("\n")
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@tscircuit/circuit-json-placement-analysis": "^0.0.6",
     "@tscircuit/circuit-json-routing-analysis": "^0.0.6",
     "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
-    "@tscircuit/circuit-json-util": "^0.0.104",
+    "@tscircuit/circuit-json-util": "^0.0.105",
     "@tscircuit/eval": "^0.0.1016",
     "@tscircuit/fake-snippets": "^0.0.182",
     "@tscircuit/file-server": "^0.0.32",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tscircuit/circuit-json-placement-analysis": "^0.0.6",
     "@tscircuit/circuit-json-routing-analysis": "^0.0.6",
     "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
+    "@tscircuit/circuit-json-util": "^0.0.104",
     "@tscircuit/eval": "^0.0.1016",
     "@tscircuit/fake-snippets": "^0.0.182",
     "@tscircuit/file-server": "^0.0.32",

--- a/tests/analyze-circuit-json-warning-type-precedence.test.ts
+++ b/tests/analyze-circuit-json-warning-type-precedence.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
+
+test("analyzeCircuitJson prefers a warning type over error_type metadata", () => {
+  const { errors, warnings } = analyzeCircuitJson([
+    {
+      type: "source_property_ignored_warning",
+      error_type: "source_property_ignored_warning",
+      property_name: "positiveConnection",
+      message: "ambiguous differential-pair trace",
+    },
+  ])
+
+  expect(errors).toHaveLength(0)
+  expect(warnings).toHaveLength(1)
+})

--- a/tests/cli/check/check-all-diagnostics.test.ts
+++ b/tests/cli/check/check-all-diagnostics.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("check prints diagnostics from every category including unknown", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitJsonPath = path.join(tmpDir, "all-diagnostics.circuit.json")
+  const diagnosticTypes = [
+    "source_property_ignored_warning",
+    "source_pin_must_be_connected_error",
+    "pcb_component_outside_board_error",
+    "pcb_trace_error",
+    "source_no_power_pin_defined_warning",
+    "future_diagnostic_warning",
+  ]
+
+  await writeFile(
+    circuitJsonPath,
+    JSON.stringify(
+      diagnosticTypes.map((type) => ({
+        type,
+        message: `Diagnostic for ${type}`,
+      })),
+    ),
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci check ${circuitJsonPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("Errors: 3")
+  expect(stdout).toContain("Warnings: 3")
+
+  for (const type of diagnosticTypes) {
+    expect(stdout).toContain(type)
+  }
+})

--- a/tests/cli/check/check-source.test.ts
+++ b/tests/cli/check/check-source.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("check source prints only source diagnostics", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitJsonPath = path.join(tmpDir, "source-warning.circuit.json")
+
+  await writeFile(
+    circuitJsonPath,
+    JSON.stringify([
+      {
+        type: "source_property_ignored_warning",
+        error_type: "source_property_ignored_warning",
+        message: "Source property was ignored",
+      },
+      {
+        type: "source_pin_must_be_connected_error",
+        error_type: "source_pin_must_be_connected_error",
+        message: "Pin must be connected",
+      },
+      {
+        type: "pcb_trace_error",
+        error_type: "pcb_trace_error",
+        message: "Trace failed",
+      },
+    ]),
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci check source ${circuitJsonPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("Errors: 0")
+  expect(stdout).toContain("Warnings: 1")
+  expect(stdout).toContain("source_property_ignored_warning")
+  expect(stdout).not.toContain("source_pin_must_be_connected_error")
+  expect(stdout).not.toContain("pcb_trace_error")
+})


### PR DESCRIPTION
## Summary

- add the `check source` subcommand using `categorizeErrorOrWarning`
- make plain `check` print every detected error and warning without category filtering
- preserve source and unknown diagnostics when existing category ignore flags are used
- keep existing category-specific commands and mappings unchanged

## Behavior

`source_property_ignored_warning` remains visible through both plain `check` and `check source`. Plain `check` is exhaustive and includes source, netlist, placement, routing, pin-specification, and unknown diagnostic types.

No property-name matching, message parsing, Circuit JSON metadata, schema changes, or diagnostic-producer changes are involved.

## Dependency

Uses the published `@tscircuit/circuit-json-util@0.0.105` release containing the first-class `source` category.

## Validation

- 12 focused and existing category tests passed against the published utility package
- TypeScript type-check passed
- production build passed
- formatting and diff checks passed

Supersedes #4042 with a clean branch based directly on current `main`.
