### PR TITLE
version update to Improve EasyEDA imports: passive primitives, parsing, symbols, aliases, and arc layers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "debug": "^4.4.0",
         "delay": "^6.0.0",
         "dsn-converter": "^0.0.90",
-        "easyeda": "^0.0.296",
+        "easyeda": "^0.0.301",
         "fuse.js": "^7.1.0",
         "get-port": "^7.1.0",
         "globby": "^14.1.0",
@@ -683,7 +683,7 @@
 
     "earcut": ["earcut@3.2.3", "", {}, "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q=="],
 
-    "easyeda": ["easyeda@0.0.296", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-o/urZ98vOxbKx18xsPwBP0M3OgWQ7MCpcKEWopy3dH5hfZ76XQt6EEWJGhxOvnfpepV14yX7OBlyL0xz/umcHA=="],
+    "easyeda": ["easyeda@0.0.301", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda": "dist/main.cjs", "easyeda-converter": "dist/main.cjs" } }, "sha512-O0dPOFJgmcYvYeBA6+6Fey9gaRe4VOVfeVh06F1whzCPQOZu+SQtEVW5X5QN014bL78b4VDtPyjXu6ldmfq6HA=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "debug": "^4.4.0",
     "delay": "^6.0.0",
     "dsn-converter": "^0.0.90",
-    "easyeda": "^0.0.296",
+    "easyeda": "^0.0.301",
     "fuse.js": "^7.1.0",
     "get-port": "^7.1.0",
     "globby": "^14.1.0",


### PR DESCRIPTION
## Summary

Update the `easyeda` dependency from `^0.0.296` to `^0.0.301`.

## Changes

- Updated the declared dependency in `package.json`.
- Updated `bun.lock` to resolve `easyeda@0.0.301`.
- Updated the lockfile integrity hash and package metadata for the new release.
- Preserved unrelated lockfile entries.

## Impact

The CLI's EasyEDA/JLCPCB import and conversion paths now use EasyEDA 0.0.301, bringing in the requested upstream release while keeping the existing dependency range behavior.

## Validation

- `git diff --check` passed.
- `bun test tests/cli/import/import.test.ts` completed; its existing EasyEDA import test was skipped by its test condition.