### PR TITLE
Generate 3D previews for --site builds

### DIFF
--- a/cli/build/build-preview-images.ts
+++ b/cli/build/build-preview-images.ts
@@ -23,12 +23,14 @@ const generatePreviewAssets = async ({
   distDir,
   imageFormats,
   pcbSnapshotSettings,
+  skipExisting,
 }: {
   build: BuildFileResult
   outputDir: string
   distDir: string
   imageFormats: BuildImageFormatSelection
   pcbSnapshotSettings?: PcbSnapshotSettings
+  skipExisting?: boolean
 }) => {
   const prefixRelative = path.relative(distDir, outputDir) || "."
   const prefix = prefixRelative === "." ? "" : `[${prefixRelative}] `
@@ -125,10 +127,13 @@ const generatePreviewAssets = async ({
   }
 
   if (imageFormats.threeDPngs) {
+    const outputPath = path.join(outputDir, "3d.png")
+    if (skipExisting && fs.existsSync(outputPath)) return
+
     try {
       console.log(`${prefix}Generating 3D PNG...`)
       const pngBuffer = await renderCircuitJsonTo3dPng(circuitJson)
-      fs.writeFileSync(path.join(outputDir, "3d.png"), Buffer.from(pngBuffer))
+      fs.writeFileSync(outputPath, Buffer.from(pngBuffer))
       console.log(`${prefix}Written 3d.png`)
     } catch (error) {
       console.error(`${prefix}Failed to generate 3D PNG:`, error)
@@ -144,6 +149,7 @@ export const buildPreviewImages = async ({
   allImages,
   imageFormats,
   pcbSnapshotSettings,
+  skipExisting,
 }: {
   builtFiles: BuildFileResult[]
   distDir: string
@@ -152,6 +158,7 @@ export const buildPreviewImages = async ({
   allImages?: boolean
   imageFormats: BuildImageFormatSelection
   pcbSnapshotSettings?: PcbSnapshotSettings
+  skipExisting?: boolean
 }) => {
   const successfulBuilds = builtFiles.filter((file) => file.ok)
   // previewComponentPath takes precedence over mainEntrypoint for preview images
@@ -176,6 +183,7 @@ export const buildPreviewImages = async ({
         distDir,
         imageFormats,
         pcbSnapshotSettings,
+        skipExisting,
       })
     }
     return
@@ -204,5 +212,6 @@ export const buildPreviewImages = async ({
     pcbSnapshotSettings,
     distDir,
     imageFormats,
+    skipExisting,
   })
 }

--- a/cli/build/image-format-selection.ts
+++ b/cli/build/image-format-selection.ts
@@ -30,6 +30,11 @@ export const EMPTY_IMAGE_FORMAT_SELECTION: BuildImageFormatSelection = {
   simulationSchematicSvgs: false,
 }
 
+export const SITE_IMAGE_FORMAT_SELECTION: BuildImageFormatSelection = {
+  ...EMPTY_IMAGE_FORMAT_SELECTION,
+  threeDPngs: true,
+}
+
 export const hasAnyImageFormatSelected = (
   selection: BuildImageFormatSelection,
 ) =>

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -44,6 +44,7 @@ import {
 import {
   hasAnyImageFormatSelected,
   resolveImageFormatSelection,
+  SITE_IMAGE_FORMAT_SELECTION,
 } from "./image-format-selection"
 import { resolveBuildOptions } from "./resolve-build-options"
 import { transpileFile } from "./transpile"
@@ -468,6 +469,12 @@ export const registerBuild = (program: Command) => {
         const shouldGenerateAllPreviewImages = Boolean(
           resolvedOptions?.allImages,
         )
+        const shouldGenerateSite3dImages = Boolean(
+          resolvedOptions?.site &&
+            !(
+              shouldGenerateAllPreviewImages && imageFormatSelection.threeDPngs
+            ),
+        )
         const shouldGeneratePreviewAssetsInWorker = Boolean(
           resolvedOptions?.ci &&
             concurrencyValue > 1 &&
@@ -817,6 +824,19 @@ export const registerBuild = (program: Command) => {
                 : projectConfig?.pcbSnapshotSettings,
             })
           }
+        }
+
+        if (shouldGenerateSite3dImages) {
+          console.log("Generating 3D preview images for all site builds...")
+          await buildPreviewImages({
+            builtFiles,
+            distDir,
+            mainEntrypoint,
+            previewComponentPath,
+            allImages: true,
+            imageFormats: SITE_IMAGE_FORMAT_SELECTION,
+            skipExisting: true,
+          })
         }
 
         if (resolvedOptions?.previewGltf) {

--- a/tests/cli/build/build-site.test.ts
+++ b/tests/cli/build/build-site.test.ts
@@ -35,6 +35,30 @@ test("build with --site generates index.html and standalone.min.js", async () =>
   expect(standaloneJs.isFile()).toBe(true)
 }, 30_000)
 
+test("build with --site generates only 3D preview images for every circuit", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await writeFile(path.join(tmpDir, "first.circuit.tsx"), circuitCode)
+  await writeFile(path.join(tmpDir, "second.circuit.tsx"), circuitCode)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { stderr } = await runCommand("tsci build --site --use-cdn-javascript")
+  expect(stderr).toBe("")
+
+  for (const circuitName of ["first", "second"]) {
+    const outputDir = path.join(tmpDir, "dist", circuitName)
+    const preview3d = await readFile(path.join(outputDir, "3d.png"))
+
+    expect(preview3d[0]).toBe(0x89)
+    expect(preview3d[1]).toBe(0x50)
+    expect(preview3d[2]).toBe(0x4e)
+    expect(preview3d[3]).toBe(0x47)
+    await expect(stat(path.join(outputDir, "pcb.svg"))).rejects.toBeTruthy()
+    await expect(
+      stat(path.join(outputDir, "schematic.svg")),
+    ).rejects.toBeTruthy()
+  }
+}, 60_000)
+
 test("build with --site --use-cdn-javascript uses CDN URL and no standalone.min.js", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "test.circuit.tsx")


### PR DESCRIPTION
## Summary

- generate `3d.png` for every successful circuit when `tsci build --site` is used
- keep site defaults limited to the 3D preview; PCB and schematic images remain opt-in
- skip rendering a site preview when another image option already produced the same `3d.png`
- add coverage for multi-circuit site builds

## Why

Runframe's static circuit gallery looks for `3d.png` next to each `circuit.json`, but `--site` previously generated only circuit JSON unless additional image flags were provided. That left gallery cards without preview images.

## Validation

- `bun test tests/cli/build/build-site.test.ts`
- `bun test tests/cli/build/build-site.test.ts tests/cli/build/build.test.ts tests/cli/build/build-with-concurrency-generate-site.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`