### PR TITLE
fix npm publishing blocked by override conflicts and stale versions

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -33,7 +33,6 @@ jobs:
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
-      - run: npm publish --dry-run --ignore-scripts
       - run: pver release --no-push-main
         env:
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -33,6 +33,7 @@ jobs:
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
+      - run: npm publish --dry-run --ignore-scripts
       - run: pver release --no-push-main
         env:
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     },
   },
   "overrides": {
-    "circuit-json": "0.0.479",
+    "circuit-json": "^0.0.479",
   },
   "packages": {
     "@anatine/zod-openapi": ["@anatine/zod-openapi@2.2.8", "", { "dependencies": { "ts-deepmerge": "^6.0.3" }, "peerDependencies": { "openapi3-ts": "^4.1.2", "zod": "^3.20.0" } }, "sha512-iyM8mB556KdiZ6a1GTZ67ACLnJakU1hrzzXoh7PLaReldAdMq88MlZn/Ir/U56/TBuQctBhh/4seo0b0B343uw=="],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tscircuit/cli",
-  "version": "0.1.2019",
+  "version": "0.1.2030",
   "repository": {
     "type": "git",
     "url": "https://github.com/tscircuit/cli"
@@ -112,7 +112,7 @@
     }
   },
   "overrides": {
-    "circuit-json": "0.0.479"
+    "circuit-json": "^0.0.479"
   },
   "scripts": {
     "start": "bun run dev",


### PR DESCRIPTION
**motivation**
restore cli releases blocked by conflicting circuit-json specifications and exhausted version-tag retries.

**before**
npm rejected the override after pver pushed a tag. repeated failures left tags through 0.1.2030 while the manifest stayed at 0.1.2019.

**after**
align the override range and advance the version baseline to 0.1.2030. bun frozen install, build, npm publish dry run, and three focused tests pass. after a squash merge, pver skips the version-changing commit; the following code merge can publish 0.1.2031.
