### PR TITLE
Remove stale circuit JSON before rebuilding

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -41,6 +41,10 @@ export const buildFile = async (
   try {
     console.log("Generating circuit JSON...")
 
+    if (path.resolve(input) !== path.resolve(output)) {
+      fs.rmSync(output, { force: true })
+    }
+
     const normalizedInputPath = input.toLowerCase().replaceAll("\\", "/")
     const isPrebuiltCircuitJson =
       normalizedInputPath.endsWith(".circuit.json") ||

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -45,6 +45,10 @@ export const handleBuildFile = async (
   try {
     process.chdir(projectDir)
 
+    if (path.resolve(filePath) !== path.resolve(outputPath)) {
+      fs.rmSync(outputPath, { force: true })
+    }
+
     workerLog(
       `Generating circuit JSON for ${path.relative(projectDir, filePath)}...`,
     )

--- a/tests/cli/build/build-failed-rebuild-stale-output.test.ts
+++ b/tests/cli/build/build-failed-rebuild-stale-output.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { readFile, writeFile } from "node:fs/promises"
+import { stat, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
@@ -17,7 +17,7 @@ export default () => {
 }
 `
 
-test("failed rebuild leaves the previous circuit JSON in dist", async () => {
+test("failed rebuild removes the previous circuit JSON", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "index.tsx")
   const outputPath = path.join(tmpDir, "dist", "index", "circuit.json")
@@ -26,12 +26,12 @@ test("failed rebuild leaves the previous circuit JSON in dist", async () => {
 
   const firstBuild = await runCommand("tsci build index.tsx")
   expect(firstBuild.exitCode).toBe(0)
-  const previousCircuitJson = await readFile(outputPath, "utf8")
+  expect((await stat(outputPath)).isFile()).toBe(true)
 
   await writeFile(circuitPath, failingCircuitCode)
   const failedRebuild = await runCommand("tsci build index.tsx")
 
   expect(failedRebuild.exitCode).toBe(1)
   expect(failedRebuild.stderr).toContain("intentional failed rebuild")
-  expect(await readFile(outputPath, "utf8")).toBe(previousCircuitJson)
-})
+  await expect(stat(outputPath)).rejects.toMatchObject({ code: "ENOENT" })
+}, 30_000)


### PR DESCRIPTION
## Summary

- remove an entrypoint's existing `circuit.json` before circuit generation starts
- apply the same behavior to sequential builds and concurrent worker builds
- preserve the source when a prebuilt Circuit JSON path is also the output path
- turn the reproduction into a regression test that requires the stale artifact to be absent after a fatal rebuild

## Stack

- Reproduction: #4394
- Fix: this PR

This branch is based directly on the reproduction branch so GitHub can show the stack.

## Tests

- `bun test tests/cli/build/build-failed-rebuild-stale-output.test.ts`
- `bun run format:check`
- `bun run build`
