### PR TITLE
Reproduce build succeeding with DRC errors

### DIFF
--- a/tests/cli/build/build-with-drc-error.test.ts
+++ b/tests/cli/build/build-with-drc-error.test.ts
@@ -10,13 +10,14 @@ export default () => (
   </board>
 )`
 
-test("build succeeds when circuit JSON is generated with DRC errors", async () => {
+test("default build and --ignore-errors both exit zero for DRC errors", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   await writeFile(path.join(tmpDir, "test.circuit.tsx"), validCircuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
-  const { exitCode, stdout } = await runCommand("tsci build")
+  const defaultBuild = await runCommand("tsci build")
+  const ignoredBuild = await runCommand("tsci build --ignore-errors")
 
   const circuitJsonPath = path.join(tmpDir, "dist", "test", "circuit.json")
   const circuitJson = await readFile(circuitJsonPath, "utf-8")
@@ -28,6 +29,7 @@ test("build succeeds when circuit JSON is generated with DRC errors", async () =
     "Component R1 extends outside board boundaries",
   )
 
-  expect(exitCode).toBe(0)
-  expect(stdout).toContain("Build completed with errors")
+  expect(defaultBuild.exitCode).toBe(0)
+  expect(defaultBuild.stdout).toContain("Build completed with errors")
+  expect(ignoredBuild.exitCode).toBe(0)
 }, 30_000)


### PR DESCRIPTION
## Problem

`tsci build` writes Circuit JSON containing DRC errors, prints `Build completed with errors`, and still exits with status 0. A fabrication or CI script therefore cannot distinguish a clean build from a board with reported errors.

## Reproduction

The focused CLI test builds a real board with a resistor outside the board boundary. It verifies that the generated Circuit JSON contains the corresponding `pcb_component_outside_board_error` and records the current contradiction:

- the default command prints `Build completed with errors`
- the default command exits 0
- `--ignore-errors` also exits 0

The reproduction changes no CLI implementation.

## Expected behavior

The default command should exit nonzero when unignored DRC errors are present. `--ignore-errors` should remain the explicit opt-in for a successful exit.

## Verification

- `bun test tests/cli/build/build-with-drc-error.test.ts`
- `bun run format:check`

The fix will be proposed as a separate PR stacked on this branch.
