### PR TITLE
Use shared Gerber file generation for fabrication exports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "circuit-json-to-connectivity-map": "^0.0.25",
         "circuit-json-to-fdm-component-box": "^0.0.2",
         "circuit-json-to-footprinter": "^0.0.15",
-        "circuit-json-to-gerber": "^0.0.94",
+        "circuit-json-to-gerber": "^0.0.97",
         "circuit-json-to-kicad": "0.0.157",
         "circuit-json-to-pnp-csv": "^0.0.9",
         "circuit-json-to-readable-netlist": "^0.0.15",
@@ -573,7 +573,7 @@
 
     "circuit-json-to-footprinter": ["circuit-json-to-footprinter@0.0.15", "", { "dependencies": { "@tscircuit/footprinter": "^0.0.385", "@tscircuit/math-utils": "^0.0.36", "circuit-json": "^0.0.448", "format-si-unit": "^0.0.10" } }, "sha512-TBRI7rryKSWA15aX0LpNdy4RvKUQQ+qpp3FHpMblPW1IpzKQTQOi6lqcbABWzDllh7Cd3QZEvwYJYjdbGfm5Sw=="],
 
-    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.94", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.25", "fast-json-stable-stringify": "^2.1.0", "polygon-clipping": "^0.15.7", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-moJ8C7vFzm20H1Ydzyqyqe3GQQWyyFOmi8qHarmEfzBEeu2exV98nIUIOtI6gSpdP0lMWdYTJKMfkb6xIri1JA=="],
+    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.97", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.25", "fast-json-stable-stringify": "^2.1.0", "polygon-clipping": "^0.15.7", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-i0RlmjFT6HlGczdnmU2q/Sv/rA3pL1fQu/MEBv9oFXTe5eHSTU5Xp8MjKgfJde+Oi80Sb3EbeGf6piesGs5Odg=="],
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.106", "", { "dependencies": { "@jscad/modeling": "^2.12.6", "earcut": "^3.0.2", "jscad-electronics": "^0.0.135", "jscad-to-gltf": "^0.0.5", "occt-import-js": "^0.0.23" }, "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-js", "@resvg/resvg-wasm"] }, "sha512-U59vURQ704QTN+PxTHn8t4c0NGgdSSrNiTNYjnsXDrxK0rhtacchd9QBD4iz6x5n15QSlhcds4dyC1AVAbB9GA=="],
 

--- a/lib/shared/export-snippet.ts
+++ b/lib/shared/export-snippet.ts
@@ -7,12 +7,7 @@ import {
   convertBomRowsToCsv,
   convertCircuitJsonToBomRows,
 } from "circuit-json-to-bom-csv"
-import {
-  convertSoupToExcellonDrillCommands,
-  convertSoupToGerberCommands,
-  stringifyExcellonDrill,
-  stringifyGerberCommandLayers,
-} from "circuit-json-to-gerber"
+import { convertCircuitJsonToGerberFiles } from "circuit-json-to-gerber"
 import { convertCircuitJsonToGltf } from "circuit-json-to-gltf"
 import {
   CircuitJsonToKicadPcbConverter,
@@ -313,33 +308,11 @@ export const exportSnippet = async ({
     case "gerbers": {
       const zip = new JSZip()
 
-      const gerberLayerCmds = convertSoupToGerberCommands(circuitJson, {
+      const gerberFiles = convertCircuitJsonToGerberFiles(circuitJson, {
         flip_y_axis: false,
       })
-      const gerberFileContents = stringifyGerberCommandLayers(gerberLayerCmds)
-
-      for (const [fileName, fileContents] of Object.entries(
-        gerberFileContents,
-      )) {
-        zip.file(`${fileName}.gbr`, fileContents)
-      }
-
-      const platedDrillCmds = convertSoupToExcellonDrillCommands({
-        circuitJson,
-        is_plated: true,
-        flip_y_axis: false,
-      })
-      if (platedDrillCmds.length > 0) {
-        zip.file("drill.drl", stringifyExcellonDrill(platedDrillCmds))
-      }
-
-      const nonPlatedDrillCmds = convertSoupToExcellonDrillCommands({
-        circuitJson,
-        is_plated: false,
-        flip_y_axis: false,
-      })
-      if (nonPlatedDrillCmds.length > 0) {
-        zip.file("drill_npth.drl", stringifyExcellonDrill(nonPlatedDrillCmds))
+      for (const [fileName, fileContents] of Object.entries(gerberFiles)) {
+        zip.file(fileName, fileContents)
       }
 
       const bomRows = await convertCircuitJsonToBomRows({ circuitJson })

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "circuit-json-to-connectivity-map": "^0.0.25",
     "circuit-json-to-fdm-component-box": "^0.0.2",
     "circuit-json-to-footprinter": "^0.0.15",
-    "circuit-json-to-gerber": "^0.0.94",
+    "circuit-json-to-gerber": "^0.0.97",
     "circuit-json-to-kicad": "0.0.157",
     "circuit-json-to-pnp-csv": "^0.0.9",
     "circuit-json-to-readable-netlist": "^0.0.15",

--- a/tests/shared/export-snippet-gerber-drills.test.ts
+++ b/tests/shared/export-snippet-gerber-drills.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import type { AnyCircuitElement } from "circuit-json"
+import JSZip from "jszip"
+import { exportSnippet } from "lib/shared/export-snippet"
+
+test("gerber export includes every plated drill span and NPTH drill file", async () => {
+  const temporaryDirectory = await mkdtemp(
+    path.join(tmpdir(), "tsci-gerber-drills-"),
+  )
+  const circuitJsonPath = path.join(temporaryDirectory, "board.circuit.json")
+  const circuitJson = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      num_layers: 4,
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "blind-via",
+      x: -4,
+      y: 0,
+      hole_diameter: 0.6,
+      outer_diameter: 1.2,
+      layers: ["top", "inner1"],
+      from_layer: "top",
+      to_layer: "inner1",
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "through-via",
+      x: 4,
+      y: 0,
+      hole_diameter: 0.6,
+      outer_diameter: 1.2,
+      layers: ["top", "bottom"],
+      from_layer: "top",
+      to_layer: "bottom",
+    },
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "mounting-hole",
+      x: 0,
+      y: 4,
+      hole_diameter: 2,
+    },
+  ] as AnyCircuitElement[]
+
+  try {
+    await writeFile(circuitJsonPath, JSON.stringify(circuitJson))
+
+    let fabricationZip: Buffer | undefined
+    let exitCode: number | undefined
+    await exportSnippet({
+      filePath: circuitJsonPath,
+      format: "gerbers",
+      writeFile: false,
+      onExit: (code) => {
+        exitCode = code
+      },
+      onError: (message) => {
+        throw new Error(message)
+      },
+      onSuccess: ({ outputContent }) => {
+        fabricationZip = outputContent as Buffer
+      },
+    })
+
+    expect(exitCode).toBe(0)
+    const zip = await JSZip.loadAsync(fabricationZip!)
+    expect(Object.keys(zip.files)).toEqual(
+      expect.arrayContaining([
+        "F_Cu.gbr",
+        "In1_Cu.gbr",
+        "In2_Cu.gbr",
+        "B_Cu.gbr",
+        "Edge_Cuts.gbr",
+        "drill-L1-L2.drl",
+        "drill-L1-L4.drl",
+        "drill_npth.drl",
+        "bom.csv",
+        "pick_and_place.csv",
+      ]),
+    )
+    expect(await zip.file("drill-L1-L2.drl")!.async("string")).toContain(
+      "X-4.0000Y0.0000",
+    )
+    expect(await zip.file("drill-L1-L4.drl")!.async("string")).toContain(
+      "X4.0000Y0.0000",
+    )
+    expect(await zip.file("drill_npth.drl")!.async("string")).toContain(
+      "X0.0000Y4.0000",
+    )
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- upgrade `circuit-json-to-gerber` to the published `0.0.97` release
- build fabrication ZIP Gerber and drill entries from `convertCircuitJsonToGerberFiles`
- preserve CLI-owned BOM and JLCPCB pick-and-place generation
- cover blind-via, through-via, and NPTH drill files in the exported ZIP

This removes duplicated converter orchestration and ensures every plated layer span is included.

Closes #4346

## Validation
- `bun test tests/shared/export-snippet-gerber-drills.test.ts tests/shared/export-snippet-part-orientation.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`