### PR TITLE
Remove test changes introduced with Altium dependency update

### DIFF
--- a/tests/cli/export/export-altium-circuit-json.test.ts
+++ b/tests/cli/export/export-altium-circuit-json.test.ts
@@ -4,7 +4,7 @@ import path from "node:path"
 import JSZip from "jszip"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
-test("export Circuit JSON with a component-exempt keepout to a custom Altium archive path", async () => {
+test("export Circuit JSON to a custom Altium archive path", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
   const circuitPath = path.join(tmpDir, "board.circuit.json")
   await writeFile(
@@ -20,32 +20,6 @@ test("export Circuit JSON with a component-exempt keepout to a custom Altium arc
         material: "fr4",
         thickness: 1.4,
       },
-      {
-        type: "source_component",
-        source_component_id: "source_component_0",
-        ftype: "simple_chip",
-        name: "U2",
-      },
-      {
-        type: "pcb_component",
-        pcb_component_id: "pcb_component_0",
-        source_component_id: "source_component_0",
-        center: { x: 0, y: 0 },
-        width: 2,
-        height: 2,
-        rotation: 0,
-        layer: "top",
-      },
-      {
-        type: "pcb_keepout",
-        pcb_keepout_id: "pcb_keepout_4",
-        shape: "rect",
-        center: { x: 0, y: 0 },
-        width: 3,
-        height: 3,
-        layers: ["top", "bottom"],
-        excluded_pcb_component_ids: ["pcb_component_0"],
-      },
     ]),
   )
   const { exitCode, stderr } = await runCommand(
@@ -56,11 +30,7 @@ test("export Circuit JSON with a component-exempt keepout to a custom Altium arc
   const zip = await JSZip.loadAsync(
     await readFile(path.join(tmpDir, "custom.zip")),
   )
-  const pcbBytes = await zip.file("board.circuit.PcbDoc")!.async("uint8array")
-  const pcbText = new TextDecoder("latin1").decode(pcbBytes)
-  expect(pcbText).toContain("RULEKIND=Clearance")
-  expect(pcbText).toContain("SCOPE1EXPRESSION=IsKeepOut And InUnion(1)")
-  expect(pcbText).toContain("SCOPE2EXPRESSION=InComponent('U2')")
+  expect(zip.file("board.circuit.PcbDoc")).not.toBeNull()
   expect(zip.file("board.circuit.PrjPcb")).not.toBeNull()
   expect(zip.file("board.circuit.SchDoc")).not.toBeNull()
 }, 60_000)


### PR DESCRIPTION
Restore the existing Circuit JSON Altium export test to its state before #4694, as requested. The merged exporter dependency update remains in place.