### PR TITLE
fix: bind converted KiCad reference text to the instance name

### DIFF
--- a/cli/convert/convert-kicad-footprint-to-tsx.ts
+++ b/cli/convert/convert-kicad-footprint-to-tsx.ts
@@ -15,11 +15,25 @@ export const convertKicadFootprintToTsx = async ({
 }) => {
   const circuitJson = await convertKicadFootprintToCircuitJson(inputPath)
   const componentName = name ?? path.basename(inputPath, ".kicad_mod")
-  const tsx = convertCircuitJsonToTscircuit(circuitJson, { componentName })
+  const rawTsx = convertCircuitJsonToTscircuit(circuitJson, { componentName })
+  const tsx = bindKicadReferenceText(rawTsx)
   const outputPath = output
     ? path.resolve(output)
     : path.join(path.dirname(inputPath), `${componentName}.tsx`)
 
   await fs.writeFile(outputPath, tsx)
   console.log(kleur.green(`Converted ${outputPath}`))
+}
+
+// KiCad footprints use the literal "REF**" as the placeholder text of the
+// fp_text reference field. Bind that label to the component instance name so
+// each placed instance prints its own reference designator instead of
+// "REF**". Ordinary user text stays literal.
+const bindKicadReferenceText = (tsx: string) => {
+  // Only rewrite when the generated component has `props` in scope
+  if (!tsx.includes("(props:")) return tsx
+  return tsx.replaceAll(
+    /(<silkscreentext\b[^>]*?)text="REF\*\*"/g,
+    '$1text={props.name ?? "REF**"}',
+  )
 }

--- a/tests/cli/convert/convert-kicad-mod-reference-e2e.test.ts
+++ b/tests/cli/convert/convert-kicad-mod-reference-e2e.test.ts
@@ -1,0 +1,43 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readFile } from "node:fs/promises"
+import path from "node:path"
+
+const kicadMod = `(footprint "TwoPad"
+ (version 20240108)
+ (generator "pcbnew")
+ (layer "F.Cu")
+ (attr smd)
+ (fp_text reference "REF**" (at 0 -2) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+ (pad "1" smd rect (at -0.8 0) (size 0.9 1) (layers "F.Cu" "F.Paste" "F.Mask"))
+ (pad "2" smd rect (at 0.8 0) (size 0.9 1) (layers "F.Cu" "F.Paste" "F.Mask"))
+)
+`
+
+test("e2e: converted footprint prints instance reference designators", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const modPath = path.join(tmpDir, "two-pad.kicad_mod")
+  await writeFile(modPath, kicadMod)
+  await runCommand(`tsci convert ${modPath} --name TwoPad`)
+  await writeFile(
+    path.join(tmpDir, "board.tsx"),
+    `import { TwoPad } from "./TwoPad"
+export default () => (
+  <board width="12mm" height="8mm">
+    <TwoPad name="U1" pcbX={-3} schX={-2} />
+    <TwoPad name="U2" pcbX={3} schX={2} />
+  </board>
+)
+`,
+  )
+  const { exitCode } = await runCommand(`tsci build board.tsx`)
+  expect(exitCode).toBe(0)
+  const circuitJson = JSON.parse(
+    await readFile(path.join(tmpDir, "dist", "board", "circuit.json"), "utf-8"),
+  )
+  const texts = circuitJson
+    .filter((e: any) => e.type === "pcb_silkscreen_text")
+    .map((e: any) => e.text)
+    .sort()
+  expect(texts).toEqual(["U1", "U2"])
+}, 30000)

--- a/tests/cli/convert/convert-kicad-mod-reference-text.test.ts
+++ b/tests/cli/convert/convert-kicad-mod-reference-text.test.ts
@@ -1,0 +1,33 @@
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+import { test, expect } from "bun:test"
+import { writeFile, readFile } from "node:fs/promises"
+import path from "node:path"
+
+// https://github.com/tscircuit/cli/issues/4708
+const kicadMod = `(footprint "TwoPad"
+ (version 20240108)
+ (generator "pcbnew")
+ (layer "F.Cu")
+ (attr smd)
+ (fp_text reference "REF**" (at 0 -2) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+ (fp_text user "KEEPME" (at 0 2) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+ (pad "1" smd rect (at -0.8 0) (size 0.9 1) (layers "F.Cu" "F.Paste" "F.Mask"))
+ (pad "2" smd rect (at 0.8 0) (size 0.9 1) (layers "F.Cu" "F.Paste" "F.Mask"))
+)
+`
+
+test("convert binds the KiCad reference placeholder to the instance name", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  const modPath = path.join(tmpDir, "two-pad.kicad_mod")
+  await writeFile(modPath, kicadMod)
+
+  const { stderr, exitCode } = await runCommand(`tsci convert ${modPath}`)
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe("")
+
+  const tsx = await readFile(path.join(tmpDir, "two-pad.tsx"), "utf-8")
+  // The reference placeholder becomes instance-aware...
+  expect(tsx).toContain('text={props.name ?? "REF**"}')
+  // ...while ordinary user text stays literal
+  expect(tsx).toContain('text="KEEPME"')
+})


### PR DESCRIPTION
Fixes #4708.

## Problem
`tsci convert` copies the KiCad `fp_text reference` placeholder into a literal `text="REF**"`, so every placed instance of the converted footprint prints "REF**" instead of its reference designator.

## Fix
After `convertCircuitJsonToTscircuit` runs, the KiCad reference placeholder (`text="REF**"` on a `silkscreentext`) is rebound to the component instance: `text={props.name ?? "REF**"}`. Ordinary user text stays literal, and the rewrite only applies when the generated component has `props` in scope.

Kept this in the CLI's convert path since the placeholder is a KiCad artifact known at conversion time; happy to move it into `circuit-json-to-tscircuit` if you'd rather handle it there.

## Tests
- `convert-kicad-mod-reference-text.test.ts`: converts the issue's two-pad `.kicad_mod` plus an `fp_text user` control - asserts the reference placeholder is rebound and user text stays literal.
- `convert-kicad-mod-reference-e2e.test.ts`: builds a board with two instances (U1, U2) and asserts the emitted `pcb_silkscreen_text` values are exactly `["U1", "U2"]` (the issue's failing scenario).

Full `tests/cli/convert` suite passes.
