### PR TITLE
test: reproduce filename-dependent circuit json checks

### DIFF
--- a/tests/cli/check/check-shorts.test.ts
+++ b/tests/cli/check/check-shorts.test.ts
@@ -189,6 +189,28 @@ test("check shorts reports no shorts for a clean board", async () => {
   }
 }, 20_000)
 
+test("repro: check shorts evaluates ordinary .json filenames as source", async () => {
+  const tmpDir = temporaryDirectory()
+  const sourceCircuitPath = path.join(tmpDir, "shorted-board.tsx")
+  const prebuiltCircuitJsonPath = path.join(tmpDir, "shorted-board.json")
+
+  try {
+    await linkWorkspaceNodeModules(tmpDir)
+    await writeFile(sourceCircuitPath, circuitCode)
+    const circuitJson = await makeCircuitJsonWithShort(sourceCircuitPath)
+    await writeFile(
+      prebuiltCircuitJsonPath,
+      JSON.stringify(circuitJson, null, 2),
+    )
+
+    await expect(checkShorts(prebuiltCircuitJsonPath)).rejects.toThrow(
+      "Element type is invalid",
+    )
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true })
+  }
+}, 20_000)
+
 test("tsci check shorts detects a copper bridge short", async () => {
   const { runCommand, tmpDir } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "shorted-board.tsx")


### PR DESCRIPTION
## Summary

- write a real routed Circuit JSON array to an ordinary shorted-board.json path
- reproduce check shorts sending that array through the React source evaluator
- assert the current unrelated Element type is invalid array failure

## Verification

- bun test tests/cli/check/check-shorts.test.ts (7 pass)
- bun run build
- bunx biome format tests/cli/check/check-shorts.test.ts