### PR TITLE
fix: update easyeda to 0.0.352 for library lookup diagnostics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "debug": "^4.4.0",
         "delay": "^6.0.0",
         "dsn-converter": "^0.0.90",
-        "easyeda": "^0.0.350",
+        "easyeda": "^0.0.352",
         "fuse.js": "^7.1.0",
         "get-port": "^7.1.0",
         "globby": "^14.1.0",
@@ -690,7 +690,7 @@
 
     "earcut": ["earcut@3.2.3", "", {}, "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q=="],
 
-    "easyeda": ["easyeda@0.0.350", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-CpTBmNoVGzSzZH4IY00sTv2AqeRRzB4kUU3360xWSOrWBCB8VJF774a/oCQcrGgj2nw0kEhrfoCKtIsyWAGtpg=="],
+    "easyeda": ["easyeda@0.0.352", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-6AXBZcdLm533mYnPXPu+9pe5Eu1a7+eexqhPebntREcz1ldUWUfwJH6IiF2rLt3NJoZaMKc2KDgbs1ItBurmfg=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "debug": "^4.4.0",
     "delay": "^6.0.0",
     "dsn-converter": "^0.0.90",
-    "easyeda": "^0.0.350",
+    "easyeda": "^0.0.352",
     "fuse.js": "^7.1.0",
     "get-port": "^7.1.0",
     "globby": "^14.1.0",

--- a/tests/fixtures/assets/C41411351.search.json
+++ b/tests/fixtures/assets/C41411351.search.json
@@ -1,0 +1,28 @@
+{
+  "success": true,
+  "code": 0,
+  "result": {
+    "facets": {
+      "mine": 0,
+      "lcsc": 0,
+      "SMT": 0,
+      "easyeda": 0,
+      "following": 0,
+      "user": 0
+    },
+    "lists": {
+      "lcsc": [],
+      "easyeda": [],
+      "mine": [],
+      "following": [],
+      "user": [],
+      "SMT": []
+    },
+    "pageSize": 100,
+    "totalPage": 0,
+    "wd": "c41411351",
+    "uid": "0819f05c4eef4c71ace90d822a990e87",
+    "type": "3",
+    "doctype": ["2"]
+  }
+}

--- a/tests/lib/import/import-missing-library-component.test.ts
+++ b/tests/lib/import/import-missing-library-component.test.ts
@@ -1,0 +1,34 @@
+import { expect, spyOn, test } from "bun:test"
+import { readdir, rm } from "node:fs/promises"
+import { importComponentFromJlcpcb } from "lib/import/import-component-from-jlcpcb"
+import { temporaryDirectory } from "tempy"
+import s4SearchResponse from "../../fixtures/assets/C41411351.search.json"
+
+test("exact S4 import explains missing EasyEDA library content without writing files", async () => {
+  const projectDir = temporaryDirectory()
+  const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
+    Response.json(s4SearchResponse),
+  )
+
+  try {
+    await expect(
+      importComponentFromJlcpcb("C41411351", projectDir, {
+        useExactFootprint: true,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Component not found in EasyEDA library search for "C41411351". A supplier catalog listing does not guarantee importable symbol/footprint data."`,
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [input, init] = fetchMock.mock.calls[0]
+    const request = new Request(input, init)
+    expect(request.url).toBe("https://easyeda.com/api/components/search")
+    expect(request.method).toBe("POST")
+    expect(new URLSearchParams(await request.text()).get("wd")).toBe(
+      "C41411351",
+    )
+    expect(await readdir(projectDir)).toEqual([])
+  } finally {
+    fetchMock.mockRestore()
+    await rm(projectDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Updates the direct `easyeda` dev dependency and its Bun lockfile resolution from 0.0.350 to 0.0.352, bringing [easyeda-converter#549](https://github.com/tscircuit/easyeda-converter/pull/549) into JLCPCB imports. An empty library search now explains the supplier-catalog/library distinction; rejected or malformed search responses report contextual errors. Unrelated dependency versions and integrity hashes remain unchanged.

Adds an offline importer regression with the captured C41411351 search response. The inline error snapshot exercises the actual `easyeda/browser` dependency through `importComponentFromJlcpcb`, verifies one exact supplier search and confirms that no import files are created. No substitute footprint is introduced; the missing supplier geometry remains a sourcing blocker.

Validation: all 10 GitHub checks pass on `6eea7d712d089490910366169b5a3e44ec983d7b`, including the five Linux test groups, Windows tests, CLI smoke test, formatting, TypeScript and dependency policy. The new S4 importer snapshot passed in Linux test group 3. npm publication and the lockfile resolution were also verified. Full local execution was blocked by disk space, so runtime validation was completed on the clean GitHub runners.