### PR TITLE
fix: align circuit-json override to unblock npm packaging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     },
   },
   "overrides": {
-    "circuit-json": "0.0.479",
+    "circuit-json": "^0.0.479",
   },
   "packages": {
     "@anatine/zod-openapi": ["@anatine/zod-openapi@2.2.8", "", { "dependencies": { "ts-deepmerge": "^6.0.3" }, "peerDependencies": { "openapi3-ts": "^4.1.2", "zod": "^3.20.0" } }, "sha512-iyM8mB556KdiZ6a1GTZ67ACLnJakU1hrzzXoh7PLaReldAdMq88MlZn/Ir/U56/TBuQctBhh/4seo0b0B343uw=="],

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     }
   },
   "overrides": {
-    "circuit-json": "0.0.479"
+    "circuit-json": "^0.0.479"
   },
   "scripts": {
     "start": "bun run dev",


### PR DESCRIPTION
The [August 27 release](https://github.com/tscircuit/cli/actions/runs/33080222010) created a tag, then npm rejected the `circuit-json` override with `EOVERRIDE`. Its specification must exactly match the direct dependency. This changes the override to `^0.0.479` and updates the lockfile without changing any resolved packages.

`npm pack --dry-run --ignore-scripts --json` fails before this change and passes afterward, including both built entrypoints. Frozen installation, the full build, typecheck, and formatting also pass. Independently reviewed; prepared with AI assistance.

This addresses the packaging failure behind #4628 and is separate from #4629. Existing orphan tags and the stale release version still need maintainer recovery. No registry publication was attempted.
