### PR TITLE
fix: preserve absolute paths passed to tsci export --output

### DIFF
--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -140,7 +140,10 @@ export const exportSnippet = async ({
   const projectDir = path.dirname(filePath)
   const outputBaseName = path.basename(filePath).replace(/\.[^.]+$/, "")
   const outputFileName = `${outputBaseName}${OUTPUT_EXTENSIONS[format]}`
-  const outputDestination = path.join(projectDir, outputPath ?? outputFileName)
+  const outputDestination =
+    outputPath && path.isAbsolute(outputPath)
+      ? outputPath
+      : path.join(projectDir, outputPath ?? outputFileName)
 
   // Handle kicad-library separately - it doesn't need generateCircuitJson
   if (format === "kicad-library") {

--- a/tests/cli/export/export-output-path.test.ts
+++ b/tests/cli/export/export-output-path.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { copyFile, mkdir, readFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const fixturePath = path.resolve(
+  import.meta.dir,
+  "../../fixtures/export/output-path-board.circuit.json",
+)
+
+const setupExportFixture = async () => {
+  const fixture = await getCliTestFixture()
+  const projectDir = path.join(fixture.tmpDir, "project")
+  const circuitPath = path.join(projectDir, "board.circuit.json")
+  await mkdir(projectDir, { recursive: true })
+  await copyFile(fixturePath, circuitPath)
+  return { ...fixture, projectDir, circuitPath }
+}
+
+test("export preserves an absolute POSIX GLB output path", async () => {
+  const { tmpDir, circuitPath, runCommand } = await setupExportFixture()
+  const outputPath = path.join(tmpDir, "absolute-board.glb")
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci export ${circuitPath} --format glb --output ${outputPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(path.posix.isAbsolute(outputPath)).toBe(true)
+  expect((await readFile(outputPath)).subarray(0, 4).toString()).toBe("glTF")
+  expect(stdout.trim()).toBe(`Exported to ${outputPath}!`)
+})
+
+test("export resolves a relative Circuit JSON output path from the input directory", async () => {
+  const { projectDir, circuitPath, runCommand } = await setupExportFixture()
+  const relativeOutputPath = "exports/relative-board.circuit.json"
+  const outputPath = path.join(projectDir, relativeOutputPath)
+  await mkdir(path.dirname(outputPath), { recursive: true })
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci export ${circuitPath} --format circuit-json --output ${relativeOutputPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(JSON.parse(await readFile(outputPath, "utf8"))).toEqual(
+    JSON.parse(await readFile(fixturePath, "utf8")),
+  )
+  expect(stdout.trim()).toBe(`Exported to ${outputPath}!`)
+})
+
+test("export resolves an output filename from the input directory", async () => {
+  const { projectDir, circuitPath, runCommand } = await setupExportFixture()
+  const outputFileName = "named-board.glb"
+  const outputPath = path.join(projectDir, outputFileName)
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci export ${circuitPath} --format glb --output ${outputFileName}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect((await readFile(outputPath)).subarray(0, 4).toString()).toBe("glTF")
+  expect(stdout.trim()).toBe(`Exported to ${outputPath}!`)
+})

--- a/tests/fixtures/export/output-path-board.circuit.json
+++ b/tests/fixtures/export/output-path-board.circuit.json
@@ -1,0 +1,19 @@
+[
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 10,
+    "height": 10,
+    "thickness": 1.6,
+    "outline": [
+      { "x": -5, "y": -5 },
+      { "x": 5, "y": -5 },
+      { "x": 5, "y": 5 },
+      { "x": -5, "y": 5 }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- preserve an absolute `tsci export --output` path exactly as supplied
- continue resolving relative output paths and filename-only outputs from the input file directory
- add command-level coverage for absolute POSIX, nested relative, and filename-only destinations across GLB and Circuit JSON exports
- use a prebuilt board-only Circuit JSON fixture so the regressions require no parts-engine or CAD downloads

## Root cause

`exportSnippet` always passed the supplied output path through `path.join(projectDir, outputPath)`. On POSIX, that appended an absolute-looking output below the project directory instead of preserving its root.

## Validation

- `bun test tests/cli/export/export-output-path.test.ts tests/cli/export/export-glb.test.ts tests/cli/export/export-circuit-json.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome format lib/shared/export-snippet.ts tests/cli/export/export-output-path.test.ts tests/fixtures/export/output-path-board.circuit.json`
- manual reproduction now writes and logs the exact absolute `/tmp/...` destination
