### PR TITLE
Update Altium exporter to support component-exempt keepouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "chokidar": "4.0.1",
         "circuit-json": "^0.0.480",
         "circuit-json-to-3d-png": "^0.0.6",
-        "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#5bdb7d235ef896ddf9ac5c4f315c4d0ce07fdfb5",
+        "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#1a50d0dd2c0737cf940d92c0315852dc0111dd87",
         "circuit-json-to-bom-csv": "^0.0.17",
         "circuit-json-to-connectivity-map": "^0.0.25",
         "circuit-json-to-fdm-component-box": "^0.0.2",
@@ -580,7 +580,7 @@
 
     "circuit-json-to-3d-png": ["circuit-json-to-3d-png@0.0.6", "", { "dependencies": { "@resvg/resvg-js": "^2.6.2", "poppygl": "^0.0.24" }, "peerDependencies": { "circuit-json": "*", "circuit-json-to-gltf": "*", "typescript": "^5" } }, "sha512-zZSnhIjZrJGG9ITWvSlWRKSY/dksIPkggZQyaVaHv1No5o8uG0l0HsZlcwx+vtoN1bIdm8GVp8dSRKIza63JOA=="],
 
-    "circuit-json-to-altium": ["circuit-json-to-altium@github:tscircuit/circuit-json-to-altium#5bdb7d2", { "dependencies": { "altiumts": "github:tscircuit/altiumts#6c8af3de0e50c7d918f7f2bf43cca5af604cf9cc", "cfb": "^1.2.2", "circuit-json": "^0.0.480", "color-string": "2.1.4", "jszip": "^3.10.1", "schematic-symbols": "^0.0.239", "transformation-matrix": "^3.1.0" } }, "tscircuit-circuit-json-to-altium-5bdb7d2", "sha512-4FBJFzmPMacUp/PC4DFNKGM03CcBFpO1C3a4ClWosKgbbByYxFMHrd8SlrenGbcx40Sc0EHAQmwr68LrB63E1A=="],
+    "circuit-json-to-altium": ["circuit-json-to-altium@github:tscircuit/circuit-json-to-altium#1a50d0d", { "dependencies": { "altiumts": "github:tscircuit/altiumts#6da231316118720feead2ebd4ff2dd5f71f8c8a9", "cfb": "^1.2.2", "circuit-json": "^0.0.480", "color-string": "2.1.4", "jszip": "^3.10.1", "schematic-symbols": "^0.0.239", "transformation-matrix": "^3.1.0" } }, "tscircuit-circuit-json-to-altium-1a50d0d", "sha512-J2+YNSQpzZ2ft030DPhgYmznvaWTbMHIPaSlzXGKuledSGYBl8qBdbDcfCHzdIH/2nSndSbUhr/Dz4ZdPVKlfQ=="],
 
     "circuit-json-to-bom-csv": ["circuit-json-to-bom-csv@0.0.17", "", { "dependencies": { "format-si-prefix": "^0.3.2", "lucide-react": "^1.23.0", "papaparse": "^5.4.1", "react": "^19.2.7", "react-dom": "^19.2.7" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-g45JJzGnYz5aM+B9CtFZpPTAlqfcC0Yr/SeeOmOyr/9I2qDk0jkCmmAv4hyKVyrZUOYuTRDVeFQLBvdLkAeL9w=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chokidar": "4.0.1",
     "circuit-json": "^0.0.480",
     "circuit-json-to-3d-png": "^0.0.6",
-    "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#5bdb7d235ef896ddf9ac5c4f315c4d0ce07fdfb5",
+    "circuit-json-to-altium": "github:tscircuit/circuit-json-to-altium#1a50d0dd2c0737cf940d92c0315852dc0111dd87",
     "circuit-json-to-bom-csv": "^0.0.17",
     "circuit-json-to-connectivity-map": "^0.0.25",
     "circuit-json-to-fdm-component-box": "^0.0.2",

--- a/tests/cli/export/export-altium-circuit-json.test.ts
+++ b/tests/cli/export/export-altium-circuit-json.test.ts
@@ -4,7 +4,7 @@ import path from "node:path"
 import JSZip from "jszip"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
-test("export Circuit JSON to a custom Altium archive path", async () => {
+test("export Circuit JSON with a component-exempt keepout to a custom Altium archive path", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "board.circuit.json")
   await writeFile(
@@ -20,6 +20,32 @@ test("export Circuit JSON to a custom Altium archive path", async () => {
         material: "fr4",
         thickness: 1.4,
       },
+      {
+        type: "source_component",
+        source_component_id: "source_component_0",
+        ftype: "simple_chip",
+        name: "U2",
+      },
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb_component_0",
+        source_component_id: "source_component_0",
+        center: { x: 0, y: 0 },
+        width: 2,
+        height: 2,
+        rotation: 0,
+        layer: "top",
+      },
+      {
+        type: "pcb_keepout",
+        pcb_keepout_id: "pcb_keepout_4",
+        shape: "rect",
+        center: { x: 0, y: 0 },
+        width: 3,
+        height: 3,
+        layers: ["top", "bottom"],
+        excluded_pcb_component_ids: ["pcb_component_0"],
+      },
     ]),
   )
   const { exitCode, stderr } = await runCommand(
@@ -30,7 +56,11 @@ test("export Circuit JSON to a custom Altium archive path", async () => {
   const zip = await JSZip.loadAsync(
     await readFile(path.join(tmpDir, "custom.zip")),
   )
-  expect(zip.file("board.circuit.PcbDoc")).not.toBeNull()
+  const pcbBytes = await zip.file("board.circuit.PcbDoc")!.async("uint8array")
+  const pcbText = new TextDecoder("latin1").decode(pcbBytes)
+  expect(pcbText).toContain("RULEKIND=Clearance")
+  expect(pcbText).toContain("SCOPE1EXPRESSION=IsKeepOut And InUnion(1)")
+  expect(pcbText).toContain("SCOPE2EXPRESSION=InComponent('U2')")
   expect(zip.file("board.circuit.PrjPcb")).not.toBeNull()
   expect(zip.file("board.circuit.SchDoc")).not.toBeNull()
 }, 60_000)


### PR DESCRIPTION
`tsci export -f altium` still pins an exporter revision that aborts when a keepout has `excluded_pcb_component_ids`, including the ESP-12E/U2 keepout in fitness_watch.

Update `circuit-json-to-altium` from `5bdb7d2` to merged commit `1a50d0dd2c0737cf940d92c0315852dc0111dd87` from https://github.com/tscircuit/circuit-json-to-altium/pull/146 and regenerate `bun.lock`. Keep the existing `altiumts@0.0.59` override. Extend the Circuit JSON CLI export test with a component-exempt keepout and assert that the native clearance rule and component scope appear in the exported PCB.

Validation:
- Both Altium CLI tests pass, covering TSX export and Circuit JSON export to a custom ZIP path.
- `bun run build` passes.
- The built `dist/cli/main.js` successfully exports the published fitness_watch Circuit JSON.
- Changed-file formatting and `git diff --check` pass.

This adopts the merged exporter behavior; it does not establish Altium Designer DRC/routing semantics beyond the verification described in the upstream PR. Users receive the update after this change is merged and included in a CLI release.