### PR TITLE
fix: update Gerber exporter to deduplicate via drill hits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
         "circuit-json-to-connectivity-map": "^0.0.25",
         "circuit-json-to-fdm-component-box": "^0.0.2",
         "circuit-json-to-footprinter": "^0.0.54",
-        "circuit-json-to-gerber": "^0.0.97",
+        "circuit-json-to-gerber": "^0.0.105",
         "circuit-json-to-kicad": "0.0.181",
         "circuit-json-to-pnp-csv": "^0.0.13",
         "circuit-json-to-readable-netlist": "^0.0.15",
@@ -592,7 +592,7 @@
 
     "circuit-json-to-footprinter": ["circuit-json-to-footprinter@0.0.54", "", { "dependencies": { "@tscircuit/footprinter": "0.0.425", "@tscircuit/manifold-2d": "^0.0.8", "@tscircuit/math-utils": "^0.0.36", "circuit-json": "^0.0.472", "format-si-unit": "^0.0.14" } }, "sha512-nOdU/flh0OuUR7GfO+t3I9tB04xKiFvCLWAr99oHGxzoBFnNr22jIKr8A7iqE4bluibeh7wrlFwULiPsARy/2g=="],
 
-    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.97", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.25", "fast-json-stable-stringify": "^2.1.0", "polygon-clipping": "^0.15.7", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-i0RlmjFT6HlGczdnmU2q/Sv/rA3pL1fQu/MEBv9oFXTe5eHSTU5Xp8MjKgfJde+Oi80Sb3EbeGf6piesGs5Odg=="],
+    "circuit-json-to-gerber": ["circuit-json-to-gerber@0.0.105", "", { "dependencies": { "@tscircuit/alphabet": "^0.0.25", "fast-json-stable-stringify": "^2.1.0", "polygon-clipping": "^0.15.7", "transformation-matrix": "^3.0.0" }, "peerDependencies": { "circuit-json": "*", "tscircuit": "*", "typescript": "^5.0.0" }, "bin": { "circuit-to-gerber": "dist/cli.js" } }, "sha512-NgbiSGneJI/QcuEDCpO2Av05b+n9YoEdtE7AysK/fkE/bt9k2P1A2VxOhhZLme+EFEorCA91LWnDye1Q6hPHig=="],
 
     "circuit-json-to-gltf": ["circuit-json-to-gltf@0.0.106", "", { "dependencies": { "@jscad/modeling": "^2.12.6", "earcut": "^3.0.2", "jscad-electronics": "^0.0.135", "jscad-to-gltf": "^0.0.5", "occt-import-js": "^0.0.23" }, "peerDependencies": { "@resvg/resvg-js": "2", "@resvg/resvg-wasm": "2", "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "circuit-to-svg": "*", "typescript": "^5" }, "optionalPeers": ["@resvg/resvg-js", "@resvg/resvg-wasm"] }, "sha512-U59vURQ704QTN+PxTHn8t4c0NGgdSSrNiTNYjnsXDrxK0rhtacchd9QBD4iz6x5n15QSlhcds4dyC1AVAbB9GA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "circuit-json-to-connectivity-map": "^0.0.25",
     "circuit-json-to-fdm-component-box": "^0.0.2",
     "circuit-json-to-footprinter": "^0.0.54",
-    "circuit-json-to-gerber": "^0.0.97",
+    "circuit-json-to-gerber": "^0.0.105",
     "circuit-json-to-kicad": "0.0.181",
     "circuit-json-to-pnp-csv": "^0.0.13",
     "circuit-json-to-readable-netlist": "^0.0.15",


### PR DESCRIPTION
When multiple traces share a physical via, Circuit JSON can contain multiple via records at the same coordinates. The CLI currently resolves `circuit-json-to-gerber@0.0.97`, which can emit repeated Excellon drill operations for that single hole. This surfaced during fabrication review of an ATtiny85 arcade keychain board, where the exported ZIP drilled `(-2.4, -10.4) mm` twice.

This PR updates the CLI's exporter dependency to `^0.0.105` and refreshes `bun.lock`. It brings in the fix from https://github.com/tscircuit/circuit-json-to-gerber/pull/159: duplicate via drills are deduplicated by position, drill diameter, and physical layer span, and trace-derived fallback drills are omitted when an explicit via already covers the transition. Distinct drill sizes and physical spans remain separate.

The dependency needs updating here because the CLI bundles the Gerber exporter used by `tsci export --format gerbers`. Updating the exporter in a board project's dependencies alone does not replace the CLI's bundled implementation. After a CLI release containing this change, consumers can receive the corrected drill output by updating their CLI. Duplicate via creation in `@tscircuit/core` remains a separate issue; this update handles those records correctly during fabrication export.

Validation:

- `bun run build` — passed.
- `bun test tests/shared/export-snippet-gerber-drills.test.ts tests/shared/export-snippet-do-not-place.test.ts tests/shared/export-snippet-part-orientation.test.ts` — 3 passed, 0 failed; covers plated drill spans, NPTH files, DNP filtering, and PnP orientation.
- `git diff --check` — passed.
