### PR TITLE
fix: shorten cache keys in autorouter logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ The debug directory contains:
 - `board.meta.json` — phase timing and connection-count summary, including the
   resolved router, solver pipeline, effort, and cache status/key.
 
-The live stage log prints the same routing metadata. This makes it explicit
-when a result was computed, reused from the local cache, or run without caching
-and records why caching was disabled.
+The live stage log prints the same routing metadata, using a compact cache ID
+to keep terminal lines readable; artifacts retain the full cache key. This
+makes it explicit when a result was computed, reused from the local cache, or
+run without caching and records why caching was disabled.
 
 Use `--autorouter-dump-srj failed` to keep only failed-stage routing data, or
 `--autorouter-dump-srj phase:N` to capture a single stage.

--- a/lib/shared/autorouter-diagnostics.ts
+++ b/lib/shared/autorouter-diagnostics.ts
@@ -800,9 +800,22 @@ export class AutorouterDiagnostics {
       event.solverName ? `solver=${event.solverName}` : null,
       event.effort !== undefined ? `effort=${event.effort}x` : null,
       cacheDescription,
-      event.cacheKey ? `cache_key=${event.cacheKey}` : null,
+      event.cacheKey
+        ? `cache_id=${this.formatCacheKeyForLog(event.cacheKey)}`
+        : null,
     ].filter(Boolean)
     return parts.join(", ")
+  }
+
+  private formatCacheKeyForLog(cacheKey: string) {
+    const localPhaseCacheMatch = cacheKey.match(
+      /:solver:([a-f0-9]{16}):srj:([a-f0-9]{16})$/,
+    )
+    if (localPhaseCacheMatch) {
+      return `${localPhaseCacheMatch[1].slice(0, 8)}/${localPhaseCacheMatch[2].slice(0, 8)}`
+    }
+    if (cacheKey.length <= 24) return cacheKey
+    return `${cacheKey.slice(0, 10)}…${cacheKey.slice(-10)}`
   }
 
   private getExecutionMetadata(activePhase: ActivePhase) {

--- a/tests/shared/autorouter-diagnostics.test.ts
+++ b/tests/shared/autorouter-diagnostics.test.ts
@@ -292,7 +292,8 @@ describe("autorouter diagnostics", () => {
       solverName: "AutoroutingPipelineSolver9_PreloadedTraceGraph",
       effort: 10,
       cacheStatus: "miss",
-      cacheKey: "routes:core@0.0.0:solver:abc:srj:def",
+      cacheKey:
+        "routes:core@0.0.0:solver:1234567890abcdef:srj:abcdef0123456789",
       simpleRouteJson: {
         connections: [{ name: "GND" }],
         obstacles: [{ obstacleId: "pad_1" }],
@@ -351,8 +352,9 @@ describe("autorouter diagnostics", () => {
     )
     expect(logs.join("\n")).toContain("effort=10x")
     expect(logs.join("\n")).toContain("cache=miss")
-    expect(logs.join("\n")).toContain(
-      "cache_key=routes:core@0.0.0:solver:abc:srj:def",
+    expect(logs.join("\n")).toContain("cache_id=12345678/abcdef01")
+    expect(logs.join("\n")).not.toContain(
+      "routes:core@0.0.0:solver:1234567890abcdef:srj:abcdef0123456789",
     )
     expect(logs.join("\n")).toContain("phase 1/1 done")
     expect(logs).toContain(
@@ -377,7 +379,8 @@ describe("autorouter diagnostics", () => {
       solverName: "AutoroutingPipelineSolver9_PreloadedTraceGraph",
       effort: 10,
       cacheStatus: "miss",
-      cacheKey: "routes:core@0.0.0:solver:abc:srj:def",
+      cacheKey:
+        "routes:core@0.0.0:solver:1234567890abcdef:srj:abcdef0123456789",
     })
     expect(
       fs


### PR DESCRIPTION
## Summary

- replace the 65-character phase cache key in live autorouter logs with a 17-character cache ID
- retain the complete cache key in board.meta.json and failure/timeout artifacts
- document the distinction and add regression coverage that prevents the full key from leaking into terminal output

## Example

Before:

    cache_key=routes:core@0.0.1840:solver:1234567890abcdef:srj:abcdef0123456789

After:

    cache_id=12345678/abcdef01

## Testing

- bun test tests/shared/autorouter-diagnostics.test.ts
- bunx tsc --noEmit
- bunx biome check README.md lib/shared/autorouter-diagnostics.ts tests/shared/autorouter-diagnostics.test.ts
- git diff --check
