### PR TITLE
Fix build exit status for circuit errors while retaining artifacts

### DIFF
--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -419,7 +419,7 @@ export const registerBuild = (program: Command) => {
         }
         const staticFileReferences: StaticBuildFileReference[] = []
 
-        const builtFiles: BuildFileResult[] = []
+        const builtFiles: (BuildFileResult & { hasErrors?: boolean })[] = []
         const kicadProjects: Array<
           GeneratedKicadProject & { sourcePath: string }
         > = []
@@ -507,6 +507,7 @@ export const registerBuild = (program: Command) => {
             sourcePath: filePath,
             outputPath,
             ok: buildOutcome.ok,
+            hasErrors: buildOutcome.hasErrors,
           })
 
           if (buildOutcome.hasErrors) {
@@ -1036,10 +1037,12 @@ export const registerBuild = (program: Command) => {
           }
         }
 
-        // Fatal errors (e.g., circuit generation exceptions) always cause exit code 1.
-        const shouldExitNonZero = hasFatalErrors
+        // Report circuit errors only after all requested artifacts are generated.
+        const shouldExitNonZero = hasErrors
 
-        const successCount = builtFiles.filter((f) => f.ok).length
+        const successCount = builtFiles.filter(
+          (f) => f.ok && !f.hasErrors,
+        ).length
         const failCount = builtFiles.length - successCount
         const enabledOpts = [
           resolvedOptions?.site && "site",
@@ -1122,7 +1125,12 @@ export const registerBuild = (program: Command) => {
             : kleur.green("\n✓ Done"),
         )
         if (shouldExitNonZero) {
-          exitBuild(1, "fatal circuit build errors occurred")
+          exitBuild(
+            1,
+            hasFatalErrors
+              ? "fatal circuit build errors occurred"
+              : "circuit build errors occurred",
+          )
         }
 
         exitBuild(0, "build finished successfully")

--- a/tests/cli/build/build-error-exit-status.test.ts
+++ b/tests/cli/build/build-error-exit-status.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+const traceError = {
+  type: "source_trace_not_connected_error",
+  error_type: "source_trace_not_connected_error",
+  message: 'Could not find port for selector "R_MISSING.pin1"',
+  selectors_not_found: ["R_MISSING.pin1"],
+}
+const warning = {
+  type: "source_no_power_pin_defined_warning",
+  warning_type: "source_no_power_pin_defined_warning",
+  message: "No power pin defined",
+}
+
+for (const concurrency of [1, 2]) {
+  test(`build retains all circuits and counts errors as failures with concurrency ${concurrency}`, async () => {
+    const { tmpDir, runCommand } = await getCliTestFixture()
+    await writeFile(path.join(tmpDir, "package.json"), "{}")
+    for (const [name, circuit] of Object.entries({
+      bad: [traceError],
+      good: [],
+      warning: [warning],
+    })) {
+      await writeFile(
+        path.join(tmpDir, `${name}.circuit.json`),
+        JSON.stringify(circuit),
+      )
+    }
+
+    const { exitCode, stdout } = await runCommand(
+      `tsci build --concurrency ${concurrency}`,
+    )
+    expect(exitCode).toBe(1)
+    expect(stdout).toContain("2 passed 1 failed")
+    expect(stdout).toContain("Build completed with errors")
+    expect(stdout).not.toContain("build finished successfully")
+    for (const [name, circuit] of Object.entries({
+      bad: [traceError],
+      good: [],
+      warning: [warning],
+    })) {
+      expect(
+        JSON.parse(
+          await readFile(
+            path.join(tmpDir, "dist", name, "circuit.json"),
+            "utf-8",
+          ),
+        ),
+      ).toEqual(circuit)
+    }
+  }, 30_000)
+
+  for (const ignoreErrors of [false, true]) {
+    test(`build exits 0 for ${ignoreErrors ? "ignored errors" : "warnings only"} with concurrency ${concurrency}`, async () => {
+      const { tmpDir, runCommand } = await getCliTestFixture()
+      await writeFile(path.join(tmpDir, "package.json"), "{}")
+      await writeFile(
+        path.join(tmpDir, "board.circuit.json"),
+        JSON.stringify(ignoreErrors ? [traceError] : [warning]),
+      )
+      const { exitCode, stdout } = await runCommand(
+        `tsci build --concurrency ${concurrency}${ignoreErrors ? " --ignore-errors" : ""}`,
+      )
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain("1 passed")
+      expect(stdout).not.toContain("Build completed with errors")
+    }, 30_000)
+  }
+}

--- a/tests/cli/build/build-ignore-drc-categories.test.ts
+++ b/tests/cli/build/build-ignore-drc-categories.test.ts
@@ -51,15 +51,14 @@ test("build reports ignored counts when selected DRC categories are filtered", a
     "tsci build board.circuit.json --ignore-placement-drc --ignore-routing-drc",
   )
 
-  expect(exitCode).toBe(0)
+  expect(exitCode).toBe(1)
   expect(getBuildSummarySnippet(stdout)).toMatchInlineSnapshot(`
 "Build complete
-  Circuits  1 passed
+  Circuits  0 passed 1 failed
   Options   ignore-placement-drc, ignore-routing-drc
   Output    dist
   Ignored DRC 2 (placement: 1, routing: 1)
-⚠ Build completed with errors
-Build exiting with code 0: build finished successfully"
+⚠ Build completed with errors"
 `)
 }, 30_000)
 

--- a/tests/cli/build/build-with-drc-error.test.ts
+++ b/tests/cli/build/build-with-drc-error.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { readFile, writeFile } from "node:fs/promises"
+import { readFile, symlink, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
 
@@ -10,13 +10,18 @@ export default () => (
   </board>
 )`
 
-test("build succeeds when circuit JSON is generated with DRC errors", async () => {
+test("build exits 1 and retains circuit JSON with DRC errors", async () => {
   const { tmpDir, runCommand } = await getCliTestFixture()
 
+  await symlink(
+    path.resolve("node_modules"),
+    path.join(tmpDir, "node_modules"),
+    "dir",
+  )
   await writeFile(path.join(tmpDir, "test.circuit.tsx"), validCircuitCode)
   await writeFile(path.join(tmpDir, "package.json"), "{}")
 
-  const { exitCode, stdout } = await runCommand("tsci build")
+  const { exitCode, stdout } = await runCommand("tsci build --pcb-svgs")
 
   const circuitJsonPath = path.join(tmpDir, "dist", "test", "circuit.json")
   const circuitJson = await readFile(circuitJsonPath, "utf-8")
@@ -28,6 +33,9 @@ test("build succeeds when circuit JSON is generated with DRC errors", async () =
     "Component R1 extends outside board boundaries",
   )
 
-  expect(exitCode).toBe(0)
+  expect(
+    await readFile(path.join(tmpDir, "dist", "test", "pcb.svg"), "utf-8"),
+  ).toContain("<svg")
+  expect(exitCode).toBe(1)
   expect(stdout).toContain("Build completed with errors")
 }, 30_000)


### PR DESCRIPTION
Builds containing circuit errors now exit 1 and count affected circuits as failed, while retaining generated artifacts and reporting “Build completed with errors.” Artifact generation still completes before the final exit status is applied. Warnings and explicitly ignored errors continue to exit 0.

Adds regression coverage for serial and parallel builds, mixed passing/failing circuits, warnings, ignored errors, and retention of circuit JSON and PCB SVG output. Updates existing DRC expectations.

Validation: 9 regression tests pass (34 assertions, 2 snapshots); CLI build, formatting checks, and `git diff --check` pass.

Fixes #4707.
