### PR TITLE
Suggest timeout flag when autorouter times out

### DIFF
--- a/lib/shared/autorouter-diagnostics.ts
+++ b/lib/shared/autorouter-diagnostics.ts
@@ -221,7 +221,7 @@ export class AutorouterDiagnostics {
 
     const artifactPath = this.writeTimeoutArtifact(this.activePhase, elapsedMs)
     const phaseLabel = this.getPhaseLabel(this.activePhase)
-    const message = `Autorouter timeout after ${this.formatElapsed(elapsedMs)} in ${phaseLabel}.`
+    const message = `Autorouter timeout after ${this.formatElapsed(elapsedMs)} in ${phaseLabel}. Set a different timeout with \`--autorouter-timeout <duration>\` (for example, \`--autorouter-timeout 2m\`).`
     this.log(kleur.red(message))
 
     throw new AutorouterPhaseTimeoutError(message, artifactPath)

--- a/tests/shared/autorouter-diagnostics.test.ts
+++ b/tests/shared/autorouter-diagnostics.test.ts
@@ -613,8 +613,16 @@ describe("autorouter diagnostics", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 5))
 
-    expect(() => diagnostics.checkTimeout()).toThrow(
-      AutorouterPhaseTimeoutError,
+    let timeoutError: unknown
+    try {
+      diagnostics.checkTimeout()
+    } catch (error) {
+      timeoutError = error
+    }
+
+    expect(timeoutError).toBeInstanceOf(AutorouterPhaseTimeoutError)
+    expect((timeoutError as Error).message).toContain(
+      "Set a different timeout with `--autorouter-timeout <duration>`",
     )
     expect(fs.existsSync(path.join(debugDir, "phase-1.timeout.json"))).toBe(
       true,


### PR DESCRIPTION
## Summary

- tell users that autorouter timeouts can be adjusted with --autorouter-timeout
- include a concrete 2m example in the timeout error
- cover the hint in the autorouter diagnostics test

## Validation

- bun test tests/shared/autorouter-diagnostics.test.ts
- bunx biome check lib/shared/autorouter-diagnostics.ts tests/shared/autorouter-diagnostics.test.ts
- git diff --check
- bun run build