### PR TITLE
Update CLI analyzer dependency for two-pad LED fabrication exports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@tscircuit/circuit-json-placement-analysis": "^0.0.9",
         "@tscircuit/circuit-json-routing-analysis": "^0.0.8",
         "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#db2cd1ca2ce51490e3230e53c3d7b361eeb14446",
-        "@tscircuit/circuit-json-util": "^0.0.112",
+        "@tscircuit/circuit-json-util": "^0.0.113",
         "@tscircuit/eval": "^0.0.1016",
         "@tscircuit/fake-snippets": "^0.0.182",
         "@tscircuit/file-server": "^0.0.32",
@@ -400,7 +400,7 @@
 
     "@tscircuit/circuit-json-schematic-placement-analysis": ["@tscircuit/circuit-json-schematic-placement-analysis@github:tscircuit/circuit-json-schematic-placement-analysis#db2cd1c", { "dependencies": { "@tscircuit/circuit-json-util": "^0.0.94" }, "peerDependencies": { "circuit-json": "*", "typescript": "^5" } }, "tscircuit-circuit-json-schematic-placement-analysis-db2cd1c", "sha512-nKAqBijEMIHwsU5+4lq3TS26TU+wy0oB/cyaoW3HTNRzFMHSDhM0artGNxu2FrLx9/YABeIBe9C8x0OWwF9SIg=="],
 
-    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.112", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-3NvAa6VWWJ1W+7y/9Pf5/nn82sdq97ON++Dr66oyoyXdu6qkZY51wKqh019WHZHSAUoVudHaR78C7KZ5pH5GlA=="],
+    "@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.113", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-1KliGS0RMvhWz9tl00gtIlFHxGG5OYfLlBvSrid2muFkWox3ZH/zSKKd9sbaB75clnJEBXJd+WFQ0oAhAPQNxw=="],
 
     "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.39", "", { "dependencies": { "@tscircuit/manifold-2d": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Z8+3UrK919QbwJkGyHsb8DGuHqE66iCylpbF/v132PuvrRbHo+phmOfP9nEQjI63ldh976EsT26qw535H15M1g=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@tscircuit/circuit-json-placement-analysis": "^0.0.9",
     "@tscircuit/circuit-json-routing-analysis": "^0.0.8",
     "@tscircuit/circuit-json-schematic-placement-analysis": "github:tscircuit/circuit-json-schematic-placement-analysis#db2cd1ca2ce51490e3230e53c3d7b361eeb14446",
-    "@tscircuit/circuit-json-util": "^0.0.112",
+    "@tscircuit/circuit-json-util": "^0.0.113",
     "@tscircuit/eval": "^0.0.1016",
     "@tscircuit/fake-snippets": "^0.0.182",
     "@tscircuit/file-server": "^0.0.32",


### PR DESCRIPTION
Update `@tscircuit/circuit-json-util` from 0.0.112 to the published 0.0.113 release and refresh its Bun lockfile entry. This adopts https://github.com/tscircuit/circuit-json-util/pull/164, which enables consistent pin-1 frames for two-pad LEDs and diodes. The CLI already requests JLCPCB supplier rotation correction and uses PnP converter 0.0.13.

Validation: both fabrication export tests (supplier rotation and drill output) pass; repository-wide formatting passes. Lockfile changes are limited to this dependency.

Coordinate with https://github.com/tscircuit/core/pull/3802 and downstream eval/tscircuit releases: bundled evaluators and existing cached orientation results also need those releases. This PR does not change raw Circuit JSON inputs or claim to regenerate missing orientation metadata.