### PR TITLE
chore: update easyeda to 0.0.292

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
         "debug": "^4.4.0",
         "delay": "^6.0.0",
         "dsn-converter": "^0.0.90",
-        "easyeda": "^0.0.279",
+        "easyeda": "^0.0.292",
         "fuse.js": "^7.1.0",
         "get-port": "^7.1.0",
         "globby": "^14.1.0",
@@ -612,7 +612,7 @@
 
     "earcut": ["earcut@3.2.3", "", {}, "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q=="],
 
-    "easyeda": ["easyeda@0.0.279", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-Bdbb4yI/Y4z4dI5KvgTchtenhYxdqhdgA9FdPe9a0uUlwKWU/CO7ufJiTDQzXNgHWpEpFv2nOJefRd4ORMH8Xw=="],
+    "easyeda": ["easyeda@0.0.292", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-snUXzqJPGOVtV9fBMR5QoRuur1BmwE+eaVIoBZ8xahop0UtboeeG9ryLoeoANucdeh0HRwAxnGlOdxfn2vrAjQ=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "debug": "^4.4.0",
     "delay": "^6.0.0",
     "dsn-converter": "^0.0.90",
-    "easyeda": "^0.0.279",
+    "easyeda": "^0.0.292",
     "fuse.js": "^7.1.0",
     "get-port": "^7.1.0",
     "globby": "^14.1.0",


### PR DESCRIPTION
## Summary

- update `easyeda` from `^0.0.279` to `^0.0.292`
- refresh the lockfile so CLI imports include the recently merged EasyEDA converter fixes

## Testing

- `bun run build`
- `bun test tests/cli/import tests/lib/import` (8 passed, 1 skipped, 0 failed)