### PR TITLE
Increase default worker timeout to 10 minutes

### DIFF
--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -94,7 +94,7 @@ export async function buildFilesWithWorkerPool(options: {
   )
   const workerJobTimeoutMs = Number.isFinite(envWorkerTimeoutMs)
     ? envWorkerTimeoutMs
-    : (options.workerJobTimeoutMs ?? 300000)
+    : (options.workerJobTimeoutMs ?? 10 * 60 * 1000)
   const poolConcurrency = Math.max(
     1,
     Math.min(options.concurrency, options.files.length),


### PR DESCRIPTION
## Summary

- increase the default build worker timeout from 5 minutes to 10 minutes
- preserve project configuration and `TSCIRCUIT_BUILD_WORKER_TIMEOUT_MS` overrides

## Testing

- `bun test tests/shared/thread-worker-pool-timeout.test.ts`
- `bunx biome check cli/build/worker-pool.ts`
- `git diff --check`