### PR TITLE
feat: surface autorouter execution metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ The debug directory contains:
   A fanout router and its downstream router appear as separate stages.
 - `phase-N.input.simple-route.json` and `phase-N.output.traces.json` when
   `--autorouter-dump-srj all` is enabled.
-- `board.meta.json` — phase timing and connection-count summary.
+- `board.meta.json` — phase timing and connection-count summary, including the
+  resolved router, solver pipeline, effort, and cache status/key.
+
+The live stage log prints the same routing metadata. This makes it explicit
+when a result was computed, reused from the local cache, or run without caching
+and records why caching was disabled.
 
 Use `--autorouter-dump-srj failed` to keep only failed-stage routing data, or
 `--autorouter-dump-srj phase:N` to capture a single stage.

--- a/lib/shared/autorouter-diagnostics.ts
+++ b/lib/shared/autorouter-diagnostics.ts
@@ -70,6 +70,12 @@ type AutoroutingEventPayload = {
   autorouterVersion?: string
   effort?: number
   solverName?: string
+  cacheStatus?: "disabled" | "hit" | "miss"
+  cacheKey?: string
+  cacheDisabledReason?:
+    | "custom_algorithm"
+    | "strategy_not_cacheable"
+    | "no_cache_engine"
   iteration?: number
   steps?: number
   progress?: number
@@ -95,6 +101,16 @@ type ActivePhase = {
   startedAt: number
   startedAtIso: string
   simpleRouteJson?: SimpleRouteJson
+  autorouterName?: string
+  autorouterVersion?: string
+  solverName?: string
+  effort?: number
+  cacheStatus?: "disabled" | "hit" | "miss"
+  cacheKey?: string
+  cacheDisabledReason?:
+    | "custom_algorithm"
+    | "strategy_not_cacheable"
+    | "no_cache_engine"
   routerDescription: string
   lastProgressLogAt: number
   hasLoggedStart: boolean
@@ -280,6 +296,13 @@ export class AutorouterDiagnostics {
       startedAt: performance.now(),
       startedAtIso: new Date().toISOString(),
       simpleRouteJson,
+      autorouterName: event.autorouterName,
+      autorouterVersion: event.autorouterVersion,
+      solverName: event.solverName,
+      effort: event.effort,
+      cacheStatus: event.cacheStatus,
+      cacheKey: event.cacheKey,
+      cacheDisabledReason: event.cacheDisabledReason,
       routerDescription: this.formatRouter(event),
       lastProgressLogAt: 0,
       hasLoggedStart: false,
@@ -354,6 +377,7 @@ export class AutorouterDiagnostics {
       connectionCount: activePhase.connectionCount,
       obstacleCount: activePhase.obstacleCount,
       previousTraceCount: activePhase.previousTraceCount,
+      ...this.getExecutionMetadata(activePhase),
       outputTraceCount,
       outputJumperCount,
       errorCount,
@@ -418,6 +442,7 @@ export class AutorouterDiagnostics {
       connectionCount: activePhase.connectionCount,
       obstacleCount: activePhase.obstacleCount,
       previousTraceCount: activePhase.previousTraceCount,
+      ...this.getExecutionMetadata(activePhase),
       elapsedMs: Math.round(elapsedMs),
       error,
       startedAt: activePhase.startedAtIso,
@@ -451,6 +476,7 @@ export class AutorouterDiagnostics {
         connectionCount: activePhase.connectionCount,
         obstacleCount: activePhase.obstacleCount,
         previousTraceCount: activePhase.previousTraceCount,
+        ...this.getExecutionMetadata(activePhase),
         error,
       })
     }
@@ -494,9 +520,7 @@ export class AutorouterDiagnostics {
       connectionCount: activePhase.connectionCount,
       obstacleCount: activePhase.obstacleCount,
       previousTraceCount: activePhase.previousTraceCount,
-      autorouter: {
-        kind: "default-or-core",
-      },
+      ...this.getExecutionMetadata(activePhase),
       files: {
         inputSimpleRouteJson: inputFile,
         previousOutputTraces: previousTracesFile,
@@ -547,15 +571,7 @@ export class AutorouterDiagnostics {
   private logPhaseStart(activePhase: ActivePhase, reason?: string) {
     const reasonText = reason ? ` ${reason}` : ""
     this.log(
-      [
-        `Autorouting ${this.formatUserFacingText(activePhase.componentDisplayName)} ${this.getPhaseLabel(activePhase)}${reasonText} start:`,
-        `connections=${activePhase.connectionCount},`,
-        `obstacles=${activePhase.obstacleCount},`,
-        `previous_traces=${activePhase.previousTraceCount}`,
-        activePhase.routerDescription
-          ? `, ${activePhase.routerDescription}`
-          : "",
-      ].join(" "),
+      `Autorouting ${this.formatUserFacingText(activePhase.componentDisplayName)} ${this.getPhaseLabel(activePhase)}${reasonText} start: connections=${activePhase.connectionCount}, obstacles=${activePhase.obstacleCount}, previous_traces=${activePhase.previousTraceCount}${activePhase.routerDescription ? `, ${activePhase.routerDescription}` : ""}`,
     )
 
     const connectionNames = this.getConnectionNames(activePhase.simpleRouteJson)
@@ -773,12 +789,32 @@ export class AutorouterDiagnostics {
   }
 
   private formatRouter(event: AutoroutingEventPayload) {
+    const cacheDescription = event.cacheStatus
+      ? event.cacheStatus === "disabled" && event.cacheDisabledReason
+        ? `cache=disabled(${event.cacheDisabledReason})`
+        : `cache=${event.cacheStatus}`
+      : null
     const parts = [
       event.autorouterName ? `router=${event.autorouterName}` : null,
       event.autorouterVersion ? `version=${event.autorouterVersion}` : null,
-      event.effort !== undefined ? `effort=${event.effort}` : null,
+      event.solverName ? `solver=${event.solverName}` : null,
+      event.effort !== undefined ? `effort=${event.effort}x` : null,
+      cacheDescription,
+      event.cacheKey ? `cache_key=${event.cacheKey}` : null,
     ].filter(Boolean)
     return parts.join(", ")
+  }
+
+  private getExecutionMetadata(activePhase: ActivePhase) {
+    return {
+      autorouterName: activePhase.autorouterName,
+      autorouterVersion: activePhase.autorouterVersion,
+      solverName: activePhase.solverName,
+      effort: activePhase.effort,
+      cacheStatus: activePhase.cacheStatus,
+      cacheKey: activePhase.cacheKey,
+      cacheDisabledReason: activePhase.cacheDisabledReason,
+    }
   }
 
   private getConnectionNames(simpleRouteJson?: SimpleRouteJson) {

--- a/tests/shared/autorouter-diagnostics.test.ts
+++ b/tests/shared/autorouter-diagnostics.test.ts
@@ -284,6 +284,15 @@ describe("autorouter diagnostics", () => {
     root.emit("autorouting:start", {
       subcircuit_id: "subcircuit_source_group_0",
       componentDisplayName: "board unnamedsubcircuit0",
+      routingPhaseIndex: 0,
+      phaseOrdinal: 1,
+      phaseCount: 1,
+      autorouterName: "tscircuit",
+      autorouterVersion: "beta_pipeline9",
+      solverName: "AutoroutingPipelineSolver9_PreloadedTraceGraph",
+      effort: 10,
+      cacheStatus: "miss",
+      cacheKey: "routes:core@0.0.0:solver:abc:srj:def",
       simpleRouteJson: {
         connections: [{ name: "GND" }],
         obstacles: [{ obstacleId: "pad_1" }],
@@ -333,10 +342,19 @@ describe("autorouter diagnostics", () => {
     expect(fs.existsSync(path.join(debugDir, "phase-0-routed.png"))).toBe(true)
     await diagnostics.finalize([])
 
-    expect(logs.join("\n")).toContain("phase 1 start")
+    expect(logs.join("\n")).toContain("phase 1/1 start")
     expect(logs.join("\n")).toContain("connections=1")
     expect(logs.join("\n")).toContain("obstacles=1")
-    expect(logs.join("\n")).toContain("phase 1 done")
+    expect(logs.join("\n")).toContain("router=tscircuit")
+    expect(logs.join("\n")).toContain(
+      "solver=AutoroutingPipelineSolver9_PreloadedTraceGraph",
+    )
+    expect(logs.join("\n")).toContain("effort=10x")
+    expect(logs.join("\n")).toContain("cache=miss")
+    expect(logs.join("\n")).toContain(
+      "cache_key=routes:core@0.0.0:solver:abc:srj:def",
+    )
+    expect(logs.join("\n")).toContain("phase 1/1 done")
     expect(logs).toContain(
       `Wrote debug artifact: ${path.relative(process.cwd(), path.join(debugDir, "placement-unrouted.png"))}`,
     )
@@ -350,6 +368,17 @@ describe("autorouter diagnostics", () => {
       fs.existsSync(path.join(debugDir, "phase-0.output.traces.json")),
     ).toBe(true)
     expect(fs.existsSync(path.join(debugDir, "board.meta.json"))).toBe(true)
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(debugDir, "board.meta.json"), "utf8"),
+    )
+    expect(summary.phases[0]).toMatchObject({
+      autorouterName: "tscircuit",
+      autorouterVersion: "beta_pipeline9",
+      solverName: "AutoroutingPipelineSolver9_PreloadedTraceGraph",
+      effort: 10,
+      cacheStatus: "miss",
+      cacheKey: "routes:core@0.0.0:solver:abc:srj:def",
+    })
     expect(
       fs
         .readFileSync(path.join(debugDir, "placement-unrouted.png"))


### PR DESCRIPTION
## Summary

- print the resolved autorouter, solver pipeline, effort, and cache decision in stage diagnostics
- persist the same execution metadata in board.meta.json, timeout artifacts, and error artifacts
- document how the richer diagnostics distinguish computed, cached, and non-cacheable routes

## Dependency

Consumes the additive autorouting event metadata introduced by tscircuit/core#3655. It remains compatible with older Core versions where those fields are absent.

## Testing

- bun test tests/shared/autorouter-diagnostics.test.ts
- bunx tsc --noEmit
- git diff --check origin/main...HEAD
