### PR TITLE
Migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -7,6 +7,11 @@ on:
       - '!version-bumps/**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 env:
   UPSTREAM_REPOS: "tscircuit" # for example: "eval"
   PACKAGE_NAMES: "@tscircuit/cli" # comma-separated list, e.g. "@tscircuit/core,@tscircuit/props"
@@ -20,16 +25,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release --no-push-main
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
             
       - name: Get package version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@tscircuit/cli",
   "version": "0.1.1958",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/cli"
+  },
   "main": "dist/cli/main.js",
   "exports": {
     ".": "./dist/cli/main.js",


### PR DESCRIPTION
## Summary
- use npm trusted publishing with GitHub Actions OIDC instead of a long-lived NPM_TOKEN
- grant id-token: write and run Node 24 with npm 11+ support
- declare an explicit GitHub repository URL in package metadata where needed

## Required npm configuration
Before merge, the npm package must trust:
- GitHub repository: tscircuit/cli
- Workflow: bun-pver-release.yml
- Allowed action: npm publish

## Validation
- package.json parsed successfully
- release workflow parsed successfully
- git diff --check