### PR TITLE
Warn when importing an out-of-stock JLCPCB part

### DIFF
--- a/cli/import/import-jlcpcb-part.ts
+++ b/cli/import/import-jlcpcb-part.ts
@@ -2,21 +2,16 @@ import kleur from "kleur"
 import { importComponentFromJlcpcb } from "lib/import/import-component-from-jlcpcb"
 import ora from "ora"
 import { logFootprintConversion } from "./log-footprint-conversion"
-import { warnIfJlcpcbPartIsOutOfStock } from "./warn-if-jlcpcb-part-is-out-of-stock"
 
 export const importJlcpcbPart = async ({
   download,
   partNumber,
-  stock,
   useExactFootprint,
 }: {
   download?: boolean
   partNumber: string
-  stock?: number
   useExactFootprint?: boolean
 }) => {
-  warnIfJlcpcbPartIsOutOfStock({ partNumber, stock })
-
   const spinner = ora({
     text: `Importing "${partNumber}" from JLCPCB...`,
     stream: process.stdout,

--- a/cli/import/import-jlcpcb-part.ts
+++ b/cli/import/import-jlcpcb-part.ts
@@ -2,16 +2,21 @@ import kleur from "kleur"
 import { importComponentFromJlcpcb } from "lib/import/import-component-from-jlcpcb"
 import ora from "ora"
 import { logFootprintConversion } from "./log-footprint-conversion"
+import { warnIfJlcpcbPartIsOutOfStock } from "./warn-if-jlcpcb-part-is-out-of-stock"
 
 export const importJlcpcbPart = async ({
   download,
   partNumber,
+  stock,
   useExactFootprint,
 }: {
   download?: boolean
   partNumber: string
+  stock?: number
   useExactFootprint?: boolean
 }) => {
+  warnIfJlcpcbPartIsOutOfStock({ partNumber, stock })
+
   const spinner = ora({
     text: `Importing "${partNumber}" from JLCPCB...`,
     stream: process.stdout,

--- a/cli/import/register.ts
+++ b/cli/import/register.ts
@@ -38,6 +38,7 @@ export const registerImport = (program: Command) => {
         const hasFilters = opts.jlcpcb || opts.lcsc || opts.tscircuit
         const searchJlc = opts.jlcpcb || opts.lcsc || !hasFilters
         const searchTscircuit = opts.tscircuit
+        let didJlcSearchSucceed = false
         const ky = getRegistryApiKy()
         const spinner = ora({
           text: "Searching...",
@@ -55,6 +56,7 @@ export const registerImport = (program: Command) => {
           package: string
           description: string
           price: number
+          stock: number
         }> = []
 
         if (searchTscircuit) {
@@ -79,8 +81,13 @@ export const registerImport = (program: Command) => {
           try {
             spinner.text = "Searching JLCPCB parts..."
             const searchUrl = `https://jlcsearch.tscircuit.com/api/search?limit=10&q=${encodeURIComponent(query)}`
-            const resp = await fetch(searchUrl).then((r) => r.json())
-            jlcResults = resp.components
+            const response = await fetch(searchUrl)
+            if (!response.ok) {
+              throw new Error(`JLCPCB search failed with ${response.status}`)
+            }
+            const resp = await response.json()
+            jlcResults = resp.components ?? []
+            didJlcSearchSucceed = true
           } catch (error) {
             spinner.fail("Failed to search JLCPCB")
             console.error(
@@ -100,6 +107,7 @@ export const registerImport = (program: Command) => {
             await importJlcpcbPart({
               download: opts.download,
               partNumber: directLcscPartNumber,
+              stock: didJlcSearchSucceed ? 0 : undefined,
               useExactFootprint: opts.useExactFootprint,
             })
             return
@@ -117,7 +125,7 @@ export const registerImport = (program: Command) => {
           title: string
           value:
             | { type: "registry"; name: string }
-            | { type: "jlcpcb"; part: number }
+            | { type: "jlcpcb"; part: number; stock: number }
           selected?: boolean
         }> = []
 
@@ -132,7 +140,11 @@ export const registerImport = (program: Command) => {
         jlcResults?.forEach((comp, idx) => {
           choices.push({
             title: `[jlcpcb] ${comp.mfr} (C${comp.lcsc}) - ${comp.description}`,
-            value: { type: "jlcpcb", part: comp.lcsc },
+            value: {
+              type: "jlcpcb",
+              part: comp.lcsc,
+              stock: comp.stock,
+            },
             selected: !choices.length && idx === 0,
           })
         })
@@ -173,6 +185,7 @@ export const registerImport = (program: Command) => {
           await importJlcpcbPart({
             download: opts.download,
             partNumber: `C${String(choice.part)}`,
+            stock: choice.stock,
             useExactFootprint: opts.useExactFootprint,
           })
         }

--- a/cli/import/register.ts
+++ b/cli/import/register.ts
@@ -7,6 +7,7 @@ import { prompts } from "lib/utils/prompts"
 import ora from "ora"
 import { importJlcpcbPart } from "./import-jlcpcb-part"
 import { parseDirectLcscPartNumber } from "./parse-direct-lcsc-part-number"
+import { warnIfJlcpcbPartIsOutOfStock } from "./warn-if-jlcpcb-part-is-out-of-stock"
 
 export const registerImport = (program: Command) => {
   program
@@ -104,10 +105,13 @@ export const registerImport = (program: Command) => {
             ? parseDirectLcscPartNumber(query)
             : null
           if (directLcscPartNumber) {
+            warnIfJlcpcbPartIsOutOfStock({
+              partNumber: directLcscPartNumber,
+              stock: didJlcSearchSucceed ? 0 : undefined,
+            })
             await importJlcpcbPart({
               download: opts.download,
               partNumber: directLcscPartNumber,
-              stock: didJlcSearchSucceed ? 0 : undefined,
               useExactFootprint: opts.useExactFootprint,
             })
             return
@@ -182,10 +186,14 @@ export const registerImport = (program: Command) => {
             return process.exit(1)
           }
         } else {
+          const partNumber = `C${String(choice.part)}`
+          warnIfJlcpcbPartIsOutOfStock({
+            partNumber,
+            stock: choice.stock,
+          })
           await importJlcpcbPart({
             download: opts.download,
-            partNumber: `C${String(choice.part)}`,
-            stock: choice.stock,
+            partNumber,
             useExactFootprint: opts.useExactFootprint,
           })
         }

--- a/cli/import/warn-if-jlcpcb-part-is-out-of-stock.ts
+++ b/cli/import/warn-if-jlcpcb-part-is-out-of-stock.ts
@@ -1,0 +1,17 @@
+import kleur from "kleur"
+
+export const warnIfJlcpcbPartIsOutOfStock = ({
+  partNumber,
+  stock,
+}: {
+  partNumber: string
+  stock?: number
+}) => {
+  if (typeof stock !== "number" || stock > 0) return
+
+  console.warn(
+    kleur.yellow(
+      `Warning: ${partNumber} is currently out of stock at JLCPCB. The component will still be imported.`,
+    ),
+  )
+}

--- a/tests/cli/import/warn-if-jlcpcb-part-is-out-of-stock.test.ts
+++ b/tests/cli/import/warn-if-jlcpcb-part-is-out-of-stock.test.ts
@@ -1,0 +1,19 @@
+import { expect, spyOn, test } from "bun:test"
+import { warnIfJlcpcbPartIsOutOfStock } from "cli/import/warn-if-jlcpcb-part-is-out-of-stock"
+
+test("warns without blocking when a JLCPCB part is out of stock", () => {
+  const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+
+  try {
+    warnIfJlcpcbPartIsOutOfStock({
+      partNumber: "C1526234",
+      stock: 0,
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Warning: C1526234 is currently out of stock at JLCPCB. The component will still be imported.",
+    )
+  } finally {
+    warnSpy.mockRestore()
+  }
+})

--- a/tests/cli/import/warn-if-jlcpcb-part-is-out-of-stock.test.ts
+++ b/tests/cli/import/warn-if-jlcpcb-part-is-out-of-stock.test.ts
@@ -10,7 +10,8 @@ test("warns without blocking when a JLCPCB part is out of stock", () => {
       stock: 0,
     })
 
-    expect(warnSpy).toHaveBeenCalledWith(
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(Bun.stripANSI(String(warnSpy.mock.calls[0]?.[0]))).toBe(
       "Warning: C1526234 is currently out of stock at JLCPCB. The component will still be imported.",
     )
   } finally {


### PR DESCRIPTION

<img width="727" height="95" alt="Screenshot 2026-08-24 at 21 12 37" src="https://github.com/user-attachments/assets/b8f9fbe8-e144-4f02-9f78-929f0e7f59a2" />


## Summary

- carry JLCPCB stock information through the `tsci import` flow
- show a warning when the selected part has zero stock
- continue importing the component instead of failing

## Testing

- added a focused test for the out-of-stock warning
- `bun test tests/cli/import/warn-if-jlcpcb-part-is-out-of-stock.test.ts`
- Biome checks pass

## Note

The full build is currently blocked by an unrelated existing `circuit-json-to-gerber` export error.