### PR TITLE
chore: update easyeda to 0.0.305

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "debug": "^4.4.0",
         "delay": "^6.0.0",
         "dsn-converter": "^0.0.90",
-        "easyeda": "^0.0.301",
+        "easyeda": "^0.0.305",
         "fuse.js": "^7.1.0",
         "get-port": "^7.1.0",
         "globby": "^14.1.0",
@@ -683,7 +683,7 @@
 
     "earcut": ["earcut@3.2.3", "", {}, "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q=="],
 
-    "easyeda": ["easyeda@0.0.301", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda": "dist/main.cjs", "easyeda-converter": "dist/main.cjs" } }, "sha512-O0dPOFJgmcYvYeBA6+6Fey9gaRe4VOVfeVh06F1whzCPQOZu+SQtEVW5X5QN014bL78b4VDtPyjXu6ldmfq6HA=="],
+    "easyeda": ["easyeda@0.0.305", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda": "dist/main.cjs", "easyeda-converter": "dist/main.cjs" } }, "sha512-ZwF3z+A2BkdZPKKznYasufwUeRFF3Tt6UP53LI9m4ER633XGBJyrbS220W3zSnOLjmqcpWCyNTlknU+5LY84Jw=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "debug": "^4.4.0",
     "delay": "^6.0.0",
     "dsn-converter": "^0.0.90",
-    "easyeda": "^0.0.301",
+    "easyeda": "^0.0.305",
     "fuse.js": "^7.1.0",
     "get-port": "^7.1.0",
     "globby": "^14.1.0",


### PR DESCRIPTION
## Summary

Update Runframe's `easyeda` dependency from `^0.0.301` to the latest published `^0.0.305`. This pulls in the converter improvements released in `0.0.302` through `0.0.305`.

## Included upstream changes

- `0.0.302`: adds regression coverage and a repro fixture for the oversized C8545 schematic symbol.
- `0.0.303`: supports additional EasyEDA payload variants, including numeric-string or blank LCSC/SZLCBSC prices, missing fill styles, and `AR`/`I` annotations that can be safely ignored instead of rejecting an otherwise usable payload.
- `0.0.304`: preserves standalone oval PCB holes when generating tscircuit footprint TSX.
- `0.0.305`: includes ports in imported passive symbols and aligns custom-symbol ports to drawing endpoints while preserving pin direction and stem length.

## Runframe changes

- Updated `package.json` to `easyeda@^0.0.305`.
- Refreshed `bun.lock` with the `0.0.305` package resolution and integrity hash.

## Impact

EasyEDA imports should handle more real-world payloads, retain oval-hole geometry, and produce more complete and correctly aligned passive-symbol schematics.
