### PR TITLE
Add explicit install and update commands for tscircuit AI skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Commands:
                                project
   snapshot [options] [path]    Generate schematic and PCB snapshots (add --3d
                                for 3d preview)
-  setup                        Setup utilities like GitHub Actions
+  setup                        Setup utilities like GitHub Actions and AI skills
   install [packageSpec]        Install project dependencies, or install a
                                specific package (e.g., tsci install
                                https://github.com/espressif/kicad-libraries)
@@ -71,6 +71,35 @@ Commands:
   help [command]               display help for command
 ```
 <!-- END_HELP_OUTPUT -->
+
+### Installing and updating AI skills
+
+```sh
+# Install missing copies in the current project
+tsci setup skills
+
+# Refresh project copies from the tscircuit/skill GitHub repository
+tsci setup skills --update
+
+# Refresh home-directory copies used across projects
+tsci setup skills --global --update
+```
+
+Skills are installed in `.claude/skills/tscircuit` and
+`.agents/skills/tscircuit`, relative to the current directory or your home with
+`--global`. Updates also refresh an existing `.codex/skills/tscircuit` copy used
+by older installations.
+
+Without `--update`, existing skills are left unchanged. Upgrading the CLI alone
+does not refresh installed skills.
+
+An update downloads the new skill before replacing any installation. Previous
+files, including local edits and files no longer present upstream, are preserved
+under `.tscircuit/skill-updates/<update-id>/backups/`; the command prints the
+backup path. Local edits are backed up, not merged into the new version. If a
+replacement fails, the command attempts to restore the previous installations
+and exits nonzero. If restoration also fails, the error identifies the retained
+backup directory.
 
 The `build` command also accepts the following options:
 

--- a/README.md
+++ b/README.md
@@ -72,35 +72,6 @@ Commands:
 ```
 <!-- END_HELP_OUTPUT -->
 
-### Installing and updating AI skills
-
-```sh
-# Install missing copies in the current project
-tsci setup skills
-
-# Refresh project copies from the tscircuit/skill GitHub repository
-tsci setup skills --update
-
-# Refresh home-directory copies used across projects
-tsci setup skills --global --update
-```
-
-Skills are installed in `.claude/skills/tscircuit` and
-`.agents/skills/tscircuit`, relative to the current directory or your home with
-`--global`. Updates also refresh an existing `.codex/skills/tscircuit` copy used
-by older installations.
-
-Without `--update`, existing skills are left unchanged. Upgrading the CLI alone
-does not refresh installed skills.
-
-An update downloads the new skill before replacing any installation. Previous
-files, including local edits and files no longer present upstream, are preserved
-under `.tscircuit/skill-updates/<update-id>/backups/`; the command prints the
-backup path. Local edits are backed up, not merged into the new version. If a
-replacement fails, the command attempts to restore the previous installations
-and exits nonzero. If restoration also fails, the error identifies the retained
-backup directory.
-
 The `build` command also accepts the following options:
 
 - `--ignore-errors` - continue build even if circuit JSON contains errors

--- a/cli/setup/register.ts
+++ b/cli/setup/register.ts
@@ -1,11 +1,13 @@
+import os from "node:os"
 import type { Command } from "commander"
-import { prompts } from "lib/utils/prompts"
 import { setupGithubActions } from "lib/shared/setup-github-actions"
+import { installTscircuitSkill } from "lib/shared/setup-tscircuit-skill"
+import { prompts } from "lib/utils/prompts"
 
 export const registerSetup = (program: Command) => {
-  program
+  const setup = program
     .command("setup")
-    .description("Setup utilities like GitHub Actions")
+    .description("Setup utilities like GitHub Actions and AI skills")
     .action(async () => {
       const { option } = await prompts({
         type: "select",
@@ -26,4 +28,30 @@ export const registerSetup = (program: Command) => {
         setupGithubActions()
       }
     })
+
+  setup
+    .command("skills")
+    .description("Install or update the tscircuit AI skill")
+    .option(
+      "--update",
+      "Replace installed skills with the latest version, preserving backups",
+    )
+    .option("--global", "Install or update skills in your home directory")
+    .action(
+      async (
+        options: { update?: boolean; global?: boolean },
+        command: Command,
+      ) => {
+        try {
+          await installTscircuitSkill(
+            options.global ? os.homedir() : process.cwd(),
+            {
+              update: options.update,
+            },
+          )
+        } catch (error) {
+          command.error(error instanceof Error ? error.message : String(error))
+        }
+      },
+    )
 }

--- a/lib/shared/setup-tscircuit-skill.ts
+++ b/lib/shared/setup-tscircuit-skill.ts
@@ -1,7 +1,7 @@
-import * as fs from "node:fs"
+import fs from "node:fs"
 import * as path from "node:path"
-import { prompts } from "lib/utils/prompts"
 import kleur from "kleur"
+import { prompts } from "lib/utils/prompts"
 
 interface GitHubContent {
   name: string
@@ -25,12 +25,12 @@ async function fetchGitHubContents(apiUrl: string): Promise<GitHubContent[]> {
   return response.json()
 }
 
-async function fetchFileContent(downloadUrl: string): Promise<string> {
+async function fetchFileContent(downloadUrl: string): Promise<Buffer> {
   const response = await fetch(downloadUrl)
   if (!response.ok) {
     throw new Error(`Failed to fetch ${downloadUrl}: ${response.statusText}`)
   }
-  return response.text()
+  return Buffer.from(await response.arrayBuffer())
 }
 
 async function downloadDirectory(
@@ -47,7 +47,7 @@ async function downloadDirectory(
       await downloadDirectory(`${apiUrl}/${item.name}`, targetPath)
     } else if (item.type === "file" && item.download_url) {
       const content = await fetchFileContent(item.download_url)
-      fs.writeFileSync(targetPath, content, "utf-8")
+      fs.writeFileSync(targetPath, content)
     }
   }
 }
@@ -69,8 +69,130 @@ async function downloadSkillRepo(targetDir: string): Promise<void> {
       await downloadDirectory(`${SKILL_REPO_API_URL}/${item.name}`, targetPath)
     } else if (item.type === "file" && item.download_url) {
       const content = await fetchFileContent(item.download_url)
-      fs.writeFileSync(targetPath, content, "utf-8")
+      fs.writeFileSync(targetPath, content)
     }
+  }
+}
+
+function pathExists(filePath: string): boolean {
+  return fs.lstatSync(filePath, { throwIfNoEntry: false }) !== undefined
+}
+
+function getInstallPaths(projectDir: string, update: boolean): string[] {
+  const paths = [...SKILL_INSTALL_PATHS]
+  // Older installers also used this location. Refresh it when present so it
+  // cannot continue to shadow the updated .agents copy.
+  const legacyPath = ".codex/skills/tscircuit"
+  if (update && pathExists(path.join(projectDir, legacyPath))) {
+    paths.push(legacyPath)
+  }
+  return update
+    ? paths
+    : paths.filter(
+        (skillPath) =>
+          !fs.existsSync(path.join(projectDir, skillPath, "SKILL.md")),
+      )
+}
+
+function logAlreadyInstalled() {
+  console.log(
+    "TSCircuit AI skills already exist. Run `tsci setup skills --update` " +
+      "to refresh them (add --global for home-directory installs).",
+  )
+}
+
+export async function installTscircuitSkill(
+  projectDir: string,
+  { update = false }: { update?: boolean } = {},
+): Promise<void> {
+  const installPaths = getInstallPaths(projectDir, update)
+  if (installPaths.length === 0) {
+    logAlreadyInstalled()
+    return
+  }
+
+  const updatesDir = path.join(projectDir, ".tscircuit", "skill-updates")
+  fs.mkdirSync(updatesDir, { recursive: true })
+  const stagingDir = fs.mkdtempSync(path.join(updatesDir, "update-"))
+  const downloadDir = path.join(stagingDir, "download")
+  const backupsDir = path.join(stagingDir, "backups")
+  const replacementsDir = path.join(stagingDir, "replacements")
+  const applied: Array<{
+    targetDir: string
+    backupDir?: string
+    installed: boolean
+  }> = []
+
+  try {
+    // Complete the download and prepare every replacement before moving any
+    // installed files. A failed request must not leave a partial installation.
+    await downloadSkillRepo(downloadDir)
+    if (
+      !fs
+        .statSync(path.join(downloadDir, "SKILL.md"), { throwIfNoEntry: false })
+        ?.isFile()
+    ) {
+      throw new Error("Downloaded skill repository does not contain SKILL.md")
+    }
+    for (const skillPath of installPaths) {
+      fs.cpSync(downloadDir, path.join(replacementsDir, skillPath), {
+        recursive: true,
+      })
+    }
+
+    for (const skillPath of installPaths) {
+      const targetDir = path.join(projectDir, skillPath)
+      fs.mkdirSync(path.dirname(targetDir), { recursive: true })
+      const backupDir = pathExists(targetDir)
+        ? path.join(backupsDir, skillPath)
+        : undefined
+      if (backupDir) {
+        fs.mkdirSync(path.dirname(backupDir), { recursive: true })
+        fs.renameSync(targetDir, backupDir)
+      }
+      const entry = { targetDir, backupDir, installed: false }
+      applied.push(entry)
+      fs.renameSync(path.join(replacementsDir, skillPath), targetDir)
+      entry.installed = true
+    }
+  } catch (error) {
+    const rollbackErrors: unknown[] = []
+    for (const entry of applied.reverse()) {
+      try {
+        if (entry.installed) fs.rmSync(entry.targetDir, { recursive: true })
+        if (entry.backupDir) fs.renameSync(entry.backupDir, entry.targetDir)
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError)
+      }
+    }
+    if (rollbackErrors.length) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        `Skill update failed and could not be fully restored. Backups: ${backupsDir}`,
+      )
+    }
+    throw error
+  } finally {
+    fs.rmSync(downloadDir, { recursive: true, force: true })
+    fs.rmSync(replacementsDir, { recursive: true, force: true })
+    // Keep backups outside the skill discovery directories. Never delete an
+    // original installation left here after a failed rollback.
+    if (
+      !applied.some((entry) => entry.backupDir && pathExists(entry.backupDir))
+    ) {
+      fs.rmSync(stagingDir, { recursive: true, force: true })
+    }
+  }
+
+  for (const skillPath of installPaths) {
+    console.info(
+      `tscircuit skill ${update ? "updated" : "installed"} at ${path.join(projectDir, skillPath)}`,
+    )
+  }
+  if (applied.some((entry) => entry.backupDir)) {
+    console.info(
+      `Previous skill files, including local edits, saved at ${backupsDir}`,
+    )
   }
 }
 
@@ -78,12 +200,8 @@ export async function setupTscircuitSkill(
   projectDir: string,
   skipPrompt = false,
 ): Promise<boolean> {
-  const missingSkillPaths = SKILL_INSTALL_PATHS.filter(
-    (skillPath) => !fs.existsSync(path.join(projectDir, skillPath, "SKILL.md")),
-  )
-
-  if (missingSkillPaths.length === 0) {
-    console.log("TSCircuit AI skills already exist, skipping...")
+  if (getInstallPaths(projectDir, false).length === 0) {
+    logAlreadyInstalled()
     return true
   }
 
@@ -95,7 +213,6 @@ export async function setupTscircuitSkill(
         "Would you like to set up tscircuit AI skills for enhanced AI assistance?",
       initial: true,
     })
-
     if (!setupSkill) {
       console.log("Skipping tscircuit skill setup.")
       return false
@@ -103,13 +220,8 @@ export async function setupTscircuitSkill(
   }
 
   console.info("Setting up tscircuit AI skills...")
-
   try {
-    for (const skillPath of missingSkillPaths) {
-      const targetDir = path.join(projectDir, skillPath)
-      await downloadSkillRepo(targetDir)
-      console.info(`tscircuit skill installed at ${skillPath}`)
-    }
+    await installTscircuitSkill(projectDir)
     return true
   } catch (error) {
     const errorMessage =

--- a/tests/cli/setup/skills.test.ts
+++ b/tests/cli/setup/skills.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { registerSetup } from "cli/setup/register"
+import { Command } from "commander"
+import {
+  installTscircuitSkill,
+  setupTscircuitSkill,
+} from "lib/shared/setup-tscircuit-skill"
+import { temporaryDirectory } from "tempy"
+
+const apiUrl = "https://api.github.com/repos/tscircuit/skill/contents"
+const installPaths = [".claude/skills/tscircuit", ".agents/skills/tscircuit"]
+const legacyPath = ".codex/skills/tscircuit"
+const binaryAsset = new Uint8Array([0, 255, 128, 42])
+let tmpDir: string
+let responses: Map<string, () => Response>
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">>
+
+function writeInstalled(skillPath: string, content = "old skill") {
+  const target = path.join(tmpDir, skillPath)
+  fs.mkdirSync(target, { recursive: true })
+  fs.writeFileSync(path.join(target, "SKILL.md"), content)
+  fs.writeFileSync(path.join(target, "local-notes.md"), "local edits")
+}
+
+function readSkill(skillPath: string) {
+  return fs.readFileSync(path.join(tmpDir, skillPath, "SKILL.md"), "utf8")
+}
+
+beforeEach(() => {
+  tmpDir = temporaryDirectory()
+  responses = new Map([
+    [
+      apiUrl,
+      () =>
+        Response.json([
+          {
+            name: "SKILL.md",
+            type: "file",
+            download_url: "https://fixture.test/skill",
+          },
+          {
+            name: "FOOTPRINTS.md",
+            type: "file",
+            download_url: "https://fixture.test/footprints",
+          },
+          { name: "assets", type: "dir", download_url: null },
+          { name: ".github", type: "dir", download_url: null },
+        ]),
+    ],
+    ["https://fixture.test/skill", () => new Response("new skill")],
+    [
+      "https://fixture.test/footprints",
+      () => new Response("Use footprint strings"),
+    ],
+    [
+      `${apiUrl}/assets`,
+      () =>
+        Response.json([
+          {
+            name: "image.png",
+            type: "file",
+            download_url: "https://fixture.test/image",
+          },
+        ]),
+    ],
+    ["https://fixture.test/image", () => new Response(binaryAsset)],
+  ])
+  const mockFetch = Object.assign(
+    async (input: Parameters<typeof fetch>[0]) => {
+      const url = input instanceof Request ? input.url : String(input)
+      return (
+        responses.get(url)?.() ?? new Response("Not found", { status: 404 })
+      )
+    },
+    { preconnect: globalThis.fetch.preconnect },
+  )
+  fetchSpy = spyOn(globalThis, "fetch").mockImplementation(mockFetch)
+})
+
+afterEach(() => {
+  fetchSpy.mockRestore()
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+test("installs a complete skill in both locations and preserves binary assets", async () => {
+  await installTscircuitSkill(tmpDir)
+  for (const skillPath of installPaths) {
+    expect(readSkill(skillPath)).toBe("new skill")
+    expect(
+      fs.readFileSync(path.join(tmpDir, skillPath, "assets/image.png")),
+    ).toEqual(Buffer.from(binaryAsset))
+    expect(fs.existsSync(path.join(tmpDir, skillPath, ".github"))).toBe(false)
+  }
+  expect(fetchSpy.mock.calls.filter(([url]) => url === apiUrl)).toHaveLength(1)
+  expect(fs.readdirSync(path.join(tmpDir, ".tscircuit/skill-updates"))).toEqual(
+    [],
+  )
+  expect(fs.existsSync(path.join(tmpDir, legacyPath))).toBe(false)
+})
+
+test("init preserves existing installs and explains how to update without fetching", async () => {
+  for (const skillPath of installPaths) writeInstalled(skillPath)
+  const log = spyOn(console, "log").mockImplementation(() => {})
+  try {
+    expect(await setupTscircuitSkill(tmpDir, true)).toBe(true)
+    for (const skillPath of installPaths)
+      expect(readSkill(skillPath)).toBe("old skill")
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(log.mock.calls.flat().join(" ")).toContain(
+      "tsci setup skills --update",
+    )
+  } finally {
+    log.mockRestore()
+  }
+})
+
+test("fills a missing install without changing the existing copy", async () => {
+  writeInstalled(installPaths[0], "custom skill")
+  await installTscircuitSkill(tmpDir)
+  expect(readSkill(installPaths[0])).toBe("custom skill")
+  expect(readSkill(installPaths[1])).toBe("new skill")
+})
+
+test("update refreshes existing and legacy copies and backs up all local files", async () => {
+  const paths = [...installPaths, legacyPath]
+  for (const skillPath of paths) writeInstalled(skillPath)
+  await installTscircuitSkill(tmpDir, { update: true })
+  const updatesDir = path.join(tmpDir, ".tscircuit/skill-updates")
+  const runs = fs.readdirSync(updatesDir)
+  expect(runs).toHaveLength(1)
+  const runDir = path.join(updatesDir, runs[0])
+  expect(fs.readdirSync(runDir)).toEqual(["backups"])
+  for (const skillPath of paths) {
+    expect(readSkill(skillPath)).toBe("new skill")
+    expect(
+      fs.readFileSync(path.join(tmpDir, skillPath, "FOOTPRINTS.md"), "utf8"),
+    ).toBe("Use footprint strings")
+    expect(fs.existsSync(path.join(tmpDir, skillPath, "local-notes.md"))).toBe(
+      false,
+    )
+    const backup = path.join(runDir, "backups", skillPath)
+    expect(fs.readFileSync(path.join(backup, "SKILL.md"), "utf8")).toBe(
+      "old skill",
+    )
+    expect(fs.readFileSync(path.join(backup, "local-notes.md"), "utf8")).toBe(
+      "local edits",
+    )
+  }
+})
+
+test("a failed download leaves every installed copy untouched", async () => {
+  for (const skillPath of installPaths) writeInstalled(skillPath)
+  responses.set(
+    "https://fixture.test/footprints",
+    () => new Response("Unavailable", { status: 503 }),
+  )
+  await expect(installTscircuitSkill(tmpDir, { update: true })).rejects.toThrow(
+    "Failed to fetch",
+  )
+  for (const skillPath of installPaths)
+    expect(readSkill(skillPath)).toBe("old skill")
+  expect(fs.readdirSync(path.join(tmpDir, ".tscircuit/skill-updates"))).toEqual(
+    [],
+  )
+})
+
+test("a download without SKILL.md cannot replace an installed skill", async () => {
+  for (const skillPath of installPaths) writeInstalled(skillPath)
+  responses.set(apiUrl, () => Response.json([]))
+  await expect(installTscircuitSkill(tmpDir, { update: true })).rejects.toThrow(
+    "does not contain SKILL.md",
+  )
+  for (const skillPath of installPaths)
+    expect(readSkill(skillPath)).toBe("old skill")
+})
+
+test("a replacement failure rolls back copies already updated", async () => {
+  for (const skillPath of installPaths) writeInstalled(skillPath)
+  const originalRename = fs.renameSync
+  let injectedFailure = false
+  const rename = spyOn(fs, "renameSync").mockImplementation((from, to) => {
+    if (
+      !injectedFailure &&
+      String(from).includes("replacements") &&
+      to === path.join(tmpDir, installPaths[1])
+    ) {
+      injectedFailure = true
+      throw new Error("simulated rename failure")
+    }
+    return originalRename(from, to)
+  })
+  try {
+    await expect(
+      installTscircuitSkill(tmpDir, { update: true }),
+    ).rejects.toThrow("simulated rename failure")
+    expect(injectedFailure).toBe(true)
+    for (const skillPath of installPaths)
+      expect(readSkill(skillPath)).toBe("old skill")
+    expect(
+      fs.readdirSync(path.join(tmpDir, ".tscircuit/skill-updates")),
+    ).toEqual([])
+  } finally {
+    rename.mockRestore()
+  }
+})
+
+test("setup skills --global --update targets home, including the legacy Codex copy", async () => {
+  writeInstalled(legacyPath)
+  const home = spyOn(os, "homedir").mockReturnValue(tmpDir)
+  // Guard the write boundary as well as mocking home resolution: a broken
+  // mock must never turn this test into a real home-directory installation.
+  const originalMkdir = fs.mkdirSync
+  const mkdir = spyOn(fs, "mkdirSync").mockImplementation(
+    (...args: Parameters<typeof fs.mkdirSync>) => {
+      expect(
+        path.resolve(String(args[0])).startsWith(`${tmpDir}${path.sep}`),
+      ).toBe(true)
+      return originalMkdir(...args)
+    },
+  )
+  try {
+    const program = new Command()
+    registerSetup(program)
+    await program.parseAsync(["setup", "skills", "--global", "--update"], {
+      from: "user",
+    })
+    for (const skillPath of [...installPaths, legacyPath])
+      expect(readSkill(skillPath)).toBe("new skill")
+  } finally {
+    home.mockRestore()
+    mkdir.mockRestore()
+  }
+})
+
+test("explicit setup command fails on download errors instead of continuing init", async () => {
+  const cwd = spyOn(process, "cwd").mockReturnValue(tmpDir)
+  responses.set(apiUrl, () => new Response("Unavailable", { status: 503 }))
+  try {
+    const program = new Command()
+      .exitOverride()
+      .configureOutput({ writeErr: () => {} })
+    registerSetup(program)
+    await expect(
+      program.parseAsync(["setup", "skills"], { from: "user" }),
+    ).rejects.toMatchObject({ exitCode: 1 })
+    for (const skillPath of installPaths)
+      expect(fs.existsSync(path.join(tmpDir, skillPath))).toBe(false)
+  } finally {
+    cwd.mockRestore()
+  }
+})
+
+test("keeps original backups when a failed replacement cannot be rolled back", async () => {
+  for (const skillPath of installPaths) writeInstalled(skillPath)
+  const originalRename = fs.renameSync
+  const rename = spyOn(fs, "renameSync").mockImplementation((from, to) => {
+    if (String(from).includes("replacements"))
+      throw new Error("replacement failed")
+    if (String(from).includes("backups")) throw new Error("restore failed")
+    return originalRename(from, to)
+  })
+  try {
+    await expect(
+      installTscircuitSkill(tmpDir, { update: true }),
+    ).rejects.toThrow("could not be fully restored. Backups:")
+    const updatesDir = path.join(tmpDir, ".tscircuit/skill-updates")
+    const [run] = fs.readdirSync(updatesDir)
+    const backup = path.join(updatesDir, run, "backups", installPaths[0])
+    expect(fs.readFileSync(path.join(backup, "SKILL.md"), "utf8")).toBe(
+      "old skill",
+    )
+    expect(fs.readFileSync(path.join(backup, "local-notes.md"), "utf8")).toBe(
+      "local edits",
+    )
+    expect(readSkill(installPaths[1])).toBe("old skill")
+  } finally {
+    rename.mockRestore()
+  }
+})
+
+test("preserves a relative skill symlink in the backup without modifying its source", async () => {
+  const customDir = path.join(tmpDir, "custom-skill")
+  fs.mkdirSync(customDir)
+  fs.writeFileSync(path.join(customDir, "SKILL.md"), "custom skill")
+  const target = path.join(tmpDir, installPaths[0])
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.symlinkSync("../../custom-skill", target, "dir")
+  await installTscircuitSkill(tmpDir, { update: true })
+  expect(readSkill(installPaths[0])).toBe("new skill")
+  expect(fs.readFileSync(path.join(customDir, "SKILL.md"), "utf8")).toBe(
+    "custom skill",
+  )
+  const updatesDir = path.join(tmpDir, ".tscircuit/skill-updates")
+  const [run] = fs.readdirSync(updatesDir)
+  const backup = path.join(updatesDir, run, "backups", installPaths[0])
+  expect(fs.lstatSync(backup).isSymbolicLink()).toBe(true)
+  expect(fs.readlinkSync(backup)).toBe("../../custom-skill")
+})


### PR DESCRIPTION
An existing tscircuit skill installation never receives newer guidance: `tsci init` checks for `SKILL.md` and skips directories that already contain it. Upgrading the CLI does not refresh those files, even though the installer downloads from the current `tscircuit/skill` repository.

This surfaced during a SparkFun INA237 board conversion. The installed skills lacked the newer guidance to prefer standard footprint strings such as `footprint="0603"`, and the AI created a manual `Capacitor0603Footprint` instead. Updating the upstream skill alone cannot help users whose installed copies remain unchanged. This PR provides an explicit way to refresh that guidance.

The new command supports:

- `tsci setup skills`: install missing project copies while preserving existing installations.
- `tsci setup skills --update`: refresh project installations from `tscircuit/skill`.
- `tsci setup skills --global --update`: refresh home-directory installations.

Updates cover `.claude/skills/tscircuit` and `.agents/skills/tscircuit`, plus an existing legacy `.codex/skills/tscircuit` copy so it cannot retain stale instructions. The existing init flow remains install-only and now prints an update hint when skills are already installed.

The installer downloads the complete skill once, validates that `SKILL.md` exists, and prepares all replacements before modifying installed copies. It preserves previous files, including local edits, under `.tscircuit/skill-updates/<update-id>/backups/` and prints that location. Local edits are backed up rather than merged. Replacement failures trigger rollback; if rollback also fails, the original backups are retained and the error identifies their location. The explicit command exits nonzero on failure. Downloads also preserve binary assets instead of decoding them as text.

Validation:

- `bun test tests/cli/setup`: 12 passing tests, 67 assertions covering installation, update, legacy copies, binary assets, download failures, rollback, backup retention, symlinks, and CLI options/error handling.
- `bun run build`: passed.
- Biome checks on changed TypeScript files and `git diff --check`: passed.
- Ran the real global updater and verified that all three installed copies have matching `SKILL.md` and `FOOTPRINTS.md` files, the standard-footprint guidance is present, and previous copies are backed up.
- `bunx tsc --noEmit`: fails on `CircuitJson` connector-standard type mismatches in unchanged `lib/shared/export-snippet.ts` and `tests/cli/export/export-component-box-3mf.test.ts`; no diagnostics in the changed files.
