### PR TITLE
Exclude work directories from default builds

### DIFF
--- a/cli/build/get-build-entrypoints.ts
+++ b/cli/build/get-build-entrypoints.ts
@@ -6,6 +6,7 @@ import {
 } from "lib/project-config"
 import { findBoardFilesAsync } from "lib/shared/find-board-files"
 import { getEntrypoint } from "lib/shared/get-entrypoint"
+import { DEFAULT_IGNORED_PATTERNS } from "lib/shared/should-ignore-path"
 
 export class BuildNoMatchingFilesError extends Error {
   readonly directoryPath: string
@@ -97,7 +98,12 @@ export async function getBuildEntrypoints({
         : undefined
 
     if (includeBoardFiles) {
-      const files = await findBoardFilesAsync({ projectDir: resolvedRoot })
+      const files = await findBoardFilesAsync({
+        projectDir: resolvedRoot,
+        ignore: hasConfiguredIncludeBoardFiles
+          ? DEFAULT_IGNORED_PATTERNS
+          : [...DEFAULT_IGNORED_PATTERNS, "**/work/**"],
+      })
 
       if (files.length > 0) {
         return {

--- a/tests/cli/build/build-default-entrypoint-discovery.test.ts
+++ b/tests/cli/build/build-default-entrypoint-discovery.test.ts
@@ -4,12 +4,16 @@ import path from "node:path"
 import { getBuildEntrypoints } from "cli/build/get-build-entrypoints"
 import { temporaryDirectory } from "tempy"
 
-test("default build discovers work circuits alongside the main entrypoint", async () => {
+test("default build excludes work circuits while retaining project circuits", async () => {
   const projectDir = temporaryDirectory()
   fs.mkdirSync(path.join(projectDir, "work"), { recursive: true })
   fs.writeFileSync(path.join(projectDir, "package.json"), "{}")
   fs.writeFileSync(
     path.join(projectDir, "index.circuit.tsx"),
+    "export default () => <board />",
+  )
+  fs.writeFileSync(
+    path.join(projectDir, "diagnostic.circuit.tsx"),
     "export default () => <board />",
   )
   fs.writeFileSync(
@@ -24,7 +28,29 @@ test("default build discovers work circuits alongside the main entrypoint", asyn
 
   expect(result.mainEntrypoint).toBeUndefined()
   expect(relativeCircuitFiles).toEqual([
+    "diagnostic.circuit.tsx",
     "index.circuit.tsx",
-    "work/diagnostic.circuit.tsx",
   ])
+})
+
+test("configured includeBoardFiles can explicitly include work circuits", async () => {
+  const projectDir = temporaryDirectory()
+  fs.mkdirSync(path.join(projectDir, "work"), { recursive: true })
+  fs.writeFileSync(path.join(projectDir, "package.json"), "{}")
+  fs.writeFileSync(
+    path.join(projectDir, "work", "diagnostic.circuit.tsx"),
+    "export default () => <board />",
+  )
+  fs.writeFileSync(
+    path.join(projectDir, "tscircuit.config.json"),
+    JSON.stringify({ includeBoardFiles: ["work/**/*.circuit.tsx"] }),
+  )
+
+  const result = await getBuildEntrypoints({ rootDir: projectDir })
+
+  expect(
+    result.circuitFiles.map((filePath) =>
+      path.relative(projectDir, filePath).split(path.sep).join("/"),
+    ),
+  ).toEqual(["work/diagnostic.circuit.tsx"])
 })


### PR DESCRIPTION
## Summary

- exclude work directories from the default board-file discovery globs
- preserve the established multi-board build behavior for normal circuit and board files
- preserve explicit includeBoardFiles patterns, including an explicit work glob

## Reproduction

Stacked on #4391, whose focused test shows the default build incorrectly discovering work/diagnostic.circuit.tsx.

## Validation

- focused reproduction and explicit-config tests pass
- established multi-file build tests pass
- concurrency and configured preview build tests pass
- 17 focused build tests pass
- formatting, TypeScript, and diff checks pass