### PR TITLE
Preserve courtyards during footprint compaction

### DIFF
--- a/cli/import/log-footprint-conversion.ts
+++ b/cli/import/log-footprint-conversion.ts
@@ -30,6 +30,15 @@ export const logFootprintConversion = (conversion: FootprintConversion) => {
     return
   }
 
+  if (conversion.mode === "exact-courtyard-loss") {
+    console.log(
+      kleur.yellow(
+        "Using the exact EasyEDA footprint because the compact footprinter result has no courtyard.",
+      ),
+    )
+    return
+  }
+
   if (conversion.mode === "exact-discovery-failed") {
     console.log(
       kleur.yellow(

--- a/lib/import/footprinter/convert-imported-footprint-to-footprinter.ts
+++ b/lib/import/footprinter/convert-imported-footprint-to-footprinter.ts
@@ -9,10 +9,25 @@ import { replaceExactFootprint } from "./replace-exact-footprint"
 
 export const DEFAULT_FOOTPRINTER_ACCURACY_THRESHOLD = 0.98
 
+const COURTYARD_ELEMENT_TYPES = new Set([
+  "pcb_courtyard_rect",
+  "pcb_courtyard_circle",
+  "pcb_courtyard_outline",
+  "pcb_courtyard_pill",
+  "pcb_courtyard_polygon",
+])
+
+const hasCourtyard = (circuitJson: readonly AnyCircuitElement[]): boolean =>
+  circuitJson.some((element) => COURTYARD_ELEMENT_TYPES.has(element.type))
+
 export interface ImportedFootprintConversion {
   accuracy?: number
   candidate?: FootprinterDiscoveryCandidate
-  mode: "exact-discovery-failed" | "exact-low-accuracy" | "footprinter"
+  mode:
+    | "exact-courtyard-loss"
+    | "exact-discovery-failed"
+    | "exact-low-accuracy"
+    | "footprinter"
   tsx: string
 }
 
@@ -47,6 +62,14 @@ export const convertImportedFootprintToFootprinter = ({
     const footprinterCircuitJson = fp
       .string(candidate.footprinterString)
       .circuitJson() as AnyCircuitElement[]
+    if (hasCourtyard(circuitJson) && !hasCourtyard(footprinterCircuitJson)) {
+      return {
+        accuracy: candidate.copperIntersectionOverUnion,
+        candidate,
+        mode: "exact-courtyard-loss",
+        tsx,
+      }
+    }
     const pinMap = getFootprinterToTargetPinMap(
       circuitJson,
       footprinterCircuitJson,

--- a/tests/lib/import/convert-imported-footprint-to-footprinter.test.ts
+++ b/tests/lib/import/convert-imported-footprint-to-footprinter.test.ts
@@ -113,3 +113,29 @@ test("keeps the exact footprint when copper IoU is at or below 98%", () => {
   expect(result.accuracy).toBeLessThanOrEqual(0.98)
   expect(result.tsx).toBe(exactTsx)
 })
+
+test("keeps the exact footprint when compaction would remove its courtyard", () => {
+  const circuitJson = fp
+    .string("res_p1.3mm_pw0.55mm_ph0.7mm")
+    .circuitJson() as AnyCircuitElement[]
+  circuitJson.push({
+    type: "pcb_courtyard_rect",
+    pcb_courtyard_rect_id: "pcb_courtyard_rect_1",
+    pcb_component_id: "pcb_component_1",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 1,
+    layer: "top",
+  })
+  const exactTsx =
+    "<chip footprint={<footprint><smtpad /><courtyardrect /></footprint>} />"
+
+  const result = convertImportedFootprintToFootprinter({
+    circuitJson,
+    tsx: exactTsx,
+  })
+
+  expect(result.mode).toBe("exact-courtyard-loss")
+  expect(result.accuracy).toBeGreaterThan(0.98)
+  expect(result.tsx).toBe(exactTsx)
+})


### PR DESCRIPTION
## Summary

- detect when a compact footprinter candidate would remove courtyard geometry from an imported EasyEDA footprint
- keep the exact imported footprint in that case
- explain the preservation decision in CLI output

## Tests

- `bun test tests/lib/import/convert-imported-footprint-to-footprinter.test.ts`
- `bunx tsc --noEmit`
- `bun run build`