### PR TITLE
Update circuit-to-canvas to 0.0.123

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
         "circuit-json-to-step": "^0.0.38",
         "circuit-json-to-tscircuit": "^0.0.42",
         "circuit-json-trace-length-analysis": "github:tscircuit/circuit-json-trace-length-analysis#2b44792a40df0ca83b6bfb6ac95ed5e35e7168b8",
-        "circuit-to-canvas": "^0.0.111",
+        "circuit-to-canvas": "^0.0.123",
         "circuit-to-svg": "^0.0.393",
         "commander": "^14.0.0",
         "conf": "^13.1.0",
@@ -526,7 +526,7 @@
 
     "circuit-json-trace-length-analysis": ["circuit-json-trace-length-analysis@github:tscircuit/circuit-json-trace-length-analysis#2b44792", { "peerDependencies": { "typescript": "^5" } }, "tscircuit-circuit-json-trace-length-analysis-2b44792", "sha512-CTFqTc+F66tflCKmXC+Ge7kD1K2rrEH4Z5vHhUJa0OxmtKh6L1gM80xCJL1YtAL+9f2p7i26U9fO+Pq22NEypQ=="],
 
-    "circuit-to-canvas": ["circuit-to-canvas@0.0.111", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-UueWYe8ZRtMql8FbT8BtFXiUFz35Fl5/wsh4hgmZ7AUU/3xeyS2jXGLc4E7HxnC6zvy4pyrTTRS0YQd2DjgvgA=="],
+    "circuit-to-canvas": ["circuit-to-canvas@0.0.123", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-qRA2RzMc2YnvXoSRSO/2dFJ86KLYJ/kixh76ObmiiiXYT7rV9inwrpGFsg9xlU0RXDIlE/rW3e4djQNikdy8gQ=="],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.393", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "debug": "^4.4.3", "svg-path-commander": "^2.1.11", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/alphabet": "*" } }, "sha512-wyPi94yex6lYMbXpNHyaTzrZM8qqH0nNUJDCl1bzQlpc9Q6P92aU6SwAHEkuxRAmhs3Yk1kS1DZLT9ci3KafDA=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "circuit-json-to-step": "^0.0.38",
     "circuit-json-to-tscircuit": "^0.0.42",
     "circuit-json-trace-length-analysis": "github:tscircuit/circuit-json-trace-length-analysis#2b44792a40df0ca83b6bfb6ac95ed5e35e7168b8",
-    "circuit-to-canvas": "^0.0.111",
+    "circuit-to-canvas": "^0.0.123",
     "circuit-to-svg": "^0.0.393",
     "commander": "^14.0.0",
     "conf": "^13.1.0",


### PR DESCRIPTION
## Summary

- update `circuit-to-canvas` to `0.0.123`
- refresh the resolved dependency or generated type bundle where tracked

## Why

Recent canvas-rendering fixes were published to npm, but this consumer was still constrained to an older `0.0.x` release. Because caret ranges for `0.0.x` do not advance to the next patch, the latest fixes were not reaching downstream users.

## Validation

- formatting check passes
- production build passes
- repository tests pass where local platform prerequisites are available
