### PR TITLE
Compare SVG snapshot pixels instead of raw bytes

### DIFF
--- a/lib/shared/compare-images.ts
+++ b/lib/shared/compare-images.ts
@@ -1,5 +1,6 @@
 import looksSame from "@tscircuit/image-utils/looks-same"
 import fs from "node:fs/promises"
+import { convertSvgToPngBuffer } from "./convert-svg-to-png"
 
 export const compareAndCreateDiff = async (
   buffer1: Uint8Array,
@@ -7,8 +8,19 @@ export const compareAndCreateDiff = async (
   diffPath: string,
   createDiff = true,
 ): Promise<{ equal: boolean }> => {
-  const b1 = Buffer.from(buffer1)
-  const b2 = Buffer.from(buffer2)
+  if (Buffer.from(buffer1).equals(Buffer.from(buffer2))) {
+    return { equal: true }
+  }
+  // looksSame decodes PNGs; SVG input otherwise falls back to byte equality.
+  // Rasterize so generated IDs and nonvisual element ordering do not fail checks.
+  const toImageBuffer = (buffer: Uint8Array) =>
+    Buffer.from(
+      diffPath.endsWith(".svg")
+        ? convertSvgToPngBuffer(Buffer.from(buffer).toString("utf8"))
+        : buffer,
+    )
+  const b1 = toImageBuffer(buffer1)
+  const b2 = toImageBuffer(buffer2)
   const { equal } = await looksSame(b1, b2, {
     strict: false,
     tolerance: 2,

--- a/lib/shared/process-snapshot-file.ts
+++ b/lib/shared/process-snapshot-file.ts
@@ -305,20 +305,22 @@ export const processSnapshotFile = async ({
     let equal: boolean
     let diffPath: string | undefined
 
-    if (createDiff) {
-      diffPath = snapPath.replace(
+    if (update && !createDiff) {
+      // Explicit updates also refresh nonvisual metadata in the SVG source.
+      equal = oldContentBuffer.equals(newContentBuffer)
+    } else {
+      const comparisonPath = snapPath.replace(
         is3d ? ".snap.png" : ".snap.svg",
         is3d ? ".diff.png" : ".diff.svg",
       )
+      if (createDiff) diffPath = comparisonPath
       const comparison = await compareAndCreateDiff(
         oldContentBuffer,
         newContentBuffer,
-        diffPath,
-        true,
+        comparisonPath,
+        createDiff,
       )
       equal = comparison.equal
-    } else {
-      equal = oldContentBuffer.equals(newContentBuffer)
     }
 
     if (update) {

--- a/tests/cli/snapshot/snapshot-svg-ids.test.ts
+++ b/tests/cli/snapshot/snapshot-svg-ids.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { join } from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+test("snapshot accepts nonvisual SVG ID changes with and without diff artifacts", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await Bun.write(
+    join(tmpDir, "ids.board.tsx"),
+    'export default () => <board width="10mm" height="10mm"><chip name="U1" footprint="soic8" /></board>',
+  )
+  expect((await runCommand("tsci snapshot --update")).exitCode).toBe(0)
+  const path = join(tmpDir, "__snapshots__", "ids.board-pcb.snap.svg")
+  const original = await Bun.file(path).text()
+  const changed = original.replace(/pcb_component_\d+/g, "pcb_component_999")
+  expect(changed).not.toBe(original)
+  await Bun.write(path, changed)
+
+  for (const flags of ["", "--ci", "--test"]) {
+    const result = await runCommand(`tsci snapshot ${flags}`)
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("All snapshots match")
+    expect(
+      await Bun.file(path.replace(".snap.svg", ".diff.svg")).exists(),
+    ).toBe(false)
+  }
+  expect(await Bun.file(path).text()).toBe(changed)
+}, 60_000)

--- a/tests/cli/snapshot/snapshot.test.ts
+++ b/tests/cli/snapshot/snapshot.test.ts
@@ -711,7 +711,7 @@ test("snapshot with directory path and default includeBoardFiles returns clear n
   expect(stdout).not.toContain("No entrypoint found")
 }, 30_000)
 
-test("snapshot command treats textual snapshot changes as mismatch by default", async () => {
+test("snapshot command ignores nonvisual text but refreshes it on update", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   await Bun.write(
@@ -735,8 +735,9 @@ test("snapshot command treats textual snapshot changes as mismatch by default", 
 
   const { stderr: matchStderr, exitCode: matchExitCode } =
     await runCommand("tsci snapshot")
-  expect(matchExitCode).toBe(1)
-  expect(matchStderr).toContain("Snapshot mismatch")
+  expect(matchExitCode).toBe(0)
+  expect(matchStderr).not.toContain("Snapshot mismatch")
+  expect(fs.readFileSync(pcbPath, "utf-8")).toBe(contentsBefore)
 
   await runCommand("tsci snapshot --update")
   const contentsAfter = fs.readFileSync(pcbPath, "utf-8")
@@ -745,7 +746,7 @@ test("snapshot command treats textual snapshot changes as mismatch by default", 
   expect(contentsAfter).not.toContain("<!-- comment -->")
 }, 30_000)
 
-test("snapshot command treats textual pcb and schematic changes as mismatch by default", async () => {
+test("snapshot command ignores nonvisual PCB and schematic text changes", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
   await Bun.write(
@@ -772,8 +773,10 @@ test("snapshot command treats textual pcb and schematic changes as mismatch by d
   const schBefore = fs.readFileSync(schPath, "utf-8")
 
   const { stderr, exitCode } = await runCommand("tsci snapshot")
-  expect(exitCode).toBe(1)
-  expect(stderr).toContain("Snapshot mismatch")
+  expect(exitCode).toBe(0)
+  expect(stderr).not.toContain("Snapshot mismatch")
+  expect(fs.readFileSync(pcbPath, "utf-8")).toBe(pcbBefore)
+  expect(fs.readFileSync(schPath, "utf-8")).toBe(schBefore)
 
   await runCommand("tsci snapshot --update")
 

--- a/tests/shared/compare-images.test.ts
+++ b/tests/shared/compare-images.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { compareAndCreateDiff } from "../../lib/shared/compare-images"
+import { convertSvgToPngBuffer } from "../../lib/shared/convert-svg-to-png"
+
+const svg = (content: string) =>
+  Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40">${content}</svg>`,
+  )
+const left =
+  '<rect id="pcb_component_1" x="5" y="5" width="20" height="20" fill="red" />'
+const right =
+  '<rect id="pcb_component_2" x="45" y="5" width="20" height="20" fill="blue" />'
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map((dir) => rm(dir, { recursive: true })),
+  )
+})
+
+test("SVG snapshots ignore generated IDs and independent element order", async () => {
+  const before = svg(left + right)
+  const after = svg(
+    right.replace("pcb_component_2", "pcb_component_10") +
+      left.replace("pcb_component_1", "pcb_component_11"),
+  )
+  expect(before.equals(after)).toBe(false)
+  expect(
+    await compareAndCreateDiff(before, after, "pcb.diff.svg", false),
+  ).toEqual({ equal: true })
+})
+
+test("SVG snapshots detect visual changes and preserve the SVG diff", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "compare-images-"))
+  directories.push(dir)
+  const diffPath = join(dir, "pcb.diff.svg")
+  const after = svg(left.replace('fill="red"', 'fill="green"') + right)
+  expect(
+    await compareAndCreateDiff(svg(left + right), after, diffPath),
+  ).toEqual({ equal: false })
+  expect(await readFile(diffPath)).toEqual(after)
+})
+
+test("SVG snapshots detect element order changes that alter overlapping pixels", async () => {
+  const overlapping = right.replace('x="45"', 'x="10"')
+  expect(
+    await compareAndCreateDiff(
+      svg(left + overlapping),
+      svg(overlapping + left),
+      "pcb.diff.svg",
+      false,
+    ),
+  ).toEqual({ equal: false })
+})
+
+test("PNG comparison and PNG diff generation still work", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "compare-images-"))
+  directories.push(dir)
+  const diffPath = join(dir, "pcb.diff.png")
+  const before = convertSvgToPngBuffer(svg(left).toString())
+  const after = convertSvgToPngBuffer(svg(right).toString())
+  expect(await compareAndCreateDiff(before, before, diffPath, false)).toEqual({
+    equal: true,
+  })
+  expect(await compareAndCreateDiff(before, after, diffPath)).toEqual({
+    equal: false,
+  })
+  expect((await readFile(diffPath)).subarray(0, 8)).toEqual(
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+  )
+})


### PR DESCRIPTION
SVG snapshot checks can fail even when the rendered board is unchanged. Asynchronous footprint loading can change generated IDs and the order of independent SVG elements; the AP3429A snapshot failure in https://github.com/tscircuit/sparkfun-boards/pull/328 is one example. Plain `tsci snapshot` compares raw buffers, and the image comparator used by `--ci`/`--test` also falls back to byte equality for SVG input because it only decodes PNGs.

Render differing SVGs to PNGs with the existing Resvg helper before comparing them. Use this visual comparison for normal checks as well as checks that produce diff artifacts. Identical buffers take a fast path, and explicit `--update` without diff generation continues to refresh metadata and other nonvisual SVG text. SVG mismatch artifacts remain SVG files; PNG diff generation is preserved.

Regression coverage verifies that changed IDs, comments, and reordered non-overlapping elements pass, while changed colors and reordered overlapping shapes fail. CLI tests cover normal, `--ci`, and `--test` checks, explicit updates, and real visual mismatches. The captured AP3429A SVG pair has different bytes and compares equal with this change.

The comparison uses the SVG's native rendered dimensions and the existing tolerance of 2. This makes snapshot validation visual; it does not promise to detect subpixel geometry changes or make Circuit JSON generation deterministic.

Validation on current upstream main:
- 12 targeted tests passed, including SVG equality, visual mismatch detection, metadata updates, all snapshot check modes, and PCB/schematic/3D diff artifacts.
- TypeScript check and package build passed.
- Formatting and `git diff --check` passed.
- Manually verified the actual AP3429A SVG mismatch is accepted by the patched comparator.
