### PR TITLE
Update easyeda to 0.0.315

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "debug": "^4.4.0",
         "delay": "^6.0.0",
         "dsn-converter": "^0.0.90",
-        "easyeda": "^0.0.307",
+        "easyeda": "^0.0.315",
         "fuse.js": "^7.1.0",
         "get-port": "^7.1.0",
         "globby": "^14.1.0",
@@ -683,7 +683,7 @@
 
     "earcut": ["earcut@3.2.3", "", {}, "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q=="],
 
-    "easyeda": ["easyeda@0.0.307", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-4jmSN2hTghI1357Qq3EbTC7V/w4lx9S02kbfYb5ocLGbP67synkeT3rw7y/eFmp27FvuRtUMEh2uLEDgFKHtpw=="],
+    "easyeda": ["easyeda@0.0.315", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-Vm1VTbTrsK+5/WPaHmMsZuLkqkTXQejJLtmx8RoE1TZwanD2NMjh23tOCsihCec/hJOpJNZ03MnSZvsa0aWqSA=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "debug": "^4.4.0",
     "delay": "^6.0.0",
     "dsn-converter": "^0.0.90",
-    "easyeda": "^0.0.307",
+    "easyeda": "^0.0.315",
     "fuse.js": "^7.1.0",
     "get-port": "^7.1.0",
     "globby": "^14.1.0",


### PR DESCRIPTION
## Summary

- update the `easyeda` dev dependency from `^0.0.307` to `^0.0.315`
- refresh the Bun lockfile to resolve `easyeda@0.0.315`

## Why

This brings the CLI's bundled EasyEDA conversion dependency up to the latest published version, so CLI builds include the current converter implementation.

## Validation

- `bun install --frozen-lockfile`
- `bun run format:check`
- `bun run build`
- `git diff --check`