### PR TITLE
fix: recognize prebuilt circuit json by content

### DIFF
--- a/cli/check/shared.ts
+++ b/cli/check/shared.ts
@@ -9,6 +9,34 @@ import { getEntrypoint } from "lib/shared/get-entrypoint"
 import { isCircuitJsonFile } from "lib/shared/is-circuit-json-file"
 import { findCircuitProjectDir } from "lib/shared/circuit-json-build-cache"
 
+const hasCircuitJsonElementDiscriminator = (
+  value: unknown,
+): value is { type: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "string"
+
+const tryReadPrebuiltCircuitJson = (
+  filePath: string,
+): AnyCircuitElement[] | null => {
+  try {
+    const parsedFile: unknown = JSON.parse(fs.readFileSync(filePath, "utf-8"))
+    if (
+      !Array.isArray(parsedFile) ||
+      !parsedFile.every(hasCircuitJsonElementDiscriminator)
+    ) {
+      return null
+    }
+
+    // Circuit JSON is a discriminated element array. Full semantic checks are
+    // command-specific, matching the existing *.circuit.json loading path.
+    return parsedFile as AnyCircuitElement[]
+  } catch {
+    return null
+  }
+}
+
 export const resolveCheckInputFilePath = async (file?: string) => {
   if (file) {
     return path.isAbsolute(file) ? file : path.resolve(process.cwd(), file)
@@ -36,6 +64,11 @@ export const getCircuitJsonForCheck = async ({
   allowPrebuiltCircuitJson?: boolean
   autorouterDiagnostics?: AutorouterDiagnosticsOptions
 }): Promise<AnyCircuitElement[]> => {
+  if (allowPrebuiltCircuitJson) {
+    const prebuiltCircuitJson = tryReadPrebuiltCircuitJson(filePath)
+    if (prebuiltCircuitJson) return prebuiltCircuitJson
+  }
+
   if (allowPrebuiltCircuitJson && isCircuitJsonFile(filePath)) {
     const parsedJson = JSON.parse(fs.readFileSync(filePath, "utf-8"))
     return Array.isArray(parsedJson) ? parsedJson : []

--- a/tests/cli/check/__snapshots__/check-shorts-ordinary-json-pcb.snap.svg
+++ b/tests/cli/check/__snapshots__/check-shorts-ordinary-json-pcb.snap.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><style></style><rect class="boundary" x="0" y="0" fill="#000" width="800" height="600" data-type="pcb_background" data-pcb-layer="global"/><rect class="pcb-boundary" fill="none" stroke="#fff" stroke-width="0.3" x="150" y="50" width="500" height="500" data-type="pcb_boundary" data-pcb-layer="global"/><path class="pcb-board" d="M 150 550 L 650 550 L 650 50 L 150 50 Z" fill="none" stroke="rgba(255, 255, 255, 0.5)" stroke-width="5" data-type="pcb_board" data-pcb-layer="board"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="261" y="284" width="27" height="32" data-type="pcb_smtpad" data-pcb-layer="top" data-pad-name="R1.pin1"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="312" y="284" width="27" height="32" data-type="pcb_smtpad" data-pcb-layer="top" data-pad-name="R1.pin2"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="461" y="284" width="27" height="32" data-type="pcb_smtpad" data-pcb-layer="top" data-pad-name="C1.pin1"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="512" y="284" width="27" height="32" data-type="pcb_smtpad" data-pcb-layer="top" data-pad-name="C1.pin2"/><path class="pcb-trace" stroke="rgb(200, 52, 52)" fill="none" d="M 290 300 L 510 300" stroke-width="12.5" stroke-linecap="round" stroke-linejoin="round" shape-rendering="crispEdges" data-type="pcb_trace" data-pcb-layer="top"/><path class="pcb-silkscreen pcb-silkscreen-top" d="M 292.31795 281 L 307.68205 281" fill="none" stroke="#f2eda1" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" data-pcb-component-id="pcb_component_0" data-pcb-silkscreen-path-id="pcb_silkscreen_path_0" data-type="pcb_silkscreen_path" data-pcb-layer="top"/><path class="pcb-silkscreen pcb-silkscreen-top" d="M 292.31795 319 L 307.68205 319" fill="none" stroke="#f2eda1" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" data-pcb-component-id="pcb_component_0" data-pcb-silkscreen-path-id="pcb_silkscreen_path_1" data-type="pcb_silkscreen_path" data-pcb-layer="top"/><text x="0" y="0" dx="0" dy="0" fill="#f2eda1" font-family="Arial, sans-serif" font-size="20" text-anchor="middle" dominant-baseline="central" transform="matrix(1,0,0,1,300,239)" class="pcb-silkscreen-text pcb-silkscreen-top" data-pcb-silkscreen-text-id="pcb_silkscreen_text_0" stroke="none" data-type="pcb_silkscreen_text" data-pcb-layer="top">R1</text><path class="pcb-silkscreen pcb-silkscreen-top" d="M 525.5 264 L 451 264 L 451 336 L 525.5 336" fill="none" stroke="#f2eda1" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" data-pcb-component-id="pcb_component_1" data-pcb-silkscreen-path-id="pcb_silkscreen_path_2" data-type="pcb_silkscreen_path" data-pcb-layer="top"/><text x="0" y="0" dx="0" dy="0" fill="#f2eda1" font-family="Arial, sans-serif" font-size="20" text-anchor="middle" dominant-baseline="central" transform="matrix(1,0,0,1,500,239)" class="pcb-silkscreen-text pcb-silkscreen-top" data-pcb-silkscreen-text-id="pcb_silkscreen_text_1" stroke="none" data-type="pcb_silkscreen_text" data-pcb-layer="top">C1</text>
+  <g data-type="short-debug" data-mode="gerber" data-layer="top">
+    <title>SHORT 1: R1.pin2 &lt;-&gt; pcb_trace_short_bridge</title>
+    <circle cx="324.83" cy="300.00" r="14" fill="none" stroke="#9b5cff" stroke-width="4"/>
+    <circle cx="324.83" cy="300.00" r="6" fill="none" stroke="#9b5cff" stroke-width="3"/>
+  </g>
+  <g data-type="short-debug" data-mode="gerber" data-layer="top">
+    <title>SHORT 2: C1.pin1 &lt;-&gt; pcb_trace_short_bridge</title>
+    <circle cx="473.43" cy="300.00" r="14" fill="none" stroke="#9b5cff" stroke-width="4"/>
+    <circle cx="473.43" cy="300.00" r="6" fill="none" stroke="#9b5cff" stroke-width="3"/>
+  </g>
+  <g data-type="short-debug" data-mode="gerber" data-layer="top">
+    <title>SHORT 3: R1.pin1 &lt;-&gt; pcb_trace_short_bridge</title>
+    <circle cx="285.20" cy="299.13" r="14" fill="none" stroke="#9b5cff" stroke-width="4"/>
+    <circle cx="285.20" cy="299.13" r="6" fill="none" stroke="#9b5cff" stroke-width="3"/>
+  </g>
+  <g data-type="short-debug" data-mode="gerber" data-layer="top">
+    <title>SHORT 4: C1.pin2 &lt;-&gt; pcb_trace_short_bridge</title>
+    <circle cx="513.05" cy="299.13" r="14" fill="none" stroke="#9b5cff" stroke-width="4"/>
+    <circle cx="513.05" cy="299.13" r="6" fill="none" stroke="#9b5cff" stroke-width="3"/>
+  </g>
+</svg>

--- a/tests/cli/check/check-shorts.test.ts
+++ b/tests/cli/check/check-shorts.test.ts
@@ -189,7 +189,7 @@ test("check shorts reports no shorts for a clean board", async () => {
   }
 }, 20_000)
 
-test("repro: check shorts evaluates ordinary .json filenames as source", async () => {
+test("check shorts recognizes prebuilt Circuit JSON by content", async () => {
   const tmpDir = temporaryDirectory()
   const sourceCircuitPath = path.join(tmpDir, "shorted-board.tsx")
   const prebuiltCircuitJsonPath = path.join(tmpDir, "shorted-board.json")
@@ -203,8 +203,14 @@ test("repro: check shorts evaluates ordinary .json filenames as source", async (
       JSON.stringify(circuitJson, null, 2),
     )
 
-    await expect(checkShorts(prebuiltCircuitJsonPath)).rejects.toThrow(
-      "Element type is invalid",
+    const result = await checkShorts(prebuiltCircuitJsonPath)
+    const debugSvg = createShortDebugSvg(circuitJson, result.shorts)
+
+    expect(result.shorts).toHaveLength(4)
+    expect(result.output).toContain("Detected 4 shorts in shorted-board.json")
+    expect(debugSvg).toMatchSvgSnapshot(
+      import.meta.path,
+      "check-shorts-ordinary-json-pcb",
     )
   } finally {
     await rm(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- recognize prebuilt Circuit JSON from a discriminated element array instead of requiring a special filename suffix
- preserve the existing canonical filename fallback for backward compatibility
- run check shorts successfully against shorted-board.json and render its PCB debug snapshot

## Stack

- Reproduction: https://github.com/tscircuit/cli/pull/4302
- This PR is based on the reproduction branch

## Verification

- bun test tests/cli/check/check-shorts.test.ts (7 pass)
- bun test tests/cli/check (26 pass when run with localhost fixture access)
- bun run build
- bunx biome format cli/check/shared.ts tests/cli/check/check-shorts.test.ts
- fixed PCB SVG snapshot rendered and visually inspected