### PR TITLE
Fix upgrade exit status when package installation fails

### DIFF
--- a/cli/upgrade/register.ts
+++ b/cli/upgrade/register.ts
@@ -10,13 +10,18 @@ export function registerUpgradeCommand(program: Command) {
     .command("upgrade")
     .description("Upgrade CLI to the latest version")
     .action(async () => {
-      const isUpdated = await updateTsciIfNewVersionIsAvailable()
-      if (!isUpdated) {
-        console.log(
-          kleur.green(
-            `You are already using the latest version of tsci (v${currentCliVersion()})`,
-          ),
-        )
+      try {
+        const isUpdated = await updateTsciIfNewVersionIsAvailable()
+        if (!isUpdated) {
+          console.log(
+            kleur.green(
+              `You are already using the latest version of tsci (v${currentCliVersion()})`,
+            ),
+          )
+        }
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error))
+        process.exitCode = 1
       }
     })
 }

--- a/lib/shared/check-for-cli-update.ts
+++ b/lib/shared/check-for-cli-update.ts
@@ -48,7 +48,10 @@ export const updateTsciIfNewVersionIsAvailable = async () => {
   if (!latestCliVersion) return false
 
   if (semver.gt(latestCliVersion, currentCliVersion())) {
-    return await updateTsci()
+    if (!(await updateTsci())) {
+      throw new Error("Failed to upgrade tsci")
+    }
+    return true
   }
   return false
 }
@@ -66,6 +69,7 @@ export const updateTsci = async () => {
   } catch {
     console.warn("Update failed. You can try updating manually by running:")
     console.warn(`  ${installCommand}`)
+    return false
   }
   return true
 }

--- a/tests/cli/upgrade/upgrade.test.ts
+++ b/tests/cli/upgrade/upgrade.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import { fileURLToPath } from "node:url"
+
+const runScenario = async (scenario: string) => {
+  const proc = Bun.spawn(
+    [
+      process.execPath,
+      fileURLToPath(
+        new URL("../../fixtures/run-upgrade-scenario.ts", import.meta.url),
+      ),
+      scenario,
+    ],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FORCE_COLOR: "0", TSCI_SKIP_CLI_UPDATE: "false" },
+    },
+  )
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
+}
+
+test("upgrade exits unsuccessfully when package installation fails", async () => {
+  const result = await runScenario("failure")
+  expect(result.stderr).toContain("Update failed")
+  expect(result.stdout).toContain("install-attempts=1")
+  expect(result.stdout).not.toContain("already using the latest")
+  expect(result.stdout).not.toContain("updated successfully")
+  expect(result.exitCode).toBe(1)
+})
+
+test("upgrade succeeds after successful package installation", async () => {
+  const result = await runScenario("success")
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toContain("updated successfully")
+  expect(result.stdout).toContain("install-attempts=1")
+  expect(result.stdout).not.toContain("already using the latest")
+})
+
+test("upgrade skips installation when the current version is latest", async () => {
+  const result = await runScenario("current")
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toContain("already using the latest")
+  expect(result.stdout).toContain("install-attempts=0")
+})
+
+test("an optional update failure returns false and lets the command continue", async () => {
+  const result = await runScenario("optional")
+  expect(result.exitCode).toBe(0)
+  expect(result.stderr).toContain("Update failed")
+  expect(result.stdout).toContain("optional-update-result=false")
+  expect(result.stdout).toContain("original-command-continues")
+  expect(result.stdout).toContain("install-attempts=1")
+})

--- a/tests/fixtures/run-upgrade-scenario.ts
+++ b/tests/fixtures/run-upgrade-scenario.ts
@@ -1,0 +1,50 @@
+import { mock } from "bun:test"
+import { Command } from "commander"
+
+const scenario = process.argv[2]
+let installAttempts = 0
+
+// Execute a harmless local process in place of the package manager, including its exit status.
+mock.module("lib/shared/get-dep-install-command", () => ({
+  getGlobalDepsInstallCommand: () => {
+    installAttempts++
+    return `"${process.execPath}" -e "process.exit(${scenario === "success" ? 0 : 1})"`
+  },
+}))
+mock.module("lib/shared/get-package-manager", () => ({
+  getPackageManager: () => ({ name: "npm" }),
+}))
+mock.module("cli/main", () => ({
+  program: { version: () => "1.0.0" },
+}))
+mock.module("ky", () => ({
+  default: {
+    get: () => ({
+      json: async () => ({
+        version: scenario === "current" ? "1.0.0" : "1.0.1",
+      }),
+    }),
+  },
+}))
+
+if (scenario === "optional") {
+  mock.module("lib/utils/should-be-interactive", () => ({
+    shouldBeInteractive: () => true,
+  }))
+  mock.module("lib/utils/prompts", () => ({
+    prompts: async () => ({ userWantsToUpdate: true }),
+  }))
+  const { checkForTsciUpdates } = await import(
+    "lib/shared/check-for-cli-update"
+  )
+  const updated = await checkForTsciUpdates()
+  console.log(`optional-update-result=${updated}`)
+  console.log("original-command-continues")
+} else {
+  const { registerUpgradeCommand } = await import("cli/upgrade/register")
+  const program = new Command()
+  registerUpgradeCommand(program)
+  await program.parseAsync(["bun", "tsci", "upgrade"])
+}
+
+console.log(`install-attempts=${installAttempts}`)


### PR DESCRIPTION
When the package manager exits unsuccessfully during `tsci upgrade`, the CLI prints an update warning but still exits with status 0. `updateTsci` catches the installation error and then returns true, preventing callers from distinguishing failure from a successful upgrade.

Return false from the installer helper on failure. The explicit upgrade path turns that result into an error and exits with status 1, without printing the misleading “already using the latest version” message. An optional update check continues returning false so an initialization command can continue after the failed optional update.

Validation on Windows with Bun 1.4.2, based on main at 0454fe0e7f4bb9a65ef749a08206abcdbaa3e191:

- Regression tests before the fix: 2 pass, 2 fail. Installation failure exits 0 and the optional update incorrectly returns true.
- Regression tests after the fix: 4 pass, 0 fail, 17 assertions. Includes successful installation and already-current controls.
- Tests run each scenario in a separate process. Registry responses and the package-manager command are substituted; the final fixture executes a harmless local process with the requested exit status, without installing packages or contacting the registry.
- TypeScript: `bun run tsc --noEmit` passes.
- Build: `bun run build` passes.
- Formatting of the four changed files and `git diff --check` pass.
- Existing `tests/cli/init/init-yes-skips-update-prompt.test.ts` times out after 30 seconds and its cleanup reports EBUSY on this Windows host. Running it with both changed source files restored to upstream reproduces the timeout and EBUSY. The full repository suite has not been run; a clean full-suite result is not claimed.

AI assistance: prepared with OpenAI Codex (GPT-6 Astra), including investigation, code and tests. The failure and passing results above were executed locally.

I would like this contribution considered under the published contributor sponsorship program. No fixed bounty or payment approval is assumed.