### PR TITLE
Fix concurrent builds in Bun workers

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -61,6 +61,7 @@ export const buildFile = async (
     if (!isPrebuiltCircuitJson) {
       const result = await generateCircuitJson({
         filePath: input,
+        projectDir,
         platformConfig: platformConfigWithCliDefaults,
         injectedProps: options?.injectedProps,
         autorouterDiagnostics: options?.autorouterDiagnostics,

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -43,13 +43,11 @@ export const handleBuildFile = async (
   const startedAt = options?.profile ? performance.now() : 0
 
   try {
-    process.chdir(projectDir)
-
     workerLog(
       `Generating circuit JSON for ${path.relative(projectDir, filePath)}...`,
     )
 
-    await registerStaticAssetLoaders()
+    await registerStaticAssetLoaders(undefined, projectDir)
 
     const projectConfig = await loadRuntimeProjectConfig(projectDir)
     const platformConfig = mergePlatformConfigs(
@@ -71,6 +69,7 @@ export const handleBuildFile = async (
       : (
           await generateCircuitJson({
             filePath,
+            projectDir,
             platformConfig: platformConfigWithCliDefaults,
             injectedProps: options?.injectedProps,
             autorouterDiagnostics: options?.autorouterDiagnostics

--- a/cli/snapshot/worker-snapshot-handlers.ts
+++ b/cli/snapshot/worker-snapshot-handlers.ts
@@ -28,8 +28,7 @@ export const handleSnapshotFile = async (
   snapshotsDirName: string | undefined,
   options: SnapshotWorkerOptions,
 ): Promise<SnapshotCompletedMessage> => {
-  process.chdir(projectDir)
-  await registerStaticAssetLoaders()
+  await registerStaticAssetLoaders(undefined, projectDir)
   const projectConfig = await loadRuntimeProjectConfig(projectDir)
   const platformConfig = mergePlatformConfigs(
     projectConfig?.platformConfig,

--- a/lib/shared/generate-circuit-json.tsx
+++ b/lib/shared/generate-circuit-json.tsx
@@ -40,6 +40,7 @@ const ALLOWED_FILE_EXTENSIONS = [
 
 type GenerateCircuitJsonOptions = {
   filePath: string
+  projectDir?: string
   outputDir?: string
   outputFileName?: string
   saveToFile?: boolean
@@ -59,6 +60,7 @@ type GenerateCircuitJsonOptions = {
  */
 export async function generateCircuitJson({
   filePath,
+  projectDir: projectDirOption,
   outputDir,
   outputFileName,
   saveToFile = false,
@@ -75,10 +77,14 @@ export async function generateCircuitJson({
     sourceFilesystemMd5Hash ?? getSourceFilesystemMd5Hash(filePath)
 
   // Import React and make it globally available for packages referencing it
-  const React = await importFromUserLand("react")
+  const projectRootDir = path.resolve(projectDirOption ?? process.cwd())
+  const React = await importFromUserLand("react", projectRootDir)
   ;(globalThis as any).React = React
-  registerStaticAssetLoaders(platformConfig)
-  const userLandTscircuit = await importFromUserLand("tscircuit")
+  registerStaticAssetLoaders(platformConfig, projectRootDir)
+  const userLandTscircuit = await importFromUserLand(
+    "tscircuit",
+    projectRootDir,
+  )
 
   const runner = new userLandTscircuit.RootCircuit({
     platform: platformConfig,
@@ -93,12 +99,12 @@ export async function generateCircuitJson({
   solverDiagnostics?.attachToRootCircuit(runner)
   const absoluteFilePath = path.isAbsolute(filePath)
     ? filePath
-    : path.resolve(process.cwd(), filePath)
-  const projectDir = path.dirname(absoluteFilePath)
-  const resolvedOutputDir = outputDir ?? projectDir
+    : path.resolve(projectRootDir, filePath)
+  const sourceDir = path.dirname(absoluteFilePath)
+  const resolvedOutputDir = outputDir ?? sourceDir
 
   // Get the relative path to the component from the project directory
-  const relativeComponentPath = path.relative(projectDir, absoluteFilePath)
+  const relativeComponentPath = path.relative(sourceDir, absoluteFilePath)
 
   // Create a default output filename if not provided
   const baseFileName =
@@ -108,14 +114,14 @@ export async function generateCircuitJson({
     `${baseFileName}.circuit.json`,
   )
 
-  debug(`Project directory: ${projectDir}`)
+  debug(`Project directory: ${sourceDir}`)
   debug(`Relative component path: ${relativeComponentPath}`)
   debug(`Output path: ${outputPath}`)
 
   // Create a virtual file system with the project files
   const fsMap = {
     ...((await getVirtualFileSystemFromDirPath({
-      dirPath: projectDir,
+      dirPath: sourceDir,
       fileMatchFn: (filePath) => {
         const normalizedFilePath = filePath.replace(/\\/g, "/")
 

--- a/lib/shared/get-platform-config-with-cli-defaults.ts
+++ b/lib/shared/get-platform-config-with-cli-defaults.ts
@@ -51,10 +51,9 @@ export function getPlatformConfigWithCliDefaults(
   userConfig?: PlatformConfig,
   options?: { projectDir?: string },
 ): PlatformConfig {
+  const projectDir = options?.projectDir ?? process.cwd()
   const basePlatformConfig = getPlatformConfig()
-  const cacheDir = options?.projectDir
-    ? path.join(options.projectDir, ".tscircuit", "cache")
-    : undefined
+  const cacheDir = path.join(projectDir, ".tscircuit", "cache")
 
   const defaultConfig: PlatformConfig = {
     ...basePlatformConfig,
@@ -68,7 +67,7 @@ export function getPlatformConfigWithCliDefaults(
           let fetchUrl = url
           if (url.startsWith("./") || url.startsWith("../")) {
             // Relative path - resolve to absolute first
-            const absolutePath = path.resolve(process.cwd(), url)
+            const absolutePath = path.resolve(projectDir, url)
             fetchUrl = `file://${absolutePath}`
           } else if (url.startsWith("/")) {
             // Absolute path - check if it exists, otherwise try resolving as relative
@@ -77,7 +76,7 @@ export function getPlatformConfigWithCliDefaults(
             } else {
               // Try treating it as a relative path (strip leading / and resolve from cwd)
               const relativePath = `.${url}`
-              const absolutePath = path.resolve(process.cwd(), relativePath)
+              const absolutePath = path.resolve(projectDir, relativePath)
               if (fs.existsSync(absolutePath)) {
                 fetchUrl = `file://${absolutePath}`
               } else {

--- a/lib/shared/importFromUserLand.ts
+++ b/lib/shared/importFromUserLand.ts
@@ -2,12 +2,15 @@ import { createRequire } from "node:module"
 import fs from "node:fs"
 import path, { relative, resolve } from "node:path"
 
-export async function importFromUserLand(moduleName: string) {
+export async function importFromUserLand(
+  moduleName: string,
+  projectDir = process.cwd(),
+) {
   // First try to resolve relative to the user's project without triggering
   // Bun's auto-install (which can pull in inconsistent dependency versions)
-  const userModulePath = path.join(process.cwd(), "node_modules", moduleName)
+  const userModulePath = path.join(projectDir, "node_modules", moduleName)
   if (fs.existsSync(userModulePath)) {
-    const userRequire = createRequire(path.join(process.cwd(), "noop.js"))
+    const userRequire = createRequire(path.join(projectDir, "noop.js"))
     try {
       const resolvedUserPath = userRequire.resolve(moduleName)
       return await import(resolvedUserPath)

--- a/lib/shared/process-snapshot-file.ts
+++ b/lib/shared/process-snapshot-file.ts
@@ -83,6 +83,7 @@ export const processSnapshotFile = async ({
 
       const result = await getOrGenerateCircuitJson({
         filePath: file,
+        projectDir,
         platformConfig: platformConfigWithCliDefaults,
       })
       circuitJson = result.circuitJson

--- a/lib/shared/register-static-asset-loaders.ts
+++ b/lib/shared/register-static-asset-loaders.ts
@@ -76,8 +76,8 @@ const normalizeStaticFileLoaderResult = (result: any) => {
  * Finds and reads the tsconfig.json file, returning the baseUrl if configured.
  * Returns null if no tsconfig.json is found or no baseUrl is set.
  */
-const getBaseUrlFromTsConfig = (): string | null => {
-  const tsconfigPath = path.join(process.cwd(), "tsconfig.json")
+const getBaseUrlFromTsConfig = (projectDir: string): string | null => {
+  const tsconfigPath = path.join(projectDir, "tsconfig.json")
 
   try {
     if (!fs.existsSync(tsconfigPath)) {
@@ -97,14 +97,17 @@ const getBaseUrlFromTsConfig = (): string | null => {
   return null
 }
 
-export const registerStaticAssetLoaders = (platformConfig?: PlatformConfig) => {
+export const registerStaticAssetLoaders = (
+  platformConfig?: PlatformConfig,
+  projectDir = process.cwd(),
+) => {
   activePlatformConfig = platformConfig
 
   if (registered) return
   registered = true
 
   if (typeof Bun !== "undefined" && typeof Bun.plugin === "function") {
-    const baseUrl = getBaseUrlFromTsConfig()
+    const baseUrl = getBaseUrlFromTsConfig(projectDir)
 
     Bun.plugin({
       name: "tsci-static-assets",
@@ -123,8 +126,8 @@ export const registerStaticAssetLoaders = (platformConfig?: PlatformConfig) => {
           }
 
           const baseDir = baseUrl
-            ? path.resolve(process.cwd(), baseUrl)
-            : process.cwd()
+            ? path.resolve(projectDir, baseUrl)
+            : projectDir
 
           const relativePath = path
             .relative(baseDir, args.path)


### PR DESCRIPTION
## What changed

Remove the worker-thread dependency on `process.chdir(projectDir)` from concurrent build and snapshot execution. Thread the project directory explicitly through path-sensitive helpers instead.

The affected helpers now resolve paths relative to the supplied project directory for:

- userland `react`/`tscircuit` module resolution;
- static asset loading and `tsconfig.json` `baseUrl`;
- KiCad footprint/model URL conversion;
- circuit JSON generation and snapshot generation.

Sequential callers retain the same behavior through the default `process.cwd()` fallback.

## Root cause

The concurrent worker handlers called `process.chdir(projectDir)`. This worked with Bun `1.3.14`, but Bun `1.4.0` rejects `process.chdir()` inside worker threads with:

```text
process.chdir() is not supported in workers
```

The failure was exposed by `tscircuit/sparkfun-boards` after its CI environment picked up Bun `1.4.0`. The CLI worker code had contained this call since the concurrent build worker implementation, so pinning Bun would only mask the compatibility issue.

## Why this approach

Workers should not mutate process-global working-directory state. Passing absolute project paths makes worker behavior deterministic, supports multiple projects safely, and remains compatible with Bun versions that prohibit `process.chdir()` in workers.

## Validation

- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun test ./tests/cli/build/build-with-concurrency-client-server-pattern.test.ts`
  - 1 test passed
  - 3 concurrent workers completed circuit JSON, GLB, and preview generation
  - build exited successfully

This addresses the build failure observed in [tscircuit/sparkfun-boards#324](https://github.com/tscircuit/sparkfun-boards/pull/324).