### PR TITLE
Fix Node dependency imports on Windows and URL-significant paths

### DIFF
--- a/lib/shared/importFromUserLand.ts
+++ b/lib/shared/importFromUserLand.ts
@@ -1,6 +1,13 @@
 import { createRequire } from "node:module"
 import fs from "node:fs"
-import path, { relative, resolve } from "node:path"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+
+function toImportSpecifier(resolvedPath: string) {
+  return path.isAbsolute(resolvedPath)
+    ? pathToFileURL(resolvedPath).href
+    : resolvedPath
+}
 
 export async function importFromUserLand(
   moduleName: string,
@@ -13,7 +20,7 @@ export async function importFromUserLand(
     const userRequire = createRequire(path.join(projectDir, "noop.js"))
     try {
       const resolvedUserPath = userRequire.resolve(moduleName)
-      return await import(resolvedUserPath)
+      return await import(toImportSpecifier(resolvedUserPath))
     } catch (error: any) {
       if (error?.code !== "MODULE_NOT_FOUND") {
         throw error
@@ -26,7 +33,7 @@ export async function importFromUserLand(
   const cliRequire = createRequire(import.meta.url)
   try {
     const resolvedCliPath = cliRequire.resolve(moduleName)
-    return await import(resolvedCliPath)
+    return await import(toImportSpecifier(resolvedCliPath))
   } catch (error: any) {
     if (error?.code !== "MODULE_NOT_FOUND") {
       throw error

--- a/tests/shared/import-from-user-land.test.ts
+++ b/tests/shared/import-from-user-land.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const importerPath = fileURLToPath(
+  new URL("../../lib/shared/importFromUserLand.ts", import.meta.url),
+)
+
+function importWithNode(options: {
+  localEntry?: string
+  cliEntry?: string
+  moduleName?: string
+}) {
+  // URL-significant characters also expose this regression on Unix systems.
+  const fixtureDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsci import # percent% "),
+  )
+  try {
+    const projectDir = path.join(fixtureDir, "project")
+    const cliDir = path.join(fixtureDir, "cli")
+    fs.mkdirSync(projectDir, { recursive: true })
+    fs.mkdirSync(cliDir, { recursive: true })
+
+    for (const { parentDir, entry } of [
+      { parentDir: projectDir, entry: options.localEntry },
+      { parentDir: cliDir, entry: options.cliEntry },
+    ]) {
+      if (entry === undefined) continue
+      const packageDir = path.join(parentDir, "node_modules", "fixture-module")
+      fs.mkdirSync(packageDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({ name: "fixture-module", main: "index.cjs" }),
+      )
+      fs.writeFileSync(path.join(packageDir, "index.cjs"), entry)
+    }
+
+    // Transpile the actual helper without bundling it. Run in Node without tsx
+    // so a loader cannot mask native ESM path/URL resolution behavior.
+    const compiledImporterPath = path.join(cliDir, "importer.mjs")
+    fs.writeFileSync(
+      compiledImporterPath,
+      new Bun.Transpiler({ loader: "ts", target: "node" }).transformSync(
+        fs.readFileSync(importerPath, "utf8"),
+      ),
+    )
+    const runnerPath = path.join(fixtureDir, "runner.mjs")
+    fs.writeFileSync(
+      runnerPath,
+      `import { importFromUserLand } from ${JSON.stringify(pathToFileURL(compiledImporterPath).href)};
+const imported = await importFromUserLand(${JSON.stringify(options.moduleName ?? "fixture-module")}, ${JSON.stringify(projectDir)});
+console.log(JSON.stringify({ marker: imported.default?.marker, hasJoin: typeof imported.join === "function" }));
+`,
+    )
+    return spawnSync("node", [runnerPath], {
+      encoding: "utf8",
+      timeout: 10_000,
+    })
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true })
+  }
+}
+
+test("Node loads the project's dependency from paths containing spaces, # and %", () => {
+  const result = importWithNode({
+    localEntry: 'module.exports = { marker: "project" }',
+    cliEntry: 'module.exports = { marker: "cli" }',
+  })
+  expect(result.stderr).toBe("")
+  expect(result.status).toBe(0)
+  expect(JSON.parse(result.stdout).marker).toBe("project")
+})
+
+test("Node falls back to the CLI dependency using a file URL", () => {
+  const result = importWithNode({
+    cliEntry: 'module.exports = { marker: "cli" }',
+  })
+  expect(result.stderr).toBe("")
+  expect(result.status).toBe(0)
+  expect(JSON.parse(result.stdout).marker).toBe("cli")
+})
+
+test.each(["path", "node:path"])(
+  "Node preserves builtin specifier %s",
+  (moduleName) => {
+    const result = importWithNode({ moduleName })
+    expect(result.stderr).toBe("")
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout).hasJoin).toBe(true)
+  },
+)
+
+test("Node propagates project module errors instead of selecting the CLI copy", () => {
+  const result = importWithNode({
+    localEntry: 'throw new Error("project module failed")',
+    cliEntry: 'module.exports = { marker: "cli" }',
+  })
+  expect(result.status).not.toBe(0)
+  expect(result.stderr).toContain("project module failed")
+  expect(result.stdout).toBe("")
+})


### PR DESCRIPTION
# Fix Node dependency imports on Windows and URL-significant paths

`importFromUserLand` passes absolute filesystem paths from `require.resolve()` directly to dynamic `import()`. On Windows, Node interprets the drive letter as a URL scheme and throws `ERR_UNSUPPORTED_ESM_URL_SCHEME`. Paths containing URL-significant characters such as `#` also need escaping.

Convert absolute resolved paths to file URLs for both project dependencies and CLI fallback dependencies. Preserve built-in specifiers such as `path` and `node:path`, dependency preference, and propagation of module execution errors.

Regression tests transpile the actual helper without bundling and execute it in native Node, using temporary directories containing spaces, `#`, and `%`.

Validation on Windows (Node 24.12.0, Bun 1.4.2):

- Before the fix: three regression tests failed; two built-in module tests passed.
- After the fix: all five tests passed (15 assertions).
- `bun run build` passed.
- `bunx tsc --noEmit` passed.
- Biome formatting of both changed files and `git diff --check` passed.

Prepared with OpenAI Codex. Linux execution and the complete test suite have not been run locally.
