### PR TITLE
chore: update placement analysis to 0.0.15

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@babel/standalone": "^7.26.9",
         "@biomejs/biome": "^1.9.4",
         "@tscircuit/check-shorts": "https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.19.tgz",
-        "@tscircuit/circuit-json-placement-analysis": "^0.0.9",
+        "@tscircuit/circuit-json-placement-analysis": "^0.0.15",
         "@tscircuit/circuit-json-routing-analysis": "^0.0.8",
         "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#db2cd1ca2ce51490e3230e53c3d7b361eeb14446",
         "@tscircuit/circuit-json-util": "^0.0.105",
@@ -392,7 +392,7 @@
 
     "@tscircuit/checks": ["@tscircuit/checks@0.0.145", "", { "peerDependencies": { "@flatten-js/core": "*", "@tscircuit/math-utils": "*", "circuit-json": "*", "circuit-json-to-connectivity-map": "*", "typescript": "^5.5.3" } }, "sha512-HKdugkjGSrx4HyyrrtDi4pXmORZGx9kA/4zKRUnk7qqqaIyF7OKXGSKW1nIxv+O2oSHOu4z9lpMCEYkHmPUdrQ=="],
 
-    "@tscircuit/circuit-json-placement-analysis": ["@tscircuit/circuit-json-placement-analysis@0.0.9", "", { "dependencies": { "flatbush": "^4.5.1", "rbush": "^4.0.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-B74isDuH0RkWoJ37OGcL4taQdKSNwf+yaDGCEWhzPuTftRwlpVSa8Z1vFS2NIpNH4XQCSPqw0g6i4t6gDInSsg=="],
+    "@tscircuit/circuit-json-placement-analysis": ["@tscircuit/circuit-json-placement-analysis@0.0.15", "", { "dependencies": { "flatbush": "^4.5.1", "rbush": "^4.0.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-6ihkUeXEYN/Wm1YUIS3Q9quT+RLrPav6mTvYxmRyRKU40IVY6T9B5CdLl8jpGpMom4zFJX9CYzj8kFFc8WS4SA=="],
 
     "@tscircuit/circuit-json-routing-analysis": ["@tscircuit/circuit-json-routing-analysis@0.0.8", "", { "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "sha512-mZxRSUbqVb6iZ47ZhNL3mDL7BY9kUcbLg7o4f8Jn5amkDGvmTo52547JQ5ui/6WSJHXmaW7hmRVTEj6PlivskQ=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/standalone": "^7.26.9",
     "@biomejs/biome": "^1.9.4",
     "@tscircuit/check-shorts": "https://jscdn.tscircuit.com/@tscircuit/check-shorts/0.0.19.tgz",
-    "@tscircuit/circuit-json-placement-analysis": "^0.0.9",
+    "@tscircuit/circuit-json-placement-analysis": "^0.0.15",
     "@tscircuit/circuit-json-routing-analysis": "^0.0.8",
     "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#db2cd1ca2ce51490e3230e53c3d7b361eeb14446",
     "@tscircuit/circuit-json-util": "^0.0.105",


### PR DESCRIPTION
Update `@tscircuit/circuit-json-placement-analysis` from `^0.0.9` to the latest published version, `^0.0.15`, so `tsci check placement` uses the current analysis. Refresh the Bun lockfile to resolve version `0.0.15`.

Validation:
- Placement and placement exit-status tests: 9 passed.
- `bun run build`: passed.
- `bun install --frozen-lockfile --ignore-scripts`: passed.
- `git diff --check`: passed.
