### PR TITLE
Update schematic placement analysis

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@tscircuit/check-shorts": "https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.19.tgz",
         "@tscircuit/circuit-json-placement-analysis": "^0.0.9",
         "@tscircuit/circuit-json-routing-analysis": "^0.0.8",
-        "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
+        "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#2bfa85c47dd0bd0d360b85083980170c01d3afca",
         "@tscircuit/circuit-json-util": "^0.0.105",
         "@tscircuit/eval": "^0.0.1016",
         "@tscircuit/fake-snippets": "^0.0.182",
@@ -393,7 +393,7 @@
 
     "@tscircuit/circuit-json-routing-analysis": ["@tscircuit/circuit-json-routing-analysis@0.0.8", "", { "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "sha512-mZxRSUbqVb6iZ47ZhNL3mDL7BY9kUcbLg7o4f8Jn5amkDGvmTo52547JQ5ui/6WSJHXmaW7hmRVTEj6PlivskQ=="],
 
-    "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-bb0b41d", "sha512-L8P1Qs4rs9tBWosUJEFvNKSKwBKHHIArmJh+aDCGz5m9g5dP+STyadkTOb9BJRXuWXm1ndBD05VMfHMwb9F9JQ=="],
+    "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#2bfa85c", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-2bfa85c"],
 
     "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.105", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-zyAP7AkfARgw8Bsme6D9AmffA03swTYDKg0ypDASMMR3aGghR5MET+IswugfOuAa019gnBOV6Q1an4kaIOKdCw=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@tscircuit/check-shorts": "https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.19.tgz",
     "@tscircuit/circuit-json-placement-analysis": "^0.0.9",
     "@tscircuit/circuit-json-routing-analysis": "^0.0.8",
-    "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#bb0b41d80c9714695b498e182c2a558f1e0ceb2d",
+    "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#2bfa85c47dd0bd0d360b85083980170c01d3afca",
     "@tscircuit/circuit-json-util": "^0.0.105",
     "@tscircuit/eval": "^0.0.1016",
     "@tscircuit/fake-snippets": "^0.0.182",

--- a/tests/cli/check/check-schematic-placement.test.ts
+++ b/tests/cli/check/check-schematic-placement.test.ts
@@ -14,6 +14,91 @@ export default () => (
 )
 `
 
+const misalignedPinPairsCircuitJson = [
+  {
+    type: "source_component",
+    source_component_id: "source_component_1",
+    name: "U1",
+    ftype: "simple_chip",
+  },
+  {
+    type: "source_component",
+    source_component_id: "source_component_2",
+    name: "U2",
+    ftype: "simple_chip",
+  },
+  {
+    type: "schematic_component",
+    schematic_component_id: "schematic_component_1",
+    source_component_id: "source_component_1",
+    center: { x: -3, y: 0 },
+    size: { width: 2, height: 1 },
+    rotation: 0,
+  },
+  {
+    type: "schematic_component",
+    schematic_component_id: "schematic_component_2",
+    source_component_id: "source_component_2",
+    center: { x: 3, y: 1 },
+    size: { width: 2, height: 1 },
+    rotation: 0,
+  },
+  {
+    type: "schematic_port",
+    schematic_port_id: "schematic_port_1",
+    schematic_component_id: "schematic_component_1",
+    source_port_id: "source_port_1",
+    center: { x: -2, y: 0.1 },
+    facing_direction: "right",
+    pin_number: 1,
+    display_pin_label: "SCL",
+  },
+  {
+    type: "schematic_port",
+    schematic_port_id: "schematic_port_2",
+    schematic_component_id: "schematic_component_1",
+    source_port_id: "source_port_2",
+    center: { x: -2, y: -0.1 },
+    facing_direction: "right",
+    pin_number: 2,
+    display_pin_label: "SDA",
+  },
+  {
+    type: "schematic_port",
+    schematic_port_id: "schematic_port_3",
+    schematic_component_id: "schematic_component_2",
+    source_port_id: "source_port_3",
+    center: { x: 2, y: 1.1 },
+    facing_direction: "left",
+    pin_number: 1,
+    display_pin_label: "SCL",
+  },
+  {
+    type: "schematic_port",
+    schematic_port_id: "schematic_port_4",
+    schematic_component_id: "schematic_component_2",
+    source_port_id: "source_port_4",
+    center: { x: 2, y: 0.9 },
+    facing_direction: "left",
+    pin_number: 2,
+    display_pin_label: "SDA",
+  },
+  {
+    type: "schematic_trace",
+    schematic_trace_id: "schematic_trace_1",
+    source_trace_id: "source_trace_1",
+    edges: [{ from: { x: -2, y: 0.1 }, to: { x: 2, y: 1.1 } }],
+    junctions: [],
+  },
+  {
+    type: "schematic_trace",
+    schematic_trace_id: "schematic_trace_2",
+    source_trace_id: "source_trace_2",
+    edges: [{ from: { x: -2, y: -0.1 }, to: { x: 2, y: 0.9 } }],
+    junctions: [],
+  },
+]
+
 test("tsci check schematic-placement prints schematic placement analysis", async () => {
   const { runCommand } = await getCliTestFixture()
   const circuitPath = path.join(
@@ -40,3 +125,19 @@ test("tsci check schematic-placement prints schematic placement analysis", async
     await rm(circuitPath, { force: true })
   }
 }, 20_000)
+
+test("tsci check schematic-placement reports a better vertical pin alignment", async () => {
+  const { runCommand, tmpDir } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "misaligned-pins.circuit.json")
+  await writeFile(circuitPath, JSON.stringify(misalignedPinPairsCircuitJson))
+
+  const { stdout, stderr, exitCode } = await runCommand(
+    `tsci check schematic-placement ${circuitPath}`,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+  expect(stdout).toContain(
+    '<ComponentPinsWouldAlignWithVerticalShift firstComponentName="U1" secondComponentName="U2" targetComponentName="U2" deltaSchY="-1" newSchY="0" currentlyAlignedPinCount="0" alignedPinCount="2"',
+  )
+})


### PR DESCRIPTION
## Summary

- update `@tscircuit/circuit-json-schematic-placement-analysis` from `bb0b41d` to merged main commit `2bfa85c`
- refresh the Bun lockfile for that exact commit
- add end-to-end CLI coverage confirming `tsci check schematic-placement` reports `ComponentPinsWouldAlignWithVerticalShift` for two consistently offset pin pairs

## Why

The CLI pins the schematic placement analyzer by Git commit, so it did not yet contain the newly merged vertical pin-alignment detector. This updates the command to expose that diagnostic to users.

## Validation

- `bun test tests/cli/check/check-schematic-placement.test.ts` (2 passing)
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`

The full `bun test` suite was also attempted. It reached unrelated local-environment failures: missing Sharp native bindings, missing Playwright browser binaries, legacy registry fixture 404s, and an existing init test timeout.