### PR TITLE
fix: prevent npm publish failures when release tags outpace main

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -12,6 +12,10 @@ permissions:
   id-token: write
   pull-requests: write
 
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
 env:
   UPSTREAM_REPOS: "tscircuit" # for example: "eval"
   PACKAGE_NAMES: "@tscircuit/cli" # comma-separated list, e.g. "@tscircuit/core,@tscircuit/props"
@@ -21,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -32,6 +38,9 @@ jobs:
           package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
+      # Version bump PRs can lag behind tags created by pver --no-push-main.
+      - name: Sync release version with existing tags
+        run: node scripts/sync-release-version.mjs
       - run: bun run build
       - run: pver release --no-push-main
         env:

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -1,0 +1,25 @@
+import { execFileSync } from "node:child_process"
+import { readFileSync, writeFileSync } from "node:fs"
+import semver from "semver"
+
+// Refresh after entering the publish concurrency group so queued runs see tags
+// created by the previous release, even when their checkout is an older commit.
+execFileSync("git", ["fetch", "origin", "--tags"], { stdio: "inherit" })
+
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"))
+const latestVersion = execFileSync("git", ["tag", "--list", "v*"], {
+  encoding: "utf8",
+})
+  .split("\n")
+  .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
+  .map((tag) => tag.slice(1))
+  .filter((version) => semver.valid(version))
+  .sort(semver.rcompare)[0]
+
+if (latestVersion && semver.gt(latestVersion, packageJson.version)) {
+  console.log(
+    `Syncing release baseline: ${packageJson.version} -> ${latestVersion}`,
+  )
+  packageJson.version = latestVersion
+  writeFileSync("package.json", `${JSON.stringify(packageJson, null, 2)}\n`)
+}


### PR DESCRIPTION
The [failed publish job](https://github.com/tscircuit/cli/actions/runs/34273042045/job/102219183434) starts from package.json version `0.1.2019`, but tags `v0.1.2020` through `v0.1.2030` already exist. `pver` exhausts its ten collision retries before reaching npm publish. Version bump PRs can fall behind because releases use `--no-push-main`.

Fetch full history and tags, then raise the working package.json version to the highest stable release tag before building and running pver. This lets the failing case select `0.1.2031` and keeps working when version bump PRs lag again. Preserve newer manifest versions and ignore prerelease/unrelated tags. Serialize publish runs without cancelling an active release so concurrent runs cannot select the same version.

Validation:
- Reproduced the ten-tag failure with the actual `pver@0.0.43` in an isolated local Git repository; after synchronization, `pver analyze` selects `0.1.2031`.
- Six local Git fixture cases pass: stale baseline, no release tags, newer manifest, numeric ordering, prerelease/invalid tag filtering, and already-synchronized version. Repeated execution is idempotent.
- Workflow YAML parsing and step-order/concurrency assertions, Node syntax check, repository Biome formatting, and `git diff --check` pass.

No package was published during validation. The full CLI build/test suite was not run; changes are confined to release preparation.
