### PR TITLE
fix: make check placement fail when placement errors are reported

### DIFF
--- a/cli/check/placement/register.ts
+++ b/cli/check/placement/register.ts
@@ -1,17 +1,18 @@
 import {
+  type PlacementIssue,
   analyzeAllPlacements,
   analyzeComponentPlacement,
 } from "@tscircuit/circuit-json-placement-analysis"
 import {
-  categorizeErrorOrWarning,
   type DrcCategory,
+  categorizeErrorOrWarning,
 } from "@tscircuit/circuit-json-util"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import type { Command } from "commander"
 import {
-  analyzeCircuitJson,
   type CircuitJsonIssue,
+  analyzeCircuitJson,
 } from "lib/shared/circuit-json-diagnostics"
 import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
 
@@ -147,7 +148,15 @@ const formatPlacementDiagnostics = ({
   return lines.join("\n")
 }
 
-export const checkPlacement = async (file?: string, refdes?: string) => {
+const isPlacementAnalysisIssueRelatedToRefdes = (
+  issue: PlacementIssue,
+  refdes: string,
+) => issue.componentA === refdes || issue.componentB === refdes
+
+export const getCheckPlacementResult = async (
+  file?: string,
+  refdes?: string,
+) => {
   const resolvedInputFilePath = await resolveCheckInputFilePath(file)
   const circuitJson = (await getCircuitJsonForCheck({
     filePath: resolvedInputFilePath,
@@ -158,15 +167,31 @@ export const checkPlacement = async (file?: string, refdes?: string) => {
     allowPrebuiltCircuitJson: true,
   })) as AnyCircuitElement[]
 
+  const placementAnalysis = analyzeAllPlacements(circuitJson)
   const analysisReport = refdes
     ? analyzeComponentPlacement(circuitJson, refdes).getString()
-    : analyzeAllPlacements(circuitJson).getString()
+    : placementAnalysis.getString()
+  const placementAnalysisIssues = refdes
+    ? placementAnalysis
+        .getIssues()
+        .filter((issue) =>
+          isPlacementAnalysisIssueRelatedToRefdes(issue, refdes),
+        )
+    : placementAnalysis.getIssues()
   const placementDiagnostics = getPlacementDiagnostics(circuitJson, refdes)
 
-  return `${analysisReport.trimEnd()}\n\n${formatPlacementDiagnostics(
-    placementDiagnostics,
-  )}`
+  return {
+    output: `${analysisReport.trimEnd()}\n\n${formatPlacementDiagnostics(
+      placementDiagnostics,
+    )}`,
+    hasErrors:
+      placementDiagnostics.errors.length > 0 ||
+      placementAnalysisIssues.length > 0,
+  }
 }
+
+export const checkPlacement = async (file?: string, refdes?: string) =>
+  (await getCheckPlacementResult(file, refdes)).output
 
 export const registerCheckPlacement = (program: Command) => {
   program.commands
@@ -177,8 +202,12 @@ export const registerCheckPlacement = (program: Command) => {
     .argument("[refdes]", "Optional refdes to scope the check")
     .action(async (file?: string, refdes?: string) => {
       try {
-        const output = await checkPlacement(file, refdes)
+        const { output, hasErrors } = await getCheckPlacementResult(
+          file,
+          refdes,
+        )
         console.log(output)
+        if (hasErrors) process.exitCode = 1
       } catch (error) {
         console.error(error instanceof Error ? error.message : String(error))
         process.exit(1)

--- a/tests/cli/check/check-placement-exit-status.test.ts
+++ b/tests/cli/check/check-placement-exit-status.test.ts
@@ -1,0 +1,163 @@
+import { expect, test } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const overlappingResistorsFixturePath = path.resolve(
+  import.meta.dir,
+  "../../fixtures/check-placement/overlapping-0402-resistors.tsx",
+)
+
+const cleanPlacementCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm" routingDisabled>
+    <resistor resistance="1k" footprint="0402" name="R1" pcbX={-2} pcbY={0} />
+    <resistor resistance="1k" footprint="0402" name="R2" pcbX={2} pcbY={0} />
+  </board>
+)
+`
+
+const connectorIntrusionCircuitJson = [
+  {
+    type: "source_component",
+    source_component_id: "source_usb1",
+    name: "USB1",
+    ftype: "chip",
+  },
+  {
+    type: "source_component",
+    source_component_id: "source_c1",
+    name: "C1",
+    ftype: "simple_capacitor",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_usb1",
+    source_component_id: "source_usb1",
+    center: { x: 0, y: 0 },
+    width: 4,
+    height: 3,
+    layer: "top",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_c1",
+    source_component_id: "source_c1",
+    center: { x: 1, y: 0 },
+    width: 2,
+    height: 1,
+    layer: "top",
+  },
+  {
+    type: "pcb_board",
+    pcb_board_id: "board_1",
+    center: { x: 0, y: 0 },
+    width: 20,
+    height: 20,
+  },
+]
+
+const scopedPlacementCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm" routingDisabled>
+    <resistor resistance="1k" footprint="0402" name="R1" pcbX={0} pcbY={0} />
+    <resistor resistance="1k" footprint="0402" name="R2" pcbX={0} pcbY={0} />
+    <resistor resistance="1k" footprint="0402" name="R3" pcbX={3} pcbY={0} />
+  </board>
+)
+`
+
+const writeCircuit = async (tmpDir: string, fileName: string, code: string) => {
+  const circuitPath = path.join(tmpDir, fileName)
+  await writeFile(circuitPath, code)
+  return circuitPath
+}
+
+test("check placement exits zero for clean placement", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = await writeCircuit(
+    tmpDir,
+    "clean-placement.tsx",
+    cleanPlacementCircuitCode,
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci check placement ${circuitPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("no placement issues")
+  expect(stdout).toContain("Errors: 0")
+})
+
+test("check placement exits nonzero for pad and courtyard overlap", async () => {
+  const { runCommand } = await getCliTestFixture()
+
+  const { stdout, exitCode } = await runCommand(
+    `tsci check placement ${overlappingResistorsFixturePath}`,
+  )
+
+  expect(exitCode).not.toBe(0)
+  expect(stdout).toContain("placement summary: 1 pad overlap")
+  expect(stdout).toContain("pcb_courtyard_overlap_error")
+})
+
+test("check placement exits nonzero for connector intrusion", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "connector-intrusion.circuit.json")
+  await writeFile(circuitPath, JSON.stringify(connectorIntrusionCircuitJson))
+
+  const { stdout, exitCode } = await runCommand(
+    `tsci check placement ${circuitPath}`,
+  )
+
+  expect(exitCode).not.toBe(0)
+  expect(stdout).toContain("connector-body intrusion")
+  expect(stdout).toContain("Errors: 0")
+})
+
+test("check placement exits zero for warning-only diagnostics", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "placement-warning.circuit.json")
+  await writeFile(
+    circuitPath,
+    JSON.stringify([
+      {
+        type: "pcb_connector_not_in_accessible_orientation_warning",
+        warning_type: "pcb_connector_not_in_accessible_orientation_warning",
+        message: "Connector J1 does not face an accessible board edge",
+        component_name: "J1",
+      },
+    ]),
+  )
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci check placement ${circuitPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain("Errors: 0")
+  expect(stdout).toContain("Warnings: 1")
+})
+
+test("check placement exit status only considers the requested refdes", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = await writeCircuit(
+    tmpDir,
+    "scoped-placement.tsx",
+    scopedPlacementCircuitCode,
+  )
+
+  const cleanScope = await runCommand(`tsci check placement ${circuitPath} R3`)
+  const failingScope = await runCommand(
+    `tsci check placement ${circuitPath} R1`,
+  )
+
+  expect(cleanScope.exitCode).toBe(0)
+  expect(cleanScope.stdout).toContain("R3")
+  expect(cleanScope.stdout).not.toContain("R1 and R2 pad overlap")
+  expect(failingScope.exitCode).not.toBe(0)
+  expect(failingScope.stdout).toContain("pcb_smtpad R1.pin1 overlaps")
+}, 20_000)

--- a/tests/fixtures/check-placement/overlapping-0402-resistors.tsx
+++ b/tests/fixtures/check-placement/overlapping-0402-resistors.tsx
@@ -1,0 +1,6 @@
+export default () => (
+  <board width="10mm" height="10mm" routingDisabled>
+    <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} pcbY={0} />
+    <resistor name="R2" resistance="1k" footprint="0402" pcbX={0} pcbY={0} />
+  </board>
+)


### PR DESCRIPTION
## Summary

- make `tsci check placement` exit nonzero when scoped placement DRC errors are present
- also fail on actionable placement-analysis issues while keeping warning-only results successful
- preserve refdes scoping for both diagnostics and analysis issues
- add an overlapping-0402 fixture and command-level regressions for clean, overlap, connector-intrusion, warning-only, and scoped outcomes

## Root cause

The command printed both the placement analysis and DRC summaries but never used either result to set the process exit status.

## Validation

- `bun test tests/cli/check/check-placement.test.ts tests/cli/check/check-placement-exit-status.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome check cli/check/placement/register.ts tests/cli/check/check-placement-exit-status.test.ts tests/fixtures/check-placement/overlapping-0402-resistors.tsx`
- manual reproduction: overlapping 0402 fixture now exits 1 (previously 0)
