### PR TITLE
fix: preserve default platform config maps

### DIFF
--- a/lib/shared/get-platform-config-with-cli-defaults.ts
+++ b/lib/shared/get-platform-config-with-cli-defaults.ts
@@ -3,6 +3,7 @@ import fs from "node:fs"
 import path from "node:path"
 import { getPlatformConfig } from "@tscircuit/eval/platform-config"
 import type { PlatformConfig } from "@tscircuit/props"
+import { mergePlatformConfigs } from "./platform-config-utils"
 
 export function createLocalCacheEngine(
   cacheDir = path.join(process.cwd(), ".tscircuit", "cache"),
@@ -98,22 +99,5 @@ export function getPlatformConfigWithCliDefaults(
     return defaultConfig
   }
 
-  const mergedConfig: PlatformConfig = {
-    ...defaultConfig,
-    ...userConfig,
-    // If user provides footprintFileParserMap, merge it with our defaults
-    footprintFileParserMap: {
-      ...defaultConfig.footprintFileParserMap,
-      ...userConfig.footprintFileParserMap,
-    },
-  }
-
-  if (defaultConfig.staticFileLoaderMap || userConfig.staticFileLoaderMap) {
-    mergedConfig.staticFileLoaderMap = {
-      ...defaultConfig.staticFileLoaderMap,
-      ...userConfig.staticFileLoaderMap,
-    }
-  }
-
-  return mergedConfig
+  return mergePlatformConfigs(defaultConfig, userConfig)!
 }

--- a/tests/shared/get-platform-config-with-cli-defaults.test.ts
+++ b/tests/shared/get-platform-config-with-cli-defaults.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "bun:test"
+import type { PlatformConfig } from "@tscircuit/props"
+import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
+import { mergePlatformConfigs } from "lib/shared/platform-config-utils"
+
+test("a pipeline-merged SPICE-only override preserves every default platform map", () => {
+  const customSpiceEngine = {
+    simulate: async () => ({ simulationResultCircuitJson: [] }),
+  }
+
+  const projectConfig = mergePlatformConfigs(
+    { spiceEngineMap: { custom: customSpiceEngine } },
+    undefined,
+  )
+  expect(projectConfig?.footprintLibraryMap).toEqual({})
+
+  const platformConfig = getPlatformConfigWithCliDefaults(projectConfig)
+
+  expect(typeof platformConfig.footprintLibraryMap?.kicad).toBe("function")
+  expect(typeof platformConfig.footprintLibraryMap?.jlcpcb).toBe("function")
+  expect(platformConfig.footprintFileParserMap?.kicad_mod).toBeDefined()
+  expect(typeof platformConfig.staticFileLoaderMap?.kicad_pcb).toBe("function")
+  expect(typeof platformConfig.staticFileLoaderMap?.kicad_sym).toBe("function")
+  expect(platformConfig.autorouterMap?.krt).toBeDefined()
+  expect(platformConfig.spiceEngineMap?.ngspice).toBeDefined()
+  expect(platformConfig.spiceEngineMap?.custom).toBe(customSpiceEngine)
+})
+
+test("custom platform map entries merge with defaults and override matching keys", () => {
+  const footprintOverride = async () => ({ footprintCircuitJson: [] })
+  const customFootprint = async () => ({ footprintCircuitJson: [] })
+  const parserOverride = {
+    loadFromUrl: async () => ({ footprintCircuitJson: [] }),
+  }
+  const customParser = {
+    loadFromUrl: async () => ({ footprintCircuitJson: [] }),
+  }
+  const staticLoaderOverride = async () => ({
+    __esModule: true as const,
+    default: [],
+  })
+  const customStaticLoader = async () => ({
+    __esModule: true as const,
+    default: [],
+  })
+  const autorouterOverride = {
+    createAutorouter: () => ({
+      run: async () => {},
+      getOutputSimpleRouteJson: async () => ({}),
+    }),
+  }
+  const customAutorouter = {
+    createAutorouter: () => ({
+      run: async () => {},
+      getOutputSimpleRouteJson: async () => ({}),
+    }),
+  }
+  const spiceEngineOverride = {
+    simulate: async () => ({ simulationResultCircuitJson: [] }),
+  }
+  const customSpiceEngine = {
+    simulate: async () => ({ simulationResultCircuitJson: [] }),
+  }
+  const userConfig: PlatformConfig = {
+    footprintLibraryMap: {
+      kicad: footprintOverride,
+      custom: customFootprint,
+    },
+    footprintFileParserMap: {
+      kicad_mod: parserOverride,
+      custom_footprint: customParser,
+    },
+    staticFileLoaderMap: {
+      kicad_sym: staticLoaderOverride,
+      custom_asset: customStaticLoader,
+    },
+    autorouterMap: {
+      krt: autorouterOverride,
+      custom: customAutorouter,
+    },
+    spiceEngineMap: {
+      ngspice: spiceEngineOverride,
+      custom: customSpiceEngine,
+    },
+  }
+
+  const platformConfig = getPlatformConfigWithCliDefaults(userConfig)
+
+  expect(platformConfig.footprintLibraryMap?.kicad).toBe(footprintOverride)
+  expect(platformConfig.footprintLibraryMap?.custom).toBe(customFootprint)
+  expect(typeof platformConfig.footprintLibraryMap?.jlcpcb).toBe("function")
+  expect(platformConfig.footprintFileParserMap?.kicad_mod).toBe(parserOverride)
+  expect(platformConfig.footprintFileParserMap?.custom_footprint).toBe(
+    customParser,
+  )
+  expect(platformConfig.staticFileLoaderMap?.kicad_sym).toBe(
+    staticLoaderOverride,
+  )
+  expect(platformConfig.staticFileLoaderMap?.custom_asset).toBe(
+    customStaticLoader,
+  )
+  expect(typeof platformConfig.staticFileLoaderMap?.kicad_pcb).toBe("function")
+  expect(platformConfig.autorouterMap?.krt).toBe(autorouterOverride)
+  expect(platformConfig.autorouterMap?.custom).toBe(customAutorouter)
+  expect(platformConfig.spiceEngineMap?.ngspice).toBe(spiceEngineOverride)
+  expect(platformConfig.spiceEngineMap?.custom).toBe(customSpiceEngine)
+})


### PR DESCRIPTION
## Summary

- deep-merge project platform-map overrides with the CLI defaults
- preserve built-in footprint resolvers, file parsers, static loaders, autorouters, and SPICE engines unless the project overrides the same key
- add regression coverage for the build pipeline's normalized, SPICE-only project config

## Root cause

The build worker first combines platform configs with `mergePlatformConfigs`. That helper materializes absent nested maps as `{}`. `getPlatformConfigWithCliDefaults` then shallow-spread the normalized project config over the default config, so an empty `footprintLibraryMap` erased the built-in `kicad` and `jlcpcb` resolvers.

This meant a project that only configured a custom `spiceEngineMap` could no longer load KiCad footprints. It surfaced as `No footprint resolver is configured for library "kicad"` in [this TI release build](https://tscircuit.com/tscircuit/ti/releases/c426ce29-c854-41fe-be28-3a835b67b418).

The fix reuses the existing map-aware merge helper with defaults first and project config second, so project entries still take precedence.

Companion cleanup for the three stale identifiers exposed after restoring the resolvers: tscircuit/ti#139.

## Testing

- `bun test tests/shared/get-platform-config-with-cli-defaults.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- related build-concurrency and static-file-loader tests

The regression first passes a SPICE-only config through `mergePlatformConfigs`, confirms the empty maps produced by that normalization step, and then verifies all CLI defaults survive.
