### PR TITLE
Reproduce default build discovering work circuits

### DIFF
--- a/tests/cli/build/build-default-entrypoint-discovery.test.ts
+++ b/tests/cli/build/build-default-entrypoint-discovery.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import { getBuildEntrypoints } from "cli/build/get-build-entrypoints"
+import { temporaryDirectory } from "tempy"
+
+test("default build discovers work circuits alongside the main entrypoint", async () => {
+  const projectDir = temporaryDirectory()
+  fs.mkdirSync(path.join(projectDir, "work"), { recursive: true })
+  fs.writeFileSync(path.join(projectDir, "package.json"), "{}")
+  fs.writeFileSync(
+    path.join(projectDir, "index.circuit.tsx"),
+    "export default () => <board />",
+  )
+  fs.writeFileSync(
+    path.join(projectDir, "work", "diagnostic.circuit.tsx"),
+    "export default () => <board />",
+  )
+
+  const result = await getBuildEntrypoints({ rootDir: projectDir })
+  const relativeCircuitFiles = result.circuitFiles.map((filePath) =>
+    path.relative(projectDir, filePath).split(path.sep).join("/"),
+  )
+
+  expect(result.mainEntrypoint).toBeUndefined()
+  expect(relativeCircuitFiles).toEqual([
+    "index.circuit.tsx",
+    "work/diagnostic.circuit.tsx",
+  ])
+})


### PR DESCRIPTION
## Problem

Running `tsci build` without a file argument scans every default board pattern before considering the detected main entrypoint. A project with `index.circuit.tsx` therefore also builds temporary diagnostic circuits under `work/`, expanding build time and producing unintended outputs.

## Reproduction

The focused unit reproduction creates a project containing:

- `index.circuit.tsx`, the conventional main entrypoint
- `work/diagnostic.circuit.tsx`, an iterative diagnostic circuit

With no `includeBoardFiles` configuration and no explicit file/directory argument, `getBuildEntrypoints` currently returns both files and does not identify the main entrypoint.

The reproduction changes no CLI implementation.

## Expected behavior

A no-argument build should use the conventional/configured main entrypoint when one exists. Multi-board discovery remains available through `includeBoardFiles` or an explicit directory argument.

## Verification

- `bun test tests/cli/build/build-default-entrypoint-discovery.test.ts`
- `bun run format:check`

The fix will be proposed as a separate PR stacked on this branch.
