### PR TITLE
Use the project converter to preserve KiCad build constraints

### DIFF
--- a/cli/build/generate-kicad-project.ts
+++ b/cli/build/generate-kicad-project.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import type { PlatformConfig } from "@tscircuit/props"
 import {
   CircuitJsonToKicadPcbConverter,
+  CircuitJsonToKicadProConverter,
   CircuitJsonToKicadSchConverter,
   resolveAndLoadKicad3dModelFiles,
 } from "circuit-json-to-kicad"
@@ -23,33 +24,6 @@ export type GeneratedKicadProject = {
   outputDir: string
   projectName: string
 }
-
-const createKicadProContent = ({
-  projectName,
-  schematicFileName,
-  boardFileName,
-}: {
-  projectName: string
-  schematicFileName: string
-  boardFileName: string
-}) =>
-  JSON.stringify(
-    {
-      head: {
-        version: 1,
-        generator: "tsci",
-      },
-      project: {
-        name: projectName,
-        files: {
-          schematic: schematicFileName,
-          board: boardFileName,
-        },
-      },
-    },
-    null,
-    2,
-  )
 
 export const generateKicadProject = async ({
   circuitJson,
@@ -77,11 +51,16 @@ export const generateKicadProject = async ({
   const boardFileName = `${sanitizedProjectName}.kicad_pcb`
   const projectFileName = `${sanitizedProjectName}.kicad_pro`
 
-  const proContent = createKicadProContent({
-    projectName: sanitizedProjectName,
-    schematicFileName,
-    boardFileName,
-  })
+  const proConverter = new CircuitJsonToKicadProConverter(
+    circuitJson as AnyCircuitElement[],
+    {
+      projectName: sanitizedProjectName,
+      schematicFilename: schematicFileName,
+      pcbFilename: boardFileName,
+    },
+  )
+  proConverter.runUntilFinished()
+  const proContent = proConverter.getOutputString()
 
   if (writeFiles) {
     fs.mkdirSync(outputDir, { recursive: true })

--- a/tests/cli/build/build-kicad-project-zip.test.ts
+++ b/tests/cli/build/build-kicad-project-zip.test.ts
@@ -13,7 +13,7 @@ test("build --kicad-project-zip creates a zip and removes kicad dir", async () =
     circuitPath,
     `
 export default () => (
-  <board width="10mm" height="10mm">
+  <board width="10mm" height="10mm" minTraceWidth={0.25}>
     <resistor resistance="1k" footprint="0402" name="R1" pcbX={0} pcbY={0} />
   </board>
 )
@@ -46,4 +46,8 @@ export default () => (
   expect(fileNames).toContain("my-board.kicad_sch")
   expect(fileNames).toContain("my-board.kicad_pcb")
   expect(fileNames).toContain("my-board.kicad_pro")
+  const project = JSON.parse(
+    await zip.file("my-board.kicad_pro")!.async("string"),
+  )
+  expect(project.board.design_settings.rules.min_track_width).toBe(0.25)
 }, 60_000)

--- a/tests/cli/build/generate-kicad-project-design-rules.test.tsx
+++ b/tests/cli/build/generate-kicad-project-design-rules.test.tsx
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test"
+import { generateKicadProject } from "cli/build/generate-kicad-project"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { Circuit } from "tscircuit"
+
+test("generated KiCad projects preserve board limits in memory and on disk", async () => {
+  const circuit = new Circuit()
+  circuit.add(
+    <board
+      width="10mm"
+      height="10mm"
+      minTraceWidth={0.25}
+      minViaHoleDiameter={0.4}
+      minViaPadDiameter={0.8}
+    />,
+  )
+  await circuit.renderUntilSettled()
+  const circuitJson = circuit.getCircuitJson()
+  expect(
+    circuitJson.find((element) => element.type === "pcb_board"),
+  ).toMatchObject({
+    min_trace_width: 0.25,
+    min_via_hole_diameter: 0.4,
+    min_via_pad_diameter: 0.8,
+  })
+
+  const dir = await mkdtemp(path.join(tmpdir(), "tsci-kicad-rules-"))
+  try {
+    for (const [inputName, expectedName] of [
+      ["  limits  ", "limits"],
+      ["   ", "project"],
+    ]) {
+      for (const writeFiles of [false, true]) {
+        const outputDir = path.join(dir, `${expectedName}-${writeFiles}`)
+        const result = await generateKicadProject({
+          circuitJson,
+          outputDir,
+          projectName: inputName!,
+          writeFiles,
+        })
+        const project = JSON.parse(result.proContent)
+        expect(project.board?.design_settings?.rules).toMatchObject({
+          min_track_width: 0.25,
+          min_through_hole_diameter: 0.4,
+          min_via_diameter: 0.8,
+        })
+        expect(result.projectName).toBe(expectedName)
+        expect(project.head.project_name).toBe(expectedName)
+        expect(project.board.last_opened_board).toBe(
+          `${expectedName}.kicad_pcb`,
+        )
+        expect(project.schematic.last_opened_files).toEqual([
+          `${expectedName}.kicad_sch`,
+        ])
+        expect(result.pcbContent).toContain("(kicad_pcb")
+        expect(result.schContent).toContain("(kicad_sch")
+        if (writeFiles) {
+          for (const [extension, content] of [
+            ["pro", result.proContent],
+            ["pcb", result.pcbContent],
+            ["sch", result.schContent],
+          ]) {
+            expect(
+              await readFile(
+                path.join(outputDir, `${expectedName}.kicad_${extension}`),
+                "utf8",
+              ),
+            ).toBe(content)
+          }
+        } else {
+          expect(existsSync(outputDir)).toBe(false)
+        }
+      }
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
`tsci build --kicad-project` and `--kicad-project-zip` wrote a minimal `.kicad_pro` scaffold, discarding the board limits present in Circuit JSON. Use the existing `CircuitJsonToKicadProConverter`, as the `export kicad_zip` path already does, and remove the obsolete scaffold. Project-name trimming/fallback, output filenames, in-memory generation and 3D-model handling are preserved.

Related to #4716. This restores the limits already supported by the pinned converter, including `min_trace_width`. The companion edge-clearance mapping is submitted separately at https://github.com/tscircuit/circuit-json-to-kicad/pull/550 ; full resolution of the edge limit requires adopting a converter release containing that change. This PR leaves the current 0.0.181 dependency pin unchanged and does not claim the edge half is already released.

Tests generate an actual Circuit with nondefault trace/via constraints, exercise both in-memory and written projects with trimmed/blank names, and check that the real `--kicad-project-zip` build includes its 0.25 mm trace minimum.

Validation with Bun 1.3.5 / Node 22 on Linux: seven tests covering the generator regression and existing build ZIP, builtin/custom 3D, and KiCad export paths passed (73 assertions, two snapshots). Full TypeScript checking, build and formatting passed. Replacing the generator with the original upstream scaffold makes the new regression fail because the rules are absent.

A separate integration check links the exact converter change from #550, calls the actual CLI generator, and runs native KiCad 10.0.1 DRC: a 0.4 mm copper gap passes a 0.3 mm edge limit, a 0.2 mm gap still fails, and an independent track-width violation remains. Raising only the edge rule to 0.5 mm rejects both pads. That test passes with eight assertions.

Clean validation run and downloadable generated KiCad/DRC evidence: https://github.com/PapayaLaParupa/cli/actions/runs/34672920960 . The contributor-fork validation workflow and integration-only fixture are not included in this PR.

Prepared and validated with OpenAI GPT-6 Astra Pro acting on behalf of PapayaLaParupa.