### PR TITLE
repro: confirm KiCad silkscreen text export issue #4719

### DIFF
--- a/tests/bug-reports/issue-4719-kicad-silkscreen-text.test.ts
+++ b/tests/bug-reports/issue-4719-kicad-silkscreen-text.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import { copyFile, readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getCliTestFixture } from "../fixtures/get-cli-test-fixture"
+
+// Reproduction of https://github.com/tscircuit/cli/issues/4719.
+// These assertions document the bug, not the desired export behavior. Update
+// them when font metrics/stroke preservation is implemented in the exporter.
+async function buildReproduction() {
+  const { tmpDir, runCommand } = await getCliTestFixture()
+  await copyFile(
+    path.join(import.meta.dir, "../fixtures/assets/issue-4719/index.tsx"),
+    path.join(tmpDir, "index.tsx"),
+  )
+  await writeFile(path.join(tmpDir, "package.json"), "{}")
+  const result = await runCommand("tsci build index.tsx --svgs --kicad-project")
+  expect(result.exitCode).toBe(0)
+  const outputDir = path.join(tmpDir, "dist", "index")
+  return {
+    tmpDir,
+    outputDir,
+    pcbPath: path.join(outputDir, "kicad", "index.kicad_pcb"),
+  }
+}
+
+test("issue #4719: KiCad export substitutes native font metrics and a fixed stroke", async () => {
+  const { outputDir, pcbPath } = await buildReproduction()
+  const circuitJson = JSON.parse(
+    await readFile(path.join(outputDir, "circuit.json"), "utf8"),
+  )
+  const text = circuitJson.find(
+    (element: { type: string }) => element.type === "pcb_silkscreen_text",
+  )
+  expect(text).toMatchObject({
+    text: "SN74LVC1G17DCKR",
+    font_size: 0.8,
+    anchor_position: { x: 0, y: 0 },
+  })
+  const svg = await readFile(path.join(outputDir, "pcb.svg"), "utf8")
+  expect(svg).toContain("SN74LVC1G17DCKR")
+  expect(svg).toContain('font-family="Arial, sans-serif"')
+  const pcb = await readFile(pcbPath, "utf8")
+  expect(pcb).toMatch(
+    /\(gr_text\s+"SN74LVC1G17DCKR"[\s\S]*?\(font\s+\(size 0\.8 0\.8\)\s+\(thickness 0\.15\)/,
+  )
+}, 60_000)
+
+// KiCad is not a CI dependency. Opt in to verify the actual geometry rather
+// than inferring DRC results from serialized text size alone.
+test.skipIf(process.env.RUN_KICAD_DRC !== "1")(
+  "issue #4719: native KiCad DRC confirms the label is clipped by the board edge",
+  async () => {
+    const { tmpDir, pcbPath } = await buildReproduction()
+    const reportPath = path.join(tmpDir, "drc.json")
+    const result = Bun.spawnSync([
+      "kicad-cli",
+      "pcb",
+      "drc",
+      "--format",
+      "json",
+      "--output",
+      reportPath,
+      pcbPath,
+    ])
+    // DRC normally exits successfully even when it reports violations.
+    expect(result.exitCode).toBe(0)
+    const report = JSON.parse(await readFile(reportPath, "utf8"))
+    expect(report.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "silk_edge_clearance",
+          items: expect.arrayContaining([
+            expect.objectContaining({
+              description: expect.stringContaining("SN74LVC1G17DCKR"),
+            }),
+          ]),
+        }),
+      ]),
+    )
+  },
+  60_000,
+)

--- a/tests/fixtures/assets/issue-4719/README.md
+++ b/tests/fixtures/assets/issue-4719/README.md
@@ -1,0 +1,64 @@
+# Reproduction: KiCad silkscreen text metrics (#4719)
+
+Related issue: https://github.com/tscircuit/cli/issues/4719
+
+This is a reproduction, not a fix. The 10.4 mm board contains one centered
+`SN74LVC1G17DCKR` label with `fontSize={0.8}`.
+
+## Run from the CLI repository root
+
+```sh
+bun install --frozen-lockfile
+bun test tests/bug-reports/issue-4719-kicad-silkscreen-text.test.ts
+
+# Requires kicad-cli on PATH; tested with KiCad 10.0.0.
+RUN_KICAD_DRC=1 bun test tests/bug-reports/issue-4719-kicad-silkscreen-text.test.ts
+```
+
+The first test builds the TSX through `tsci build --svgs --kicad-project` and
+checks the generated Circuit JSON, SVG font, and KiCad text settings. The
+opt-in second test builds the same fixture and runs native KiCad DRC, checking
+for `silk_edge_clearance` on this label. It reads the JSON report because DRC
+returns exit code zero by default even when violations are found.
+
+These tests deliberately assert the currently affected behavior. They are not
+regression tests for a fix; update their expectations when fixing the exporter.
+CI does not need KiCad to run the first test.
+
+## Inspect the generated files manually
+
+```sh
+bun cli/main.ts build tests/fixtures/assets/issue-4719/index.tsx --svgs --kicad-project
+kicad-cli pcb drc --format json --output /tmp/issue-4719-drc.json dist/tests/fixtures/assets/issue-4719/index/kicad/index.kicad_pcb
+```
+
+Compare `dist/tests/fixtures/assets/issue-4719/index/pcb.svg` with `dist/tests/fixtures/assets/issue-4719/index/kicad/index.kicad_pcb` in KiCad.
+The export contains:
+
+```scheme
+(gr_text "SN74LVC1G17DCKR"
+  (at 100 100 0)
+  (layer F.SilkS)
+  ; UUID omitted
+  (effects (font (size 0.8 0.8) (thickness 0.15))))
+```
+
+Native DRC reports `silk_edge_clearance`, described as **Silkscreen clipped by
+board edge**, involving this text and an Edge.Cuts segment. No DRC rules are
+lowered or warnings suppressed by this reproduction. The single-label fixture
+does not attempt to reproduce the separate text-to-text overlap claim.
+
+## Cause and versions
+
+The SVG uses Arial/sans-serif, while the exporter creates native KiCad text
+without matching font metrics. It sets both native size axes to `font_size` and
+hard-codes the stroke to 0.15 mm. The affected functions are
+`CreateGrTextFromCircuitJson.ts` and `CreateFpTextFromCircuitJson.ts` in
+https://github.com/tscircuit/circuit-json-to-kicad/tree/a130496c23f3271aea73d4df2299844b345b81ce/lib/pcb/stages/utils.
+
+Confirmed on CLI 0.1.2064 with its locked `circuit-json-to-kicad` 0.0.181 and
+`circuit-to-svg` 0.0.393. A separate converter-level check of exporter 0.0.212
+produced the same PCB text settings. KiCad 10.0.0 measured the equivalent
+exported label's bounding width as approximately 11.83 mm, exceeding the
+10.4 mm board. The issue's `0.6 * fontSize` per character is a width estimate,
+not the exact rendered SVG glyph width.

--- a/tests/fixtures/assets/issue-4719/index.tsx
+++ b/tests/fixtures/assets/issue-4719/index.tsx
@@ -1,0 +1,5 @@
+export default () => (
+  <board width={10.4} height={10.4}>
+    <silkscreentext text="SN74LVC1G17DCKR" pcbX={0} pcbY={0} fontSize={0.8} />
+  </board>
+)


### PR DESCRIPTION
The 10.4 mm board from #4719 exports its centered `SN74LVC1G17DCKR` label at `fontSize={0.8}` as native KiCad text with `(size 0.8 0.8)` and `(thickness 0.15)`. Native KiCad 10.0.0 DRC confirms `silk_edge_clearance` ("Silkscreen clipped by board edge") on this label.

This reproduction PR confirms the issue is still present; it does not implement a fix or close #4719.

- Adds the original minimal TSX fixture and verified manual build/DRC commands.
- Adds a CLI integration test that builds the fixture with `--svgs --kicad-project` and checks the source text, SVG font, and exported KiCad settings.
- Adds an opt-in native DRC test (`RUN_KICAD_DRC=1`) checking the actual JSON violation report. KiCad is not required for the default test run.

The tests intentionally characterize the affected behavior; their expectations should change when the exporter is fixed. The source SVG uses Arial/sans-serif, while `circuit-json-to-kicad` copies font size into native KiCad size axes and hard-codes the stroke without matching font metrics. Both standalone and footprint text converters contain this logic. The single-label fixture verifies edge clipping, not the separate text-to-text overlap report.

Validation on CLI 0.1.2064, locked exporter 0.0.181, and locked circuit-to-svg 0.0.393:

- `bun test tests/bug-reports/issue-4719-kicad-silkscreen-text.test.ts`: 1 passed, native DRC test skipped.
- `RUN_KICAD_DRC=1 bun test tests/bug-reports/issue-4719-kicad-silkscreen-text.test.ts`: 2 passed, 0 failed, using KiCad 10.0.0.
- Manual README build and native DRC commands: 1 `silk_edge_clearance` violation.
- Biome formatting check for both added TypeScript files and `git diff --check`: passed.

A separate converter-level check of the latest exporter 0.0.212 also produced identical PCB output. KiCad measured the equivalent label's bounding width at approximately 11.83 mm, exceeding the 10.4 mm board. The report's `0.6 * fontSize` character-width allocation is an estimate, not an exact SVG glyph measurement.
