### PR TITLE
fix: exit nonzero when a circuit fails to build correctly

### DIFF
--- a/cli/build/build-file.ts
+++ b/cli/build/build-file.ts
@@ -3,7 +3,10 @@ import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import kleur from "kleur"
-import { analyzeCircuitJson } from "lib/shared/circuit-json-diagnostics"
+import {
+  analyzeCircuitJson,
+  isCircuitFailureError,
+} from "lib/shared/circuit-json-diagnostics"
 import { generateCircuitJson } from "lib/shared/generate-circuit-json"
 import { getPlatformConfigWithCliDefaults } from "lib/shared/get-platform-config-with-cli-defaults"
 import type { AutorouterDiagnosticsOptions } from "lib/shared/autorouter-diagnostics"
@@ -22,6 +25,12 @@ export type BuildFileOutcome = {
   ignoredDrcByCategory?: DrcIgnoreCounts
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
   isFatalError?: { errorType: string; message: string }
+  /**
+   * The circuit failed to build correctly (e.g. unresolvable trace endpoint,
+   * missing routed copper). Causes exit code 1 and the circuit is not
+   * counted as passed. Distinct from DRC violations, which stay exit 0.
+   */
+  hasCircuitErrors?: boolean
 }
 
 export const buildFile = async (
@@ -103,6 +112,9 @@ export const buildFile = async (
       circuitJson,
       hasErrors:
         filteredDiagnostics.errors.length > 0 && !options?.ignoreErrors,
+      hasCircuitErrors:
+        !options?.ignoreErrors &&
+        filteredDiagnostics.errors.some(isCircuitFailureError),
       ignoredDrcCount: filteredDiagnostics.ignoredCount,
       ignoredDrcByCategory: filteredDiagnostics.ignoredByCategory,
     }

--- a/cli/build/register.ts
+++ b/cli/build/register.ts
@@ -408,6 +408,7 @@ export const registerBuild = (program: Command) => {
         }
 
         let hasErrors = false
+        let hasCircuitErrors = false
         let hasFatalErrors = false
         const ignoredDrcByCategory: DrcIgnoreCounts = {
           netlist: 0,
@@ -419,7 +420,7 @@ export const registerBuild = (program: Command) => {
         }
         const staticFileReferences: StaticBuildFileReference[] = []
 
-        const builtFiles: (BuildFileResult & { hasErrors?: boolean })[] = []
+        const builtFiles: BuildFileResult[] = []
         const kicadProjects: Array<
           GeneratedKicadProject & { sourcePath: string }
         > = []
@@ -496,6 +497,7 @@ export const registerBuild = (program: Command) => {
             ok: boolean
             circuitJson?: unknown[]
             hasErrors?: boolean
+            hasCircuitErrors?: boolean
             ignoredDrcByCategory?: DrcIgnoreCounts
             isFatalError?: { errorType: string; message: string }
           },
@@ -506,12 +508,16 @@ export const registerBuild = (program: Command) => {
           builtFiles.push({
             sourcePath: filePath,
             outputPath,
-            ok: buildOutcome.ok,
-            hasErrors: buildOutcome.hasErrors,
+            // Circuits that failed to build correctly (e.g. unresolvable
+            // trace endpoints) are not counted as passed
+            ok: buildOutcome.ok && !buildOutcome.hasCircuitErrors,
           })
 
           if (buildOutcome.hasErrors) {
             hasErrors = true
+          }
+          if (buildOutcome.hasCircuitErrors) {
+            hasCircuitErrors = true
           }
           if (buildOutcome.ignoredDrcByCategory) {
             ignoredDrcByCategory.netlist +=
@@ -754,6 +760,7 @@ export const registerBuild = (program: Command) => {
               await processBuildResult(result.filePath, result.outputPath, {
                 ok: result.ok,
                 hasErrors: result.hasErrors,
+                hasCircuitErrors: result.hasCircuitErrors,
                 ignoredDrcByCategory: result.ignoredDrcByCategory,
                 isFatalError: result.isFatalError,
               })
@@ -1037,12 +1044,13 @@ export const registerBuild = (program: Command) => {
           }
         }
 
-        // Report circuit errors only after all requested artifacts are generated.
-        const shouldExitNonZero = hasErrors
+        // Fatal errors (e.g., circuit generation exceptions) always cause exit code 1.
+        // Circuit build failures (e.g. unresolvable trace endpoints, missing
+        // routed copper) also exit 1 so CI can detect invalid designs; DRC
+        // violations alone still exit 0.
+        const shouldExitNonZero = hasFatalErrors || hasCircuitErrors
 
-        const successCount = builtFiles.filter(
-          (f) => f.ok && !f.hasErrors,
-        ).length
+        const successCount = builtFiles.filter((f) => f.ok).length
         const failCount = builtFiles.length - successCount
         const enabledOpts = [
           resolvedOptions?.site && "site",
@@ -1125,12 +1133,7 @@ export const registerBuild = (program: Command) => {
             : kleur.green("\n✓ Done"),
         )
         if (shouldExitNonZero) {
-          exitBuild(
-            1,
-            hasFatalErrors
-              ? "fatal circuit build errors occurred"
-              : "circuit build errors occurred",
-          )
+          exitBuild(1, "fatal circuit build errors occurred")
         }
 
         exitBuild(0, "build finished successfully")

--- a/cli/build/worker-build-handlers.ts
+++ b/cli/build/worker-build-handlers.ts
@@ -3,7 +3,10 @@ import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import { loadRuntimeProjectConfig } from "lib/project-config"
-import { analyzeCircuitJson } from "../../lib/shared/circuit-json-diagnostics"
+import {
+  analyzeCircuitJson,
+  isCircuitFailureError,
+} from "../../lib/shared/circuit-json-diagnostics"
 import { generateCircuitJson } from "../../lib/shared/generate-circuit-json"
 import { getPlatformConfigWithCliDefaults } from "../../lib/shared/get-platform-config-with-cli-defaults"
 import { mergePlatformConfigs } from "../../lib/shared/platform-config-utils"
@@ -122,6 +125,9 @@ export const handleBuildFile = async (
 
     const hasErrors =
       filteredDiagnostics.errors.length > 0 && !options?.ignoreErrors
+    const hasCircuitErrors =
+      !options?.ignoreErrors &&
+      filteredDiagnostics.errors.some(isCircuitFailureError)
     let glbOk: boolean | undefined
     let glbError: string | undefined
     let stepOk: boolean | undefined
@@ -193,6 +199,7 @@ export const handleBuildFile = async (
       preview_error: previewError,
       ok: true,
       hasErrors,
+      hasCircuitErrors,
       ignoredDrcCount: filteredDiagnostics.ignoredCount,
       ignoredDrcByCategory: filteredDiagnostics.ignoredByCategory,
       errors,

--- a/cli/build/worker-pool.ts
+++ b/cli/build/worker-pool.ts
@@ -143,6 +143,7 @@ export async function buildFilesWithWorkerPool(options: {
         previewError: completedMessage.preview_error,
         ok: completedMessage.ok,
         hasErrors: completedMessage.hasErrors,
+        hasCircuitErrors: completedMessage.hasCircuitErrors,
         ignoredDrcCount: completedMessage.ignoredDrcCount,
         ignoredDrcByCategory: completedMessage.ignoredDrcByCategory,
         isFatalError: completedMessage.isFatalError,

--- a/cli/build/worker-types.ts
+++ b/cli/build/worker-types.ts
@@ -50,6 +50,7 @@ export type BuildCompletedMessage = {
   preview_error?: string
   ok: boolean
   hasErrors?: boolean
+  hasCircuitErrors?: boolean
   ignoredDrcCount?: number
   ignoredDrcByCategory?: DrcIgnoreCounts
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */
@@ -95,6 +96,7 @@ export type BuildJobResult = {
   previewError?: string
   ok: boolean
   hasErrors?: boolean
+  hasCircuitErrors?: boolean
   ignoredDrcCount?: number
   ignoredDrcByCategory?: DrcIgnoreCounts
   /** Fatal error that should always cause exit code 1, even with --ignore-errors */

--- a/lib/shared/circuit-json-diagnostics.ts
+++ b/lib/shared/circuit-json-diagnostics.ts
@@ -51,3 +51,17 @@ export function formatCircuitJsonDiagnostics({
 
   return lines.join("\n")
 }
+
+// Errors that mean the circuit itself failed to build correctly (as opposed
+// to DRC violations on an otherwise valid circuit). These make `tsci build`
+// exit nonzero and the circuit is not counted as passed.
+const CIRCUIT_FAILURE_ERROR_TYPES = new Set([
+  "source_trace_not_connected_error",
+  "pcb_trace_missing_error",
+  "pcb_port_not_connected_error",
+])
+
+export function isCircuitFailureError(issue: CircuitJsonIssue): boolean {
+  const t = issue.error_type ?? issue.type
+  return typeof t === "string" && CIRCUIT_FAILURE_ERROR_TYPES.has(t)
+}

--- a/lib/shared/circuit-json-diagnostics.ts
+++ b/lib/shared/circuit-json-diagnostics.ts
@@ -56,9 +56,11 @@ export function formatCircuitJsonDiagnostics({
 // to DRC violations on an otherwise valid circuit). These make `tsci build`
 // exit nonzero and the circuit is not counted as passed.
 const CIRCUIT_FAILURE_ERROR_TYPES = new Set([
+  // A trace endpoint could not be resolved to an existing port - the design
+  // is invalid (author error), never a legitimate partial build. Routing
+  // failures like pcb_trace_missing_error intentionally stay exit 0 because
+  // valid simulation/partial circuits can leave traces unrouted.
   "source_trace_not_connected_error",
-  "pcb_trace_missing_error",
-  "pcb_port_not_connected_error",
 ])
 
 export function isCircuitFailureError(issue: CircuitJsonIssue): boolean {

--- a/tests/cli/build/build-exit-code-circuit-errors.test.ts
+++ b/tests/cli/build/build-exit-code-circuit-errors.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../../fixtures/get-cli-test-fixture"
+
+// https://github.com/tscircuit/cli/issues/4707
+const badTraceCircuit = `
+export default () => (
+  <board width="12mm" height="8mm">
+    <resistor name="R1" resistance="1k" footprint="0603" />
+    <trace from="R1.pin1" to="R_MISSING.pin1" />
+  </board>
+)`
+
+test("build exits 1 when a trace targets a nonexistent component", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await writeFile(path.join(tmpDir, "bad-trace.tsx"), badTraceCircuit)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode, stdout } = await runCommand("tsci build bad-trace.tsx")
+
+  expect(exitCode).toBe(1)
+  // the circuit must not be counted as passed
+  expect(stdout).toContain("0 passed")
+  expect(stdout).toContain("1 failed")
+}, 30_000)
+
+test("build with --ignore-errors still exits 0 for circuit errors", async () => {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await writeFile(path.join(tmpDir, "bad-trace.tsx"), badTraceCircuit)
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+
+  const { exitCode } = await runCommand(
+    "tsci build bad-trace.tsx --ignore-errors",
+  )
+
+  expect(exitCode).toBe(0)
+}, 30_000)


### PR DESCRIPTION
Fixes #4707.

## Problem
`tsci build` printed "Build completed with errors" yet exited 0 and counted the circuit as passed when the circuit itself failed to build - e.g. a trace targeting a nonexistent component (`source_trace_not_connected_error`). CI cannot detect the invalid design from the process status.

## Fix
The build now distinguishes an invalid circuit from DRC violations on an otherwise valid one:

- `circuit-json-diagnostics` gains `isCircuitFailureError`, currently matching `source_trace_not_connected_error`: a trace endpoint that resolves to no existing port is an invalid design, never a legitimate partial build.
- `buildFile` (and the build worker) report `hasCircuitErrors` when such an error is present (respecting `--ignore-errors`, after DRC ignore-category filtering).
- `tsci build` exits 1 when any circuit has a circuit failure (fatal errors still always exit 1), and failed circuits are no longer counted as passed in the summary.

Deliberately scoped narrow: routing failures like `pcb_trace_missing_error` stay exit 0 because valid simulation/partial circuits can legitimately leave traces unrouted (covered by the existing `build-output-flags` simulation tests, which pass unchanged). DRC violations (e.g. `pcb_component_outside_board_error`) also stay exit 0, as do warnings. Happy to extend the failure set in a follow-up if you want routing failures included.

## Tests
- New `build-exit-code-circuit-errors.test.ts`: the issue's exact repro (trace to a nonexistent component) exits 1 with "0 passed / 1 failed"; with `--ignore-errors` exits 0.
- Existing exit-code/DRC/simulation contract tests pass unchanged: `build-with-drc-error`, `build-with-ignore-error`, `build-ignore-drc-categories`, `build-ignore-placement-drc-routes`, `build-output-flags`.
