### PR TITLE
fix(build): `--ignore-placement-drc` should unblock autorouting, not just hide it

### DIFF
--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -305,7 +305,8 @@ export const registerBuild = (program: Command) => {
           if (
             !resolvedOptions?.disablePcb &&
             !resolvedOptions?.routingDisabled &&
-            !resolvedOptions?.disablePartsEngine
+            !resolvedOptions?.disablePartsEngine &&
+            !resolvedOptions?.ignorePlacementDrc
           ) {
             return
           }
@@ -322,6 +323,13 @@ export const registerBuild = (program: Command) => {
 
           if (resolvedOptions?.disablePartsEngine) {
             config.partsEngineDisabled = true
+          }
+
+          // Placement DRC is not just a report: core skips autorouting for any
+          // subcircuit that has a pcb_placement_error, so filtering the
+          // diagnostics alone would still leave the board unrouted.
+          if (resolvedOptions?.ignorePlacementDrc) {
+            config.placementDrcChecksDisabled = true
           }
 
           return config

--- a/tests/cli/build/build-ignore-placement-drc-routes.test.ts
+++ b/tests/cli/build/build-ignore-placement-drc-routes.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+// R3 sits outside the board outline, which produces a pcb_placement_error.
+// Core skips autorouting for any subcircuit carrying one, so the unrelated
+// R1 -> R2 trace is left unrouted unless the placement gate is lifted.
+const circuitCode = `
+export default () => (
+  <board width="20mm" height="12mm">
+    <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} pcbY={0} />
+    <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} pcbY={0} />
+    <resistor name="R3" resistance="1k" footprint="0402" pcbX={40} pcbY={0} />
+    <trace name="T1" from=".R1 > .pin2" to=".R2 > .pin1" />
+  </board>
+)`
+
+const buildAndReadCircuitJson = async (
+  runCommand: (command: string) => Promise<{ exitCode: number }>,
+  tmpDir: string,
+  command: string,
+) => {
+  const { exitCode } = await runCommand(command)
+  const circuitJson = JSON.parse(
+    await readFile(path.join(tmpDir, "dist", "board", "circuit.json"), "utf-8"),
+  )
+  return {
+    exitCode,
+    placementErrors: circuitJson.filter((e: any) =>
+      e.type.startsWith("pcb_component_outside_board"),
+    ),
+    autoroutingErrors: circuitJson.filter(
+      (e: any) => e.type === "pcb_autorouting_error",
+    ),
+    traces: circuitJson.filter((e: any) => e.type === "pcb_trace"),
+  }
+}
+
+test("a placement error blocks autorouting by default", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await writeFile(path.join(tmpDir, "board.circuit.tsx"), circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { placementErrors, autoroutingErrors, traces } =
+    await buildAndReadCircuitJson(
+      runCommand,
+      tmpDir,
+      "tsci build board.circuit.tsx --disable-parts-engine",
+    )
+
+  expect(placementErrors.length).toBeGreaterThan(0)
+  expect(autoroutingErrors[0]?.message).toContain("Autorouting was skipped")
+  expect(traces).toHaveLength(0)
+}, 60_000)
+
+test("--ignore-placement-drc lifts the gate so the board still routes", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await writeFile(path.join(tmpDir, "board.circuit.tsx"), circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, autoroutingErrors, traces } = await buildAndReadCircuitJson(
+    runCommand,
+    tmpDir,
+    "tsci build board.circuit.tsx --disable-parts-engine --ignore-placement-drc",
+  )
+
+  expect(exitCode).toBe(0)
+  expect(autoroutingErrors).toHaveLength(0)
+  expect(traces).toHaveLength(1)
+}, 60_000)


### PR DESCRIPTION
## Problem

Placement DRC is not report-only. Core skips autorouting for any subcircuit that carries a placement error (`shouldSkipAutoroutingBecauseOfPlacementErrors`), so `--ignore-placement-drc` filtered the diagnostics while the board stayed unrouted — and the build summary cheerfully printed `Ignored DRC 1 (placement: 1)` on the way out.

The emitted error tells you how to override the gate:

> Autorouting was skipped because 1 PCB placement error was found. Fix the placement errors or set `placementDrcChecksDisabled` to true to route anyway.

but that setting is unreachable from every surface a user would try:

| attempt | routes? |
|---|---|
| `tsci build` | no |
| `tsci build --ignore-placement-drc` (prints `Ignored DRC 1 (placement: 1)`) | **no** |
| `<board placementDrcChecksDisabled>` | no — the key is on `PlatformConfig`, not `boardProps`, so zod strips it silently |
| `tscircuit.config.json` | no — not in the schema |
| `CircuitRunner({ platform: { placementDrcChecksDisabled: true } })` | **yes** |

The last row is the control: the mechanism works, it just had no path from the CLI.

The failure mode is nasty because one unrelated placement error silences routing for the whole subcircuit, and the derived `pcb_port_not_connected_error` / `pcb_trace_missing_error` then point at innocent nets rather than at the placement problem. I lost a while to this on a 4-layer board where 32 escape pads sat inside a QFN courtyard: the build "succeeded" in 20s with pads and no traces.

## Fix

`commandPlatformConfig` in `cli/build/register.ts` already translates CLI flags into `PlatformConfig` (`--disable-pcb`, `--routing-disabled`, `--disable-parts-engine`). This adds `--ignore-placement-drc` → `placementDrcChecksDisabled`, so the flag lifts the gate as well as filtering the report.

Scoped to placement deliberately: the other `--ignore-*-drc` categories really are report-only, and mapping them to `*DrcChecksDisabled` would change which checks run at all.

## Tests

`tests/cli/build/build-ignore-placement-drc-routes.test.ts` — a board with one out-of-board component plus one unrelated routable trace:

- default build: placement error present, `Autorouting was skipped`, 0 `pcb_trace`
- `--ignore-placement-drc`: no autorouting error, 1 `pcb_trace`

Reproduces on this repo's pinned core (0.0.1453), so it is longstanding rather than a recent regression.

## Follow-ups not in this PR

1. Accept `placementDrcChecksDisabled` on `boardProps` (and/or `tscircuit.config.json`) — that is where the error message sends people. Otherwise the message should name something reachable.
2. When routing is skipped by the gate, suppress the derived `pcb_port_not_connected_error` / `pcb_trace_missing_error` for nets the router never attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)