### PR TITLE
Fail builds with unignored circuit errors

### DIFF
--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -1036,8 +1036,10 @@ export const registerBuild = (program: Command) => {
           }
         }
 
-        // Fatal errors (e.g., circuit generation exceptions) always cause exit code 1.
-        const shouldExitNonZero = hasFatalErrors
+        // Fatal generation failures and unignored Circuit JSON errors both
+        // make the default build unsuccessful. `--ignore-errors` keeps
+        // `hasErrors` false and remains the explicit opt-in to exit zero.
+        const shouldExitNonZero = hasFatalErrors || hasErrors
 
         const successCount = builtFiles.filter((f) => f.ok).length
         const failCount = builtFiles.length - successCount
@@ -1122,7 +1124,12 @@ export const registerBuild = (program: Command) => {
             : kleur.green("\n✓ Done"),
         )
         if (shouldExitNonZero) {
-          exitBuild(1, "fatal circuit build errors occurred")
+          exitBuild(
+            1,
+            hasFatalErrors
+              ? "fatal circuit build errors occurred"
+              : "unignored circuit errors occurred",
+          )
         }
 
         exitBuild(0, "build finished successfully")

--- a/tests/cli/build/build-ignore-drc-categories.test.ts
+++ b/tests/cli/build/build-ignore-drc-categories.test.ts
@@ -51,15 +51,14 @@ test("build reports ignored counts when selected DRC categories are filtered", a
     "tsci build board.circuit.json --ignore-placement-drc --ignore-routing-drc",
   )
 
-  expect(exitCode).toBe(0)
+  expect(exitCode).toBe(1)
   expect(getBuildSummarySnippet(stdout)).toMatchInlineSnapshot(`
 "Build complete
   Circuits  1 passed
   Options   ignore-placement-drc, ignore-routing-drc
   Output    dist
   Ignored DRC 2 (placement: 1, routing: 1)
-⚠ Build completed with errors
-Build exiting with code 0: build finished successfully"
+⚠ Build completed with errors"
 `)
 }, 30_000)
 

--- a/tests/cli/build/build-with-drc-error.test.ts
+++ b/tests/cli/build/build-with-drc-error.test.ts
@@ -10,7 +10,7 @@ export default () => (
   </board>
 )`
 
-test("default build and --ignore-errors both exit zero for DRC errors", async () => {
+test("build exits nonzero for DRC errors unless explicitly ignored", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   await writeFile(path.join(tmpDir, "test.circuit.tsx"), validCircuitCode)
@@ -29,7 +29,7 @@ test("default build and --ignore-errors both exit zero for DRC errors", async ()
     "Component R1 extends outside board boundaries",
   )
 
-  expect(defaultBuild.exitCode).toBe(0)
+  expect(defaultBuild.exitCode).toBe(1)
   expect(defaultBuild.stdout).toContain("Build completed with errors")
   expect(ignoredBuild.exitCode).toBe(0)
 }, 30_000)


### PR DESCRIPTION
## Stack

Review and merge the reproduction first: https://github.com/tscircuit/cli/pull/4389

This branch is based directly on the reproduction branch, so the PR diff contains only the behavior change and corrected expectations.

## Fix

- exit with status 1 when Circuit JSON contains unignored errors
- retain status 1 for fatal generation failures
- retain status 0 when `--ignore-errors` explicitly suppresses the errors
- retain category-specific ignore behavior: a build only succeeds when every remaining error category is ignored
- report whether the nonzero exit came from a fatal generation failure or unignored circuit errors

## Observable result

| Command | Reproduction | Fix |
| --- | ---: | ---: |
| `tsci build` with DRC errors | 0 | 1 |
| `tsci build --ignore-errors` | 0 | 0 |

## Verification

- `bun test tests/cli/build/build-with-drc-error.test.ts tests/cli/build/build-ignore-drc-categories.test.ts tests/cli/build/build-fail-fast.test.ts`
- `bun run format:check`
- `bun run build`
