### PR TITLE
chore: update easyeda to 0.0.350 for JLCPCB import fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "debug": "^4.4.0",
         "delay": "^6.0.0",
         "dsn-converter": "^0.0.90",
-        "easyeda": "^0.0.343",
+        "easyeda": "^0.0.350",
         "fuse.js": "^7.1.0",
         "get-port": "^7.1.0",
         "globby": "^14.1.0",
@@ -690,7 +690,7 @@
 
     "earcut": ["earcut@3.2.3", "", {}, "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q=="],
 
-    "easyeda": ["easyeda@0.0.343", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-H+12J3O3jonHbJgu5Qeuu1vgiARPIG01Nz1K/teYuZf/CFzXEsFoz9I2tO0yDnrYLjezgotM/LRH4d/q9APZ3w=="],
+    "easyeda": ["easyeda@0.0.350", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-CpTBmNoVGzSzZH4IY00sTv2AqeRRzB4kUU3360xWSOrWBCB8VJF774a/oCQcrGgj2nw0kEhrfoCKtIsyWAGtpg=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "debug": "^4.4.0",
     "delay": "^6.0.0",
     "dsn-converter": "^0.0.90",
-    "easyeda": "^0.0.343",
+    "easyeda": "^0.0.350",
     "fuse.js": "^7.1.0",
     "get-port": "^7.1.0",
     "globby": "^14.1.0",


### PR DESCRIPTION
The CLI's JLCPCB importer still locks EasyEDA to 0.0.343. This updates `easyeda` to `^0.0.350` and refreshes `bun.lock` so CLI imports use the newer conversion fixes.

The CLI imports EasyEDA directly in `lib/import/import-component-from-jlcpcb.ts`, calling both `convertRawEasyToTsx` and `convertEasyEdaJsonToCircuitJson`. Updating EasyEDA in RunFrame or Parts Engine does not update this independent dependency.

The newer release includes:
- https://github.com/tscircuit/easyeda-converter/pull/540: derive `cad_component.size` from valid model bounds, addressing the undersized C165948 USB-C model in direct Circuit JSON conversion.
- https://github.com/tscircuit/easyeda-converter/pull/543: preserve the C7519 schematic body fill and visible diodes.

This brings the CLI's converter dependency up to date alongside the RunFrame and Parts Engine updates. It does not deploy or refresh the connector documentation examples. Only `package.json` and `bun.lock` change.

Validation on the updated upstream main base:
- `bun install --frozen-lockfile`: passed.
- `bun test tests/cli/import tests/lib/import`: 8 passed, 1 skipped, 0 failed, including STEP/OBJ download and footprint conversion coverage.
- `bun run build` and `git diff --check`: passed.
- `bunx tsc --noEmit`: failed with TS2345 errors in `lib/shared/export-snippet.ts:343` and `tests/cli/export/export-component-box-3mf.test.ts:52`. These report incompatible `circuit-json` connector types between the root dependency and the copy under `circuit-json-to-fdm-component-box` (`standard` includes JST families in one version but not the other). No changes to those dependencies or files are included in this PR.
