### PR TITLE
Reproduce stale circuit JSON after a failed rebuild

### DIFF
--- a/tests/cli/build/build-failed-rebuild-stale-output.test.ts
+++ b/tests/cli/build/build-failed-rebuild-stale-output.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const validCircuitCode = `
+export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" />
+  </board>
+)
+`
+
+const failingCircuitCode = `
+export default () => {
+  throw new Error("intentional failed rebuild")
+}
+`
+
+test("failed rebuild leaves the previous circuit JSON in dist", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const circuitPath = path.join(tmpDir, "index.tsx")
+  const outputPath = path.join(tmpDir, "dist", "index", "circuit.json")
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(circuitPath, validCircuitCode)
+
+  const firstBuild = await runCommand("tsci build index.tsx")
+  expect(firstBuild.exitCode).toBe(0)
+  const previousCircuitJson = await readFile(outputPath, "utf8")
+
+  await writeFile(circuitPath, failingCircuitCode)
+  const failedRebuild = await runCommand("tsci build index.tsx")
+
+  expect(failedRebuild.exitCode).toBe(1)
+  expect(failedRebuild.stderr).toContain("intentional failed rebuild")
+  expect(await readFile(outputPath, "utf8")).toBe(previousCircuitJson)
+})


### PR DESCRIPTION
## Reproduction

This adds a focused integration test that:

1. successfully builds `index.tsx` and saves `dist/index/circuit.json`
2. replaces the same source file with a component that throws during circuit generation
3. runs the same build again and confirms the command exits with a fatal error
4. records that the previous `circuit.json` is still present byte-for-byte

The stale artifact can therefore look like the failed source revision built successfully to downstream fabrication or inspection tooling.

## Expected behavior

A failed rebuild must not leave the prior `circuit.json` at the output path for that entrypoint.

## Actual behavior

The fatal build exits 1, but `dist/index/circuit.json` still contains the previous successful build.

## Test

- `bun test tests/cli/build/build-failed-rebuild-stale-output.test.ts`
- `bun run format:check`

This is the reproduction PR. The fix is intentionally kept in the next PR in the stack.
