### PR TITLE
chore: update circuit-json-to-gerber to 0.0.94

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
         "circuit-json-to-bom-csv": "^0.0.7",
         "circuit-json-to-connectivity-map": "^0.0.25",
         "circuit-json-to-footprinter": "^0.0.15",
-        "circuit-json-to-gerber": "^0.0.83",
+        "circuit-json-to-gerber": "^0.0.94",
         "circuit-json-to-kicad": "0.0.157",
         "circuit-json-to-pnp-csv": "^0.0.9",
         "circuit-json-to-readable-netlist": "^0.0.15",
@@ -506,7 +506,7 @@
 
     "circuit-json-to-footprinter": ["circuit-json-to-footprinter@0.0.15", "", { "dependencies": { "@tscircuit/footprinter": "^0.0.385", "@tscircuit/math-utils": "^0.0.36", "circuit-json": "^0.0.448", "format-si-unit": "^0.0.10" } }, "sha512-TBRI7rryKSWA15aX0LpNdy4RvKUQQ+qpp3FHpMblPW1IpzKQTQOi6lqcbABWzDllh7Cd3QZEvwYJYjdbGfm5Sw=="],
 
-    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.83", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.25", "fast-json-stable-stringify": "^2.1.0", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-mEIuns6Judi9ZZoBTChL3aq/mNINyiA+VbuOCVdljxmNjr5S6DVDK9186PHooOXhNv7f5m+s486aqGnwFW5lng=="],
+    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.94", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.25", "fast-json-stable-stringify": "^2.1.0", "polygon-clipping": "^0.15.7", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-moJ8C7vFzm20H1Ydzyqyqe3GQQWyyFOmi8qHarmEfzBEeu2exV98nIUIOtI6gSpdP0lMWdYTJKMfkb6xIri1JA=="],
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.106", "", { "dependencies": { "@jscad/modeling": "^2.12.6", "earcut": "^3.0.2", "jscad-electronics": "^0.0.135", "jscad-to-gltf": "^0.0.5", "occt-import-js": "^0.0.23" }, "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-js", "@resvg/resvg-wasm"] }, "sha512-U59vURQ704QTN+PxTHn8t4c0NGgdSSrNiTNYjnsXDrxK0rhtacchd9QBD4iz6x5n15QSlhcds4dyC1AVAbB9GA=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "circuit-json-to-bom-csv": "^0.0.7",
     "circuit-json-to-connectivity-map": "^0.0.25",
     "circuit-json-to-footprinter": "^0.0.15",
-    "circuit-json-to-gerber": "^0.0.83",
+    "circuit-json-to-gerber": "^0.0.94",
     "circuit-json-to-kicad": "0.0.157",
     "circuit-json-to-pnp-csv": "^0.0.9",
     "circuit-json-to-readable-netlist": "^0.0.15",


### PR DESCRIPTION
## Summary

- update `circuit-json-to-gerber` from `^0.0.83` to `^0.0.94`
- consume the released oval plated-hole Gerber support from tscircuit/circuit-json-to-gerber#143

## Testing

- `bun run build`
- `bun test tests/shared/export-snippet-part-orientation.test.ts tests/cli/check/check-shorts.test.ts` (7 passed)
- direct oval plated-hole Gerber conversion smoke test