### PR TITLE
Update routing analysis to 0.0.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@biomejs/biome": "^1.9.4",
         "@tscircuit/check-shorts": "https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.19.tgz",
         "@tscircuit/circuit-json-placement-analysis": "^0.0.9",
-        "@tscircuit/circuit-json-routing-analysis": "^0.0.7",
+        "@tscircuit/circuit-json-routing-analysis": "^0.0.8",
         "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
         "@tscircuit/circuit-json-util": "^0.0.105",
         "@tscircuit/eval": "^0.0.1016",
@@ -326,7 +326,7 @@
 
     "@tscircuit/circuit-json-placement-analysis": ["@tscircuit/circuit-json-placement-analysis@0.0.9", "", { "dependencies": { "flatbush": "^4.5.1", "rbush": "^4.0.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-B74isDuH0RkWoJ37OGcL4taQdKSNwf+yaDGCEWhzPuTftRwlpVSa8Z1vFS2NIpNH4XQCSPqw0g6i4t6gDInSsg=="],
 
-    "@tscircuit/circuit-json-routing-analysis": ["@tscircuit/circuit-json-routing-analysis@0.0.7", "", { "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "sha512-5KRMU7V+4aLi5HRHUfTdsJUO8TNZF7Lz4KwChYTCMGn1fSDVJvwlr3ObfuBvJDt9HxgZpYRwTlwOEPBcSPInXg=="],
+    "@tscircuit/circuit-json-routing-analysis": ["@tscircuit/circuit-json-routing-analysis@0.0.8", "", { "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "sha512-mZxRSUbqVb6iZ47ZhNL3mDL7BY9kUcbLg7o4f8Jn5amkDGvmTo52547JQ5ui/6WSJHXmaW7hmRVTEj6PlivskQ=="],
 
     "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-bb0b41d", "sha512-L8P1Qs4rs9tBWosUJEFvNKSKwBKHHIArmJh+aDCGz5m9g5dP+STyadkTOb9BJRXuWXm1ndBD05VMfHMwb9F9JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@biomejs/biome": "^1.9.4",
     "@tscircuit/check-shorts": "https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.19.tgz",
     "@tscircuit/circuit-json-placement-analysis": "^0.0.9",
-    "@tscircuit/circuit-json-routing-analysis": "^0.0.7",
+    "@tscircuit/circuit-json-routing-analysis": "^0.0.8",
     "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
     "@tscircuit/circuit-json-util": "^0.0.105",
     "@tscircuit/eval": "^0.0.1016",


### PR DESCRIPTION
## Summary

- update `@tscircuit/circuit-json-routing-analysis` from `^0.0.7` to `^0.0.8`
- refresh the Bun lockfile for the published package

## Why

Version 0.0.8 includes the bounding-box-based nearby-component analysis. Routing diagnostics now:

- use physical edge-to-edge distance instead of the smallest single-axis offset
- exclude components that are physically distant from a congestion region
- represent actual overlap with numeric overlap depth
- avoid negative displayed distances

The CLI uses the published package rather than a Git commit so its generated `dist` entrypoint is available during installation.

## Validation

- `bun test tests/cli/check/check-routing-difficulty.test.ts`
- `bun run build`
- `bun run format:check`
