### PR TITLE
fix: transpile explicit TypeScript extension imports

### DIFF
--- a/cli/build/transpile/index.ts
+++ b/cli/build/transpile/index.ts
@@ -7,11 +7,26 @@ import commonjs from "@rollup/plugin-commonjs"
 import json from "@rollup/plugin-json"
 import dts from "rollup-plugin-dts"
 import kleur from "kleur"
+import ts from "typescript"
 
 import {
   createStaticAssetPlugin,
   STATIC_ASSET_EXTENSIONS,
 } from "./static-asset-plugin"
+
+const [typescriptMajor, typescriptMinor] = ts.versionMajorMinor
+  .split(".")
+  .map(Number)
+// TypeScript 5.7+ can emit projects that import .ts/.tsx paths by rewriting
+// those specifiers, instead of reporting TS5097 or requiring noEmit.
+const supportsRewriteRelativeImportExtensions =
+  typescriptMajor > 5 || (typescriptMajor === 5 && typescriptMinor >= 7)
+const typescriptExtensionEmitOptions = supportsRewriteRelativeImportExtensions
+  ? {
+      allowImportingTsExtensions: true,
+      rewriteRelativeImportExtensions: true,
+    }
+  : { allowImportingTsExtensions: false }
 
 const createExternalFunction =
   (projectDir: string, tsconfigPath?: string) =>
@@ -143,7 +158,7 @@ export const transpileFile = async ({
               sourceMap: false,
               noEmit: false,
               emitDeclarationOnly: false,
-              allowImportingTsExtensions: false,
+              ...typescriptExtensionEmitOptions,
             }
           : {
               target: "ES2020",
@@ -156,6 +171,7 @@ export const transpileFile = async ({
               allowSyntheticDefaultImports: true,
               allowArbitraryExtensions: true,
               baseUrl: projectDir,
+              ...typescriptExtensionEmitOptions,
             },
       }),
     ]

--- a/tests/cli/transpile/transpile.test.ts
+++ b/tests/cli/transpile/transpile.test.ts
@@ -39,6 +39,46 @@ test("transpile command generates ESM, CommonJS, and type declarations", async (
   expect(dtsContent).toContain("export")
 }, 30_000)
 
+test("transpile supports explicit TypeScript extensions from user tsconfig", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const entryPath = path.join(tmpDir, "index.ts")
+  const componentPath = path.join(tmpDir, "component.tsx")
+
+  await writeFile(entryPath, 'export { Component } from "./component.tsx"\n')
+  await writeFile(componentPath, 'export const Component = "component"\n')
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  await writeFile(
+    path.join(tmpDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2020",
+        module: "ESNext",
+        moduleResolution: "node",
+        jsx: "react-jsx",
+        allowImportingTsExtensions: true,
+      },
+    }),
+  )
+
+  const { stderr, exitCode } = await runCommand(`tsci transpile ${entryPath}`)
+
+  expect(exitCode).toBe(0)
+  expect(stderr).not.toContain("TS5097")
+  expect(stderr).not.toContain("TS5096")
+
+  const esmContent = await readFile(
+    path.join(tmpDir, "dist", "index.js"),
+    "utf-8",
+  )
+  expect(esmContent).toContain("Component")
+
+  const dtsContent = await readFile(
+    path.join(tmpDir, "dist", "index.d.ts"),
+    "utf-8",
+  )
+  expect(dtsContent).toContain("Component")
+}, 30_000)
+
 test("transpile uses mainEntrypoint when available", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const mainPath = path.join(tmpDir, "index.tsx")


### PR DESCRIPTION
## Summary

- preserve explicit `.ts`/`.tsx` imports during library transpilation by enabling TypeScript 5.7+ relative-extension rewriting
- retain the existing fallback for older TypeScript versions
- add a regression test covering a user tsconfig with `allowImportingTsExtensions`

## Cause

The transpiler unconditionally overrode `allowImportingTsExtensions` to `false` because plain TypeScript emit cannot use it. Projects such as `tscircuit/ti` intentionally import `.tsx` files and therefore produced TS5097 for every import during both ESM and CJS bundling. TypeScript 5.7 introduced `rewriteRelativeImportExtensions`, which makes this combination emit-safe.

Reproduction: https://tscircuit.com/tscircuit/ti/releases/1a2d8fe2-3a34-468a-9557-70d7102d837b

## Validation

- `bun test tests/cli/transpile/transpile.test.ts`
- `bun test tests/cli/build/build-transpile.test.ts`
- `bun run format:check`
- `bun run build`
- `bun ../cli/cli/main.ts build --ci --concurrency 4` against tscircuit/ti PR #120: 118/118 circuits passed, followed by ESM, CJS, and declaration generation without TS5097
- the generated ESM, CJS, and declaration artifacts for that PR are byte-identical before and after this change