### PR TITLE
fix: allow selecting inner layers in check shorts

### DIFF
--- a/cli/check/shorts/get-check-short-layers.ts
+++ b/cli/check/shorts/get-check-short-layers.ts
@@ -1,10 +1,19 @@
-import { all_layers, type AnyCircuitElement, type LayerRef } from "circuit-json"
+import type { AnyCircuitElement, LayerRef } from "circuit-json"
 
 export type CheckShortsLayerOption = LayerRef | "all"
 
-const innerCopperLayers = all_layers.filter((layer) =>
-  layer.startsWith("inner"),
-)
+type InnerLayerRef = Exclude<LayerRef, "top" | "bottom">
+
+const innerCopperLayers = [
+  "inner1",
+  "inner2",
+  "inner3",
+  "inner4",
+  "inner5",
+  "inner6",
+  "inner7",
+  "inner8",
+] satisfies InnerLayerRef[]
 
 export const getCheckShortLayers = ({
   circuitJson,

--- a/cli/check/shorts/get-check-short-layers.ts
+++ b/cli/check/shorts/get-check-short-layers.ts
@@ -17,11 +17,10 @@ export const getCheckShortLayers = ({
   const boardLayerCount =
     pcbBoard?.type === "pcb_board" ? pcbBoard.num_layers : 2
   const innerLayerCount = Math.max(0, Math.floor(boardLayerCount) - 2)
-  const availableLayers: LayerRef[] = [
-    "top",
-    ...innerCopperLayers.slice(0, innerLayerCount),
-    "bottom",
-  ]
+  const availableLayers: LayerRef[] =
+    boardLayerCount <= 1
+      ? ["top"]
+      : ["top", ...innerCopperLayers.slice(0, innerLayerCount), "bottom"]
 
   if (layerOption === "all") return availableLayers
 

--- a/cli/check/shorts/get-check-short-layers.ts
+++ b/cli/check/shorts/get-check-short-layers.ts
@@ -1,17 +1,10 @@
-import type { AnyCircuitElement, LayerRef } from "circuit-json"
+import { all_layers, type AnyCircuitElement, type LayerRef } from "circuit-json"
 
-export type CheckShortsLayerOption = "top" | "bottom" | "all"
+export type CheckShortsLayerOption = LayerRef | "all"
 
-const innerCopperLayers = [
-  "inner1",
-  "inner2",
-  "inner3",
-  "inner4",
-  "inner5",
-  "inner6",
-  "inner7",
-  "inner8",
-] satisfies LayerRef[]
+const innerCopperLayers = all_layers.filter((layer) =>
+  layer.startsWith("inner"),
+)
 
 export const getCheckShortLayers = ({
   circuitJson,
@@ -20,12 +13,23 @@ export const getCheckShortLayers = ({
   circuitJson: AnyCircuitElement[]
   layerOption: CheckShortsLayerOption
 }): LayerRef[] => {
-  if (layerOption !== "all") return [layerOption]
-
   const pcbBoard = circuitJson.find((element) => element.type === "pcb_board")
   const boardLayerCount =
     pcbBoard?.type === "pcb_board" ? pcbBoard.num_layers : 2
   const innerLayerCount = Math.max(0, Math.floor(boardLayerCount) - 2)
+  const availableLayers: LayerRef[] = [
+    "top",
+    ...innerCopperLayers.slice(0, innerLayerCount),
+    "bottom",
+  ]
 
-  return ["top", ...innerCopperLayers.slice(0, innerLayerCount), "bottom"]
+  if (layerOption === "all") return availableLayers
+
+  if (!availableLayers.includes(layerOption)) {
+    throw new Error(
+      `--layer ${layerOption} is not available on this ${boardLayerCount}-layer board; available layers: ${availableLayers.join(", ")}`,
+    )
+  }
+
+  return [layerOption]
 }

--- a/cli/check/shorts/register.ts
+++ b/cli/check/shorts/register.ts
@@ -5,6 +5,7 @@ import type {
   FindBitmapShortsOptions,
 } from "@tscircuit/check-shorts"
 import type { PlatformConfig } from "@tscircuit/props"
+import { all_layers, layer_string } from "circuit-json"
 import type { Command } from "commander"
 import { getCircuitJsonForCheck, resolveCheckInputFilePath } from "../shared"
 import {
@@ -82,10 +83,16 @@ const parseMode = (mode?: string): "pcb" | "gerber" => {
   throw new Error("--mode must be either pcb or gerber")
 }
 
+const checkShortsLayerNames = [...all_layers, "all"].join(", ")
+
 const parseLayer = (layer?: string): CheckShortsLayerOption => {
   if (!layer) return "all"
-  if (layer === "top" || layer === "bottom" || layer === "all") return layer
-  throw new Error("--layer must be top, bottom, or all")
+  if (layer === "all") return layer
+
+  const parsedLayer = layer_string.safeParse(layer)
+  if (parsedLayer.success) return parsedLayer.data
+
+  throw new Error(`--layer must be one of: ${checkShortsLayerNames}`)
 }
 
 const formatLabels = (labels: string[]) =>
@@ -187,7 +194,11 @@ export const registerCheckShorts = (program: Command) => {
       "Bitmap source to analyze: pcb or gerber",
       "gerber",
     )
-    .option("--layer <layer>", "Layer to analyze: top, bottom, or all", "all")
+    .option(
+      "--layer <layer>",
+      `Layer to analyze: ${checkShortsLayerNames}`,
+      "all",
+    )
     .option("--pixels-per-mm <number>", "Bitmap resolution for short detection")
     .action(async (file?: string, options?: CheckShortsOptions) => {
       try {

--- a/tests/cli/check/check-shorts.test.ts
+++ b/tests/cli/check/check-shorts.test.ts
@@ -291,6 +291,55 @@ test("check shorts --layer all detects an inner-layer short", async () => {
   }
 }, 20_000)
 
+test("check shorts can select an individual inner layer", async () => {
+  const { runCommand, tmpDir } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "individual-inner-layer-short.tsx")
+  const circuitJsonPath = path.join(
+    tmpDir,
+    "individual-inner-layer-short.circuit.json",
+  )
+
+  try {
+    await linkWorkspaceNodeModules(tmpDir)
+    await writeFile(circuitPath, emptyBoardCircuitCode)
+    const circuitJson =
+      await makeFourLayerCircuitJsonWithInnerShort(circuitPath)
+    await writeFile(circuitJsonPath, JSON.stringify(circuitJson, null, 2))
+
+    const selectedInnerLayer = await runCommand(
+      `tsci check shorts ${circuitJsonPath} --mode pcb --layer inner1`,
+    )
+
+    expect(selectedInnerLayer.exitCode).toBe(1)
+    expect(selectedInnerLayer.stderr).toBe("")
+    expect(selectedInnerLayer.stdout).toContain("Detected 1 short")
+    expect(selectedInnerLayer.stdout).toContain("inner1/pcb")
+
+    const unavailableInnerLayer = await runCommand(
+      `tsci check shorts ${circuitJsonPath} --mode pcb --layer inner3`,
+    )
+
+    expect(unavailableInnerLayer.exitCode).toBe(1)
+    expect(unavailableInnerLayer.stdout).not.toContain("Detected")
+    expect(unavailableInnerLayer.stderr).toContain(
+      "--layer inner3 is not available on this 4-layer board; available layers: top, inner1, inner2, bottom",
+    )
+
+    const invalidLayer = await runCommand(
+      `tsci check shorts ${circuitJsonPath} --mode pcb --layer copper1`,
+    )
+
+    expect(invalidLayer.exitCode).toBe(1)
+    expect(invalidLayer.stdout).not.toContain("Detected")
+    expect(invalidLayer.stderr).toContain(
+      "--layer must be one of: top, bottom, inner1, inner2, inner3, inner4, inner5, inner6, inner7, inner8, all",
+    )
+  } finally {
+    await rm(circuitPath, { force: true })
+    await rm(circuitJsonPath, { force: true })
+  }
+}, 30_000)
+
 test("check shorts routes a source board before analyzing it", async () => {
   const tmpDir = temporaryDirectory()
   const circuitPath = path.join(tmpDir, "routed-board.tsx")

--- a/tests/cli/check/check-shorts.test.ts
+++ b/tests/cli/check/check-shorts.test.ts
@@ -6,9 +6,10 @@ import {
   appendCopperBridgeTrace,
   createShortDebugSvg,
 } from "@tscircuit/check-shorts"
-import type { PcbTrace } from "circuit-json"
+import { pcb_board, type PcbTrace } from "circuit-json"
 import { temporaryDirectory } from "tempy"
 import { getCircuitJsonForCheck } from "../../../cli/check/shared"
+import { getCheckShortLayers } from "../../../cli/check/shorts/get-check-short-layers"
 import {
   CHECK_SHORTS_CDN_URL,
   checkShorts,
@@ -290,6 +291,26 @@ test("check shorts --layer all detects an inner-layer short", async () => {
     await rm(circuitJsonPath, { force: true })
   }
 }, 20_000)
+
+test("check shorts exposes only top on a one-layer board", () => {
+  const circuitJson = [
+    pcb_board.parse({
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_one_layer",
+      center: { x: 0, y: 0 },
+      num_layers: 1,
+    }),
+  ]
+
+  expect(getCheckShortLayers({ circuitJson, layerOption: "all" })).toEqual([
+    "top",
+  ])
+  expect(() =>
+    getCheckShortLayers({ circuitJson, layerOption: "bottom" }),
+  ).toThrow(
+    "--layer bottom is not available on this 1-layer board; available layers: top",
+  )
+})
 
 test("check shorts can select an individual inner layer", async () => {
   const { runCommand, tmpDir } = await getCliTestFixture()


### PR DESCRIPTION
## Summary

- use `circuit-json`'s `LayerRef`, `all_layers`, and `layer_string` as the canonical layer source
- allow `tsci check shorts --layer` to select inner copper layers individually
- validate selected layers against the physical layers derived from `pcb_board.num_layers`
- preserve `--layer all`, including top-only behavior for one-layer boards
- add regression coverage for valid, unavailable, invalid, and one-layer selections

## Root cause

The shorts checker already accepts `LayerRef` values, but the CLI parser was hard-coded to `top`, `bottom`, and `all`. This caused `--layer inner1` to fail before the circuit was loaded or analyzed.

## Impact

Users can request layer-specific short evidence for canonical inner layers that exist on the board. Syntactically valid layers that are not physically present now fail with an available-layers message.

## Validation

- `bun test tests/cli/check/check-shorts.test.ts` — 8 pass
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
