### PR TITLE
Report check-shorts progress

### DIFF
--- a/cli/check/shared.ts
+++ b/cli/check/shared.ts
@@ -9,6 +9,26 @@ import { getEntrypoint } from "lib/shared/get-entrypoint"
 import { isCircuitJsonFile } from "lib/shared/is-circuit-json-file"
 import { findCircuitProjectDir } from "lib/shared/circuit-json-build-cache"
 
+export type GetCircuitJsonForCheckProgressEvent =
+  | {
+      phase: "reading-prebuilt"
+      filePath: string
+    }
+  | {
+      phase: "preparing-source"
+      filePath: string
+    }
+  | {
+      phase: "waiting-on-async-effect"
+      filePath: string
+      asyncEffectName: string
+    }
+  | {
+      phase: "ready"
+      filePath: string
+      source: "prebuilt" | "cache" | "render"
+    }
+
 export const resolveCheckInputFilePath = async (file?: string) => {
   if (file) {
     return path.isAbsolute(file) ? file : path.resolve(process.cwd(), file)
@@ -30,16 +50,22 @@ export const getCircuitJsonForCheck = async ({
   platformConfig,
   allowPrebuiltCircuitJson = false,
   autorouterDiagnostics,
+  onProgress,
 }: {
   filePath: string
   platformConfig: PlatformConfig
   allowPrebuiltCircuitJson?: boolean
   autorouterDiagnostics?: AutorouterDiagnosticsOptions
+  onProgress?: (event: GetCircuitJsonForCheckProgressEvent) => void
 }): Promise<AnyCircuitElement[]> => {
   if (allowPrebuiltCircuitJson && isCircuitJsonFile(filePath)) {
+    onProgress?.({ phase: "reading-prebuilt", filePath })
     const parsedJson = JSON.parse(fs.readFileSync(filePath, "utf-8"))
+    onProgress?.({ phase: "ready", filePath, source: "prebuilt" })
     return Array.isArray(parsedJson) ? parsedJson : []
   }
+
+  onProgress?.({ phase: "preparing-source", filePath })
 
   const platformConfigWithCliDefaults = getPlatformConfigWithCliDefaults(
     platformConfig,
@@ -48,10 +74,22 @@ export const getCircuitJsonForCheck = async ({
     },
   )
 
-  const { circuitJson } = await getOrGenerateCircuitJson({
+  const { circuitJson, cacheHit } = await getOrGenerateCircuitJson({
     filePath,
     platformConfig: platformConfigWithCliDefaults,
     autorouterDiagnostics,
+    onAsyncEffectStatus: (asyncEffectName) =>
+      onProgress?.({
+        phase: "waiting-on-async-effect",
+        filePath,
+        asyncEffectName,
+      }),
+  })
+
+  onProgress?.({
+    phase: "ready",
+    filePath,
+    source: cacheHit ? "cache" : "render",
   })
 
   return circuitJson as AnyCircuitElement[]

--- a/cli/check/shorts/register.ts
+++ b/cli/check/shorts/register.ts
@@ -6,12 +6,49 @@ import type {
 } from "@tscircuit/check-shorts"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { Command } from "commander"
-import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
+import {
+  getCircuitJsonForCheck,
+  type GetCircuitJsonForCheckProgressEvent,
+  resolveCheckInputFilePath,
+} from "../shared"
 
-interface CheckShortsOptions {
+export interface CheckShortsOptions {
   mode?: "pcb" | "gerber"
   layer?: "top" | "bottom" | "all"
   pixelsPerMm?: string
+  onProgress?: (message: string) => void
+}
+
+type BitmapShortProgressEvent =
+  | {
+      phase: "preparing"
+      mode: "pcb" | "gerber"
+      layer: string
+    }
+  | {
+      phase: "rasterizing"
+      mode: "pcb" | "gerber"
+      layer: string
+      width: number
+      height: number
+      completedGroups: number
+      totalGroups: number
+      currentConnectivityKey?: string
+    }
+  | {
+      phase: "detecting"
+      mode: "pcb" | "gerber"
+      layer: string
+    }
+  | {
+      phase: "complete"
+      mode: "pcb" | "gerber"
+      layer: string
+      shortsFound: number
+    }
+
+type ProgressCapableFindBitmapShortsOptions = FindBitmapShortsOptions & {
+  onProgress?: (event: BitmapShortProgressEvent) => void
 }
 
 export interface CheckShortsResult {
@@ -102,10 +139,76 @@ const getShortArtifactOutputPath = () =>
 const getShortPcbSnapshotOutputPath = () =>
   path.resolve(process.cwd(), "checks", "check-shorts", "pcb.svg")
 
+const formatCircuitJsonProgress = (
+  event: GetCircuitJsonForCheckProgressEvent,
+): string => {
+  const filename = path.basename(event.filePath)
+
+  switch (event.phase) {
+    case "reading-prebuilt":
+      return `Reading prebuilt circuit JSON from ${filename}...`
+    case "preparing-source":
+      return `Preparing circuit JSON for ${filename} (using the current build when available)...`
+    case "waiting-on-async-effect":
+      return `Rendering circuit: waiting on ${event.asyncEffectName}...`
+    case "ready":
+      if (event.source === "cache") {
+        return `Circuit JSON ready from the current build.`
+      }
+      if (event.source === "prebuilt") {
+        return `Prebuilt circuit JSON ready.`
+      }
+      return `Circuit JSON rendered from source.`
+  }
+}
+
+const createBitmapProgressReporter = (
+  onProgress?: (message: string) => void,
+) => {
+  const lastReportedPercent = new Map<string, number>()
+
+  return (event: BitmapShortProgressEvent) => {
+    if (!onProgress) return
+
+    const checkName = `${event.layer}/${event.mode}`
+    if (event.phase === "preparing") {
+      onProgress(`Preparing ${checkName} short-check bitmap...`)
+      return
+    }
+    if (event.phase === "detecting") {
+      onProgress(`Finding connected short regions on ${checkName}...`)
+      return
+    }
+    if (event.phase === "complete") {
+      onProgress(
+        `Finished ${checkName}: ${event.shortsFound} short${event.shortsFound === 1 ? "" : "s"} found.`,
+      )
+      return
+    }
+
+    const percent =
+      event.totalGroups === 0
+        ? 100
+        : Math.floor((event.completedGroups / event.totalGroups) * 100)
+    const previousPercent = lastReportedPercent.get(checkName)
+    const shouldReport =
+      previousPercent === undefined ||
+      event.completedGroups === event.totalGroups ||
+      percent >= previousPercent + 10
+
+    if (!shouldReport) return
+    lastReportedPercent.set(checkName, percent)
+    onProgress(
+      `Rasterizing ${checkName} copper groups: ${event.completedGroups}/${event.totalGroups} (${percent}%)...`,
+    )
+  }
+}
+
 export const checkShorts = async (
   file?: string,
   options: CheckShortsOptions = {},
 ): Promise<CheckShortsResult> => {
+  options.onProgress?.("Resolving check input...")
   const resolvedInputFilePath = await resolveCheckInputFilePath(file)
   const mode = parseMode(options.mode)
   const layerOption = parseLayer(options.layer)
@@ -121,7 +224,10 @@ export const checkShorts = async (
       routingDisabled: false,
     } satisfies PlatformConfig,
     allowPrebuiltCircuitJson: true,
+    onProgress: (event) =>
+      options.onProgress?.(formatCircuitJsonProgress(event)),
   })
+  options.onProgress?.("Loading short-check engine...")
   const {
     appendBitmapLegend,
     createShortDebugSvg,
@@ -129,14 +235,21 @@ export const checkShorts = async (
     renderBitmapShortDebug,
   } = await loadCheckShorts()
 
+  options.onProgress?.(
+    `Checking ${layers.length === 1 ? layers[0] : "top and bottom"} ${mode} copper for shorts...`,
+  )
+  const reportBitmapProgress = createBitmapProgressReporter(options.onProgress)
+
   const debugRenders = await Promise.all(
-    layers.map((layer) =>
-      renderBitmapShortDebug(circuitJson, {
+    layers.map((layer) => {
+      const renderOptions: ProgressCapableFindBitmapShortsOptions = {
         mode,
         layer,
         pixelsPerMm,
-      } satisfies FindBitmapShortsOptions),
-    ),
+        onProgress: reportBitmapProgress,
+      }
+      return renderBitmapShortDebug(circuitJson, renderOptions)
+    }),
   )
   const shorts = debugRenders.flatMap((debugRender) => debugRender.shorts)
   const filename = path.basename(resolvedInputFilePath)
@@ -151,6 +264,7 @@ export const checkShorts = async (
   const debugRenderWithShorts =
     debugRenders.find((debugRender) => debugRender.shorts.length > 0) ??
     debugRenders[0]!
+  options.onProgress?.("Creating short debug artifacts...")
   const debugRenderWithLegend = appendBitmapLegend(debugRenderWithShorts)
   const artifacts = [
     {
@@ -190,7 +304,10 @@ export const registerCheckShorts = (program: Command) => {
     .option("--pixels-per-mm <number>", "Bitmap resolution for short detection")
     .action(async (file?: string, options?: CheckShortsOptions) => {
       try {
-        const result = await checkShorts(file, options)
+        const result = await checkShorts(file, {
+          ...options,
+          onProgress: (message) => console.log(message),
+        })
         console.log(result.output)
         if (result.artifacts) {
           for (const artifact of result.artifacts) {

--- a/tests/cli/check/check-shorts.test.ts
+++ b/tests/cli/check/check-shorts.test.ts
@@ -152,6 +152,11 @@ test("tsci check shorts detects a copper bridge short", async () => {
     expect(exitCode).toBe(1)
     expect(stderr).toBe("")
     expect(stdout).toContain("Detected")
+    expect(stdout).toContain("Resolving check input")
+    expect(stdout).toContain("Reading prebuilt circuit JSON")
+    expect(stdout).toContain("Prebuilt circuit JSON ready")
+    expect(stdout).toContain("Loading short-check engine")
+    expect(stdout).toContain("Checking top and bottom gerber copper")
     expect(stdout).toContain("short")
     expect(stdout).toContain("top/gerber")
     expect(stdout).toContain("R1.pin")
@@ -184,23 +189,68 @@ test("check shorts routes a source board before analyzing it", async () => {
   const tmpDir = temporaryDirectory()
   const circuitPath = path.join(tmpDir, "routed-board.tsx")
   let pcbTraceCount = 0
+  const progressMessages: string[] = []
 
   try {
     await linkWorkspaceNodeModules(tmpDir)
     await writeFile(circuitPath, routedCircuitCode)
     mock.module("@tscircuit/check-shorts", () => ({
-      renderBitmapShortDebug: (circuitJson: Array<{ type: string }>) => {
+      renderBitmapShortDebug: (
+        circuitJson: Array<{ type: string }>,
+        options: {
+          mode: "pcb" | "gerber"
+          layer: "top" | "bottom"
+          onProgress?: (event: Record<string, unknown>) => void
+        },
+      ) => {
         pcbTraceCount = circuitJson.filter(
           (element) => element.type === "pcb_trace",
         ).length
+        const baseEvent = { mode: options.mode, layer: options.layer }
+        options.onProgress?.({ phase: "preparing", ...baseEvent })
+        options.onProgress?.({
+          phase: "rasterizing",
+          ...baseEvent,
+          width: 100,
+          height: 100,
+          completedGroups: 0,
+          totalGroups: 2,
+        })
+        options.onProgress?.({
+          phase: "rasterizing",
+          ...baseEvent,
+          width: 100,
+          height: 100,
+          completedGroups: 2,
+          totalGroups: 2,
+        })
+        options.onProgress?.({ phase: "detecting", ...baseEvent })
+        options.onProgress?.({
+          phase: "complete",
+          ...baseEvent,
+          shortsFound: 0,
+        })
         return { shorts: [] }
       },
     }))
 
-    const result = await checkShorts(circuitPath)
+    const result = await checkShorts(circuitPath, {
+      onProgress: (message) => progressMessages.push(message),
+    })
 
     expect(result.shorts).toHaveLength(0)
     expect(pcbTraceCount).toBeGreaterThan(0)
+    expect(progressMessages).toContain("Resolving check input...")
+    expect(progressMessages.join("\n")).toContain("Preparing circuit JSON")
+    expect(progressMessages).toContain("Circuit JSON rendered from source.")
+    expect(progressMessages).toContain("Loading short-check engine...")
+    expect(progressMessages).toContain(
+      "Rasterizing top/gerber copper groups: 0/2 (0%)...",
+    )
+    expect(progressMessages).toContain(
+      "Rasterizing top/gerber copper groups: 2/2 (100%)...",
+    )
+    expect(progressMessages).toContain("Finished top/gerber: 0 shorts found.")
   } finally {
     await rm(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- report input resolution and whether circuit JSON came from a prebuilt file, the current build cache, or a source render
- surface named async effects while source circuits are rendering or routing
- report checker loading, per-layer bitmap work, short-region detection, and debug-artifact generation
- throttle connectivity-group progress to roughly 10% increments to avoid noisy output
- add CLI coverage for high-level progress and structured checker events

## Why

`tsci check shorts` can spend significant time rendering/routing a source circuit and rasterizing connectivity groups. With no intermediate output, the command looks like it has hung.

High-level phase messages work with the currently packaged fallback checker. Granular rasterization events use the optional progress API introduced by tscircuit/check-shorts#40.

## Dependency sequencing

Merge and release https://github.com/tscircuit/check-shorts/pull/40 so the CLI's dynamic `latest` import receives granular checker events. The CLI remains backward-compatible when the loaded checker does not emit progress.

## Validation

- `bunx tsc --noEmit`
- `bun test tests/cli/check` — 18 tests passed
- `bun test tests/cli/check/check-shorts.test.ts` — 5 tests passed
- `bun run format:check`
- `bun run build`