### PR TITLE
feat(check): add `tsci check opens` to detect unrouted nets

### DIFF
--- a/cli/check/opens/register.ts
+++ b/cli/check/opens/register.ts
@@ -15,6 +15,7 @@ interface CheckOpensOptions {
   mode?: "pcb" | "gerber"
   layer?: CheckShortsLayerOption
   pixelsPerMm?: string
+  ignoreNet?: string[]
 }
 
 export interface CheckOpensResult {
@@ -87,11 +88,16 @@ export const checkOpens = async (
       ? undefined
       : getCheckShortLayers({ circuitJson, layerOption })
 
+  const ignoreNets = options.ignoreNet?.length ? options.ignoreNet : undefined
+
   const opens = await findBitmapOpens(circuitJson, {
     mode,
     ...(layers?.[0] ? { layer: layers[0] } : {}),
     pixelsPerMm,
-  } satisfies FindBitmapOpensOptions)
+    ignoreNets,
+    // ignoreNets ships in @tscircuit/check-shorts after 0.0.19; widen the
+    // pinned type until the dependency is bumped.
+  } satisfies FindBitmapOpensOptions & { ignoreNets?: string[] })
   const filename =
     resolvedInputFilePath.split("/").pop() ?? resolvedInputFilePath
 
@@ -123,6 +129,12 @@ export const registerCheckOpens = (program: Command) => {
     )
     .option("--layer <layer>", "Layer to analyze: top, bottom, or all", "all")
     .option("--pixels-per-mm <number>", "Bitmap resolution for open detection")
+    .option(
+      "--ignore-net <name>",
+      "Net to exclude from open detection, for nets joined off the board by design (mounting holes bonded through a metal enclosure, signals joined by a cable or mating connector). Repeatable.",
+      (value: string, previous: string[]) => [...previous, value],
+      [] as string[],
+    )
     .action(async (file?: string, options?: CheckOpensOptions) => {
       try {
         const result = await checkOpens(file, options)

--- a/cli/check/opens/register.ts
+++ b/cli/check/opens/register.ts
@@ -1,4 +1,7 @@
-import type { BitmapOpen, FindBitmapOpensOptions } from "@tscircuit/check-shorts"
+import type {
+  BitmapOpen,
+  FindBitmapOpensOptions,
+} from "@tscircuit/check-shorts"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { Command } from "commander"
 import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
@@ -73,20 +76,24 @@ export const checkOpens = async (
     } satisfies PlatformConfig,
     allowPrebuiltCircuitJson: true,
   })
-  const layers = getCheckShortLayers({ circuitJson, layerOption })
   const { findBitmapOpens } = await loadCheckShorts()
 
-  const opensPerLayer = await Promise.all(
-    layers.map((layer) =>
-      findBitmapOpens(circuitJson, {
-        mode,
-        layer,
-        pixelsPerMm,
-      } satisfies FindBitmapOpensOptions),
-    ),
-  )
-  const opens = opensPerLayer.flat()
-  const filename = resolvedInputFilePath.split("/").pop() ?? resolvedInputFilePath
+  // Unlike shorts, opens are a whole-board question: a net routed top -> via ->
+  // bottom is fully connected, but looked at one layer at a time it appears
+  // split. So "all" means one analysis spanning every copper layer (the
+  // detector's default), not one analysis per layer.
+  const layers =
+    layerOption === "all"
+      ? undefined
+      : getCheckShortLayers({ circuitJson, layerOption })
+
+  const opens = await findBitmapOpens(circuitJson, {
+    mode,
+    ...(layers?.[0] ? { layer: layers[0] } : {}),
+    pixelsPerMm,
+  } satisfies FindBitmapOpensOptions)
+  const filename =
+    resolvedInputFilePath.split("/").pop() ?? resolvedInputFilePath
 
   if (opens.length === 0) {
     return { output: `No opens detected in ${filename}`, opens }
@@ -109,7 +116,11 @@ export const registerCheckOpens = (program: Command) => {
       "Detect nets whose copper is not fully joined (unrouted connections)",
     )
     .argument("[file]", "Path to the entry file or prebuilt circuit JSON")
-    .option("--mode <mode>", "Bitmap source to analyze: pcb or gerber", "gerber")
+    .option(
+      "--mode <mode>",
+      "Bitmap source to analyze: pcb or gerber",
+      "gerber",
+    )
     .option("--layer <layer>", "Layer to analyze: top, bottom, or all", "all")
     .option("--pixels-per-mm <number>", "Bitmap resolution for open detection")
     .action(async (file?: string, options?: CheckOpensOptions) => {

--- a/cli/check/opens/register.ts
+++ b/cli/check/opens/register.ts
@@ -1,0 +1,127 @@
+import type { BitmapOpen, FindBitmapOpensOptions } from "@tscircuit/check-shorts"
+import type { PlatformConfig } from "@tscircuit/props"
+import type { Command } from "commander"
+import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
+import {
+  type CheckShortsLayerOption,
+  getCheckShortLayers,
+} from "../shorts/get-check-short-layers"
+import { loadCheckShorts } from "../shorts/register"
+
+interface CheckOpensOptions {
+  mode?: "pcb" | "gerber"
+  layer?: CheckShortsLayerOption
+  pixelsPerMm?: string
+}
+
+export interface CheckOpensResult {
+  output: string
+  opens: BitmapOpen[]
+}
+
+const parsePixelsPerMm = (value?: string): number | undefined => {
+  if (!value) return undefined
+  const parsedValue = Number(value)
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    throw new Error("--pixels-per-mm must be a positive number")
+  }
+  return parsedValue
+}
+
+const parseMode = (mode?: string): "pcb" | "gerber" => {
+  if (!mode) return "gerber"
+  if (mode === "pcb" || mode === "gerber") return mode
+  throw new Error("--mode must be either pcb or gerber")
+}
+
+const parseLayer = (layer?: string): CheckShortsLayerOption => {
+  if (!layer) return "all"
+  if (layer === "top" || layer === "bottom" || layer === "all") return layer
+  throw new Error("--layer must be top, bottom, or all")
+}
+
+const formatLabels = (labels: string[]) =>
+  labels.length > 0 ? labels.join(", ") : "(unknown)"
+
+const formatOpen = (open: BitmapOpen, index: number) => {
+  const lines = [
+    `${index + 1}. ${open.layer}/${open.mode} net split across ${open.islands.length} copper islands`,
+    `   ${formatLabels(open.ownerLabels)}`,
+  ]
+
+  for (const island of open.islands) {
+    const center = `x=${island.center.x.toFixed(3)}mm y=${island.center.y.toFixed(3)}mm`
+    lines.push(`   island at ${center} pixels=${island.pixelCount}`)
+  }
+
+  return lines.join("\n")
+}
+
+export const checkOpens = async (
+  file?: string,
+  options: CheckOpensOptions = {},
+): Promise<CheckOpensResult> => {
+  const resolvedInputFilePath = await resolveCheckInputFilePath(file)
+  const mode = parseMode(options.mode)
+  const layerOption = parseLayer(options.layer)
+  const pixelsPerMm = parsePixelsPerMm(options.pixelsPerMm)
+  const circuitJson = await getCircuitJsonForCheck({
+    filePath: resolvedInputFilePath,
+    platformConfig: {
+      pcbDisabled: false,
+      routingDisabled: false,
+    } satisfies PlatformConfig,
+    allowPrebuiltCircuitJson: true,
+  })
+  const layers = getCheckShortLayers({ circuitJson, layerOption })
+  const { findBitmapOpens } = await loadCheckShorts()
+
+  const opensPerLayer = await Promise.all(
+    layers.map((layer) =>
+      findBitmapOpens(circuitJson, {
+        mode,
+        layer,
+        pixelsPerMm,
+      } satisfies FindBitmapOpensOptions),
+    ),
+  )
+  const opens = opensPerLayer.flat()
+  const filename = resolvedInputFilePath.split("/").pop() ?? resolvedInputFilePath
+
+  if (opens.length === 0) {
+    return { output: `No opens detected in ${filename}`, opens }
+  }
+
+  return {
+    output: [
+      `Detected ${opens.length} open${opens.length === 1 ? "" : "s"} in ${filename}`,
+      ...opens.map(formatOpen),
+    ].join("\n"),
+    opens,
+  }
+}
+
+export const registerCheckOpens = (program: Command) => {
+  program.commands
+    .find((c) => c.name() === "check")!
+    .command("opens")
+    .description(
+      "Detect nets whose copper is not fully joined (unrouted connections)",
+    )
+    .argument("[file]", "Path to the entry file or prebuilt circuit JSON")
+    .option("--mode <mode>", "Bitmap source to analyze: pcb or gerber", "gerber")
+    .option("--layer <layer>", "Layer to analyze: top, bottom, or all", "all")
+    .option("--pixels-per-mm <number>", "Bitmap resolution for open detection")
+    .action(async (file?: string, options?: CheckOpensOptions) => {
+      try {
+        const result = await checkOpens(file, options)
+        console.log(result.output)
+        if (result.opens.length > 0) {
+          process.exit(1)
+        }
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exit(1)
+      }
+    })
+}

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -19,6 +19,7 @@ import { registerCheckPlacement } from "./check/placement/register"
 import { registerCheck } from "./check/register"
 import { registerCheckRoutingDifficulty } from "./check/routing-difficulty/register"
 import { registerCheckSchematicPlacement } from "./check/schematic-placement/register"
+import { registerCheckOpens } from "./check/opens/register"
 import { registerCheckShorts } from "./check/shorts/register"
 import { registerCheckSource } from "./check/source/register"
 import { registerCheckTraceLength } from "./check/trace-length/register"
@@ -90,6 +91,7 @@ registerCheckPlacement(program)
 registerCheckRoutingDifficulty(program)
 registerCheckSchematicPlacement(program)
 registerCheckShorts(program)
+registerCheckOpens(program)
 registerCheckSource(program)
 registerCheckTraceLength(program)
 

--- a/tests/cli/check/check-opens.test.ts
+++ b/tests/cli/check/check-opens.test.ts
@@ -1,8 +1,32 @@
 import { expect, test } from "bun:test"
+import { readFileSync, readdirSync } from "node:fs"
 import { symlink, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { fileURLToPath } from "node:url"
 import { checkOpens } from "../../../cli/check/opens/register"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+// ignoreNets shipped in @tscircuit/check-shorts after 0.0.19. Feature-detect
+// against the resolved package's typings (an unsupported option is silently
+// ignored at runtime, so a runtime probe can't tell) — the suppression test
+// activates once the pinned dependency is bumped.
+const checkShortsSupportsIgnoreNets = (() => {
+  try {
+    // The package exposes only an ESM "import" export, so resolve via ESM.
+    // index.d.ts is re-exports only, so scan every .d.ts beside the entry.
+    const entryPath = fileURLToPath(
+      import.meta.resolve("@tscircuit/check-shorts"),
+    )
+    const distDir = path.dirname(entryPath)
+    return readdirSync(distDir)
+      .filter((name) => name.endsWith(".d.ts"))
+      .some((name) =>
+        readFileSync(path.join(distDir, name), "utf8").includes("ignoreNets"),
+      )
+  } catch {
+    return false
+  }
+})()
 
 // The circuit is evaluated from the temp dir, so it needs the workspace's
 // node_modules to resolve react/tscircuit (same approach as check-shorts.test).
@@ -59,4 +83,76 @@ test("check opens reports nothing for a fully routed board", async () => {
 
   expect(result.opens).toHaveLength(0)
   expect(result.output).toContain("No opens detected")
+})
+
+// Two mounting holes on net.CHASSIS, joined by the metal enclosure rather than
+// board copper. The split is real on the copper, so it flags by default;
+// --ignore-net CHASSIS is the declared "joined off-board" escape hatch.
+const chassisCircuitCode = `
+export default () => (
+  <board width="30mm" height="30mm" routingDisabled>
+    <chip
+      name="H1"
+      footprint={
+        <footprint>
+          <platedhole portHints={["pin1"]} pcbX="0mm" pcbY="0mm" shape="circle" holeDiameter="3mm" outerDiameter="5mm" />
+        </footprint>
+      }
+      connections={{ pin1: "net.CHASSIS" }}
+    />
+    <chip
+      name="H2"
+      footprint={
+        <footprint>
+          <platedhole portHints={["pin1"]} pcbX="10mm" pcbY="10mm" shape="circle" holeDiameter="3mm" outerDiameter="5mm" />
+        </footprint>
+      }
+      connections={{ pin1: "net.CHASSIS" }}
+    />
+  </board>
+)
+`
+
+test("check opens flags an enclosure-joined net by default", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  await linkWorkspaceNodeModules(tmpDir)
+  const circuitPath = path.join(tmpDir, "chassis.circuit.tsx")
+  await writeFile(circuitPath, chassisCircuitCode)
+
+  const result = await checkOpens(circuitPath, { mode: "pcb" })
+
+  expect(result.opens.length).toBeGreaterThan(0)
+})
+
+test.skipIf(!checkShortsSupportsIgnoreNets)(
+  "check opens silences a net listed via --ignore-net",
+  async () => {
+    const { tmpDir } = await getCliTestFixture()
+    await linkWorkspaceNodeModules(tmpDir)
+    const circuitPath = path.join(tmpDir, "chassis-ignored.circuit.tsx")
+    await writeFile(circuitPath, chassisCircuitCode)
+
+    const result = await checkOpens(circuitPath, {
+      mode: "pcb",
+      ignoreNet: ["CHASSIS"],
+    })
+
+    expect(result.opens).toHaveLength(0)
+    expect(result.output).toContain("No opens detected")
+  },
+)
+
+test("--ignore-net for an unrelated net does not mask a real open", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  await linkWorkspaceNodeModules(tmpDir)
+  const circuitPath = path.join(tmpDir, "unrouted-ignored.circuit.tsx")
+  await writeFile(circuitPath, unroutedCircuitCode)
+
+  const result = await checkOpens(circuitPath, {
+    mode: "pcb",
+    layer: "top",
+    ignoreNet: ["CHASSIS"],
+  })
+
+  expect(result.opens.length).toBeGreaterThan(0)
 })

--- a/tests/cli/check/check-opens.test.ts
+++ b/tests/cli/check/check-opens.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { symlink, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { checkOpens } from "../../../cli/check/opens/register"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+// The circuit is evaluated from the temp dir, so it needs the workspace's
+// node_modules to resolve react/tscircuit (same approach as check-shorts.test).
+const linkWorkspaceNodeModules = async (tmpDir: string) => {
+  await symlink(
+    path.join(process.cwd(), "node_modules"),
+    path.join(tmpDir, "node_modules"),
+    "dir",
+  )
+}
+
+// routingDisabled leaves the trace declared but unrouted — no copper joins the
+// two pads. That is precisely the failure mode `check opens` exists to catch:
+// the build succeeds, no short exists, and the board is dead.
+const unroutedCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm" routingDisabled>
+    <resistor resistance="1k" footprint="0402" name="R1" pcbX={-2} pcbY={0} />
+    <capacitor capacitance="1000pF" footprint="0402" name="C1" pcbX={2} pcbY={0} />
+    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+  </board>
+)
+`
+
+const routedCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" pcbX={-2} pcbY={0} />
+    <capacitor capacitance="1000pF" footprint="0402" name="C1" pcbX={2} pcbY={0} />
+    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+  </board>
+)
+`
+
+test("check opens detects a net that was never routed", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  await linkWorkspaceNodeModules(tmpDir)
+  const circuitPath = path.join(tmpDir, "unrouted.circuit.tsx")
+  await writeFile(circuitPath, unroutedCircuitCode)
+
+  const result = await checkOpens(circuitPath, { mode: "pcb", layer: "top" })
+
+  expect(result.opens.length).toBeGreaterThan(0)
+  expect(result.output).toContain("Detected")
+})
+
+test("check opens reports nothing for a fully routed board", async () => {
+  const { tmpDir } = await getCliTestFixture()
+  await linkWorkspaceNodeModules(tmpDir)
+  const circuitPath = path.join(tmpDir, "routed.circuit.tsx")
+  await writeFile(circuitPath, routedCircuitCode)
+
+  const result = await checkOpens(circuitPath, { mode: "pcb", layer: "top" })
+
+  expect(result.opens).toHaveLength(0)
+  expect(result.output).toContain("No opens detected")
+})


### PR DESCRIPTION
> **Blocked on tscircuit/check-shorts#49.** This command calls
> `findBitmapOpens`, which that PR adds. `@tscircuit/check-shorts` is pinned
> here to a fixed tarball (`0.0.19`) and loaded from jscdn at runtime, so CI on
> this PR will fail to resolve the import until #49 lands and publishes. The
> code itself is complete: with that branch linked locally, typecheck and all
> five tests pass.

## Problem

`tsci check shorts` catches copper joined when it should not be. Nothing catches
the inverse — a connection that was declared but never routed. The build
succeeds, no short exists, and the board is dead.

That happened to me: a board shipped with two push-button ground legs unrouted,
and no part of the toolchain could have told me before I paid for it.

## Change

Adds `tsci check opens`, mirroring `check shorts`:

- same options: `--mode pcb|gerber`, `--layer top|bottom|all`, `--pixels-per-mm`
- `--ignore-net <name>` (repeatable) for nets joined off the board by design —
  mounting holes bonded through a metal enclosure, signals joined by a cable or
  mating connector. Circuit JSON cannot express "joined outside the board", so
  suppression is explicit and per net name; ignoring an unrelated net cannot
  mask a real open (covered by a test)
- same CDN-or-package loading (reuses `loadCheckShorts`)
- exits 1 when opens are found, so CI and pre-fab scripts can gate on it

```
$ tsci check opens
Detected 1 open in board.circuit.tsx
1. top/pcb net split across 2 copper islands
   SW1.pin4, R1.pin1
   island at x=6.250mm y=-2.500mm pixels=1840
   island at x=10.000mm y=-10.000mm pixels=612
```

One behavioural difference from `check shorts` worth flagging: opens are a
whole-board question. A net routed top -> via -> bottom is fully connected, but
examined one layer at a time it looks split on both. Running per layer reported
an open for essentially every routed net (41 false positives on a real two-layer
board; 0 after). So `--layer all` runs a single analysis spanning every copper
layer, while an explicit `--layer top|bottom` still scopes to that layer.

## False positives and scope — why this is a command, not a default gate

Before wiring this into the pipeline I probed the detector against hardware
that legitimately expects disjoint copper on one net; the full analysis and the
fixes it produced live in tscircuit/check-shorts#49. Summary:

- **Fixed at the detector**: pins joined inside a component body
  (`internallyConnectedPins` — switch poles, relay contacts) and bridged solder
  jumpers were real false positives; declared internal connections now bridge
  islands the way vias bridge layers. This also keeps the check compatible with
  tscircuit/core#3115 (emitting pushbutton internal connections), which would
  otherwise have made it flag every 4-leg tactile switch.
- **Handled here**: off-board joins via `--ignore-net`.
- **Not fixable in principle**: a same-net 0-ohm net tie and an unrouted MCU
  GND pin have the identical circuit-JSON signature — one is a design, the
  other is my dead board. Silencing one masks the other, so same-net
  two-terminal links remain a documented false positive (model as two nets, or
  `--ignore-net`). Prebuilt circuit JSON captured before external routing
  (FreeRouting-style workflows) also flags everything, truthfully but noisily.

Because of that residual set, `check opens` is an **explicitly-invoked
subcommand** — it is not added to any aggregate check, and it only exits
non-zero when the user runs it. Whether it should ever run by default, and at
what severity, is left as a maintainer decision with the analysis above as
input.

## Tests

`tests/cli/check/check-opens.test.ts` — an unrouted connection is reported; a
fully routed board reports nothing; an enclosure-joined net flags by default;
`--ignore-net` silences exactly that net (feature-detected against the resolved
check-shorts typings, activates when the pin is bumped past 0.0.19); ignoring
an unrelated net does not mask a real open.
